### PR TITLE
Add SEO meta tags and JSON-LD structured data to blog post pages

### DIFF
--- a/src/__tests__/pages/post/slug.test.tsx
+++ b/src/__tests__/pages/post/slug.test.tsx
@@ -39,7 +39,7 @@ function makePost( overrides: {
   title?: string;
   date?: string;
   createdAt?: string;
-} = {} ) {
+} = {}) {
   return {
     sys: {
       createdAt: overrides.createdAt ?? "2024-01-01T00:00:00.000Z",
@@ -64,14 +64,14 @@ describe( "BlogPostView — post navigation", () => {
 
   it( "renders a newer link when nextPost is provided", () => {
     render(
-      <BlogPostView post={ post } nextPost={{ slug: "newer-post", title: "Newer Post" }} />,
+      <BlogPostView post={ post } nextPost={ { slug: "newer-post", title: "Newer Post" } } />,
     );
     expect( screen.getByText( "← Newer" ).closest( "a" ) ).toHaveAttribute( "href", "/post/newer-post" );
   });
 
   it( "renders an older link when prevPost is provided", () => {
     render(
-      <BlogPostView post={ post } prevPost={{ slug: "older-post", title: "Older Post" }} />,
+      <BlogPostView post={ post } prevPost={ { slug: "older-post", title: "Older Post" } } />,
     );
     expect( screen.getByText( "Older →" ).closest( "a" ) ).toHaveAttribute( "href", "/post/older-post" );
   });
@@ -80,8 +80,8 @@ describe( "BlogPostView — post navigation", () => {
     render(
       <BlogPostView
         post={ post }
-        nextPost={{ slug: "newer-post", title: "A Newer Post Title" }}
-        prevPost={{ slug: "older-post", title: "An Older Post Title" }}
+        nextPost={ { slug: "newer-post", title: "A Newer Post Title" } }
+        prevPost={ { slug: "older-post", title: "An Older Post Title" } }
       />,
     );
     expect( screen.getByText( "A Newer Post Title" ) ).toBeInTheDocument();
@@ -94,12 +94,12 @@ describe( "BlogPostView — post navigation", () => {
   });
 
   it( "omits the newer link when nextPost is null", () => {
-    render( <BlogPostView post={ post } prevPost={{ slug: "older-post", title: "Older Post" }} /> );
+    render( <BlogPostView post={ post } prevPost={ { slug: "older-post", title: "Older Post" } } /> );
     expect( screen.queryByText( "← Newer" ) ).not.toBeInTheDocument();
   });
 
   it( "omits the older link when prevPost is null", () => {
-    render( <BlogPostView post={ post } nextPost={{ slug: "newer-post", title: "Newer Post" }} /> );
+    render( <BlogPostView post={ post } nextPost={ { slug: "newer-post", title: "Newer Post" } } /> );
     expect( screen.queryByText( "Older →" ) ).not.toBeInTheDocument();
   });
 });

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 
 import { BlogPost, getBlogPost, getBlogPosts } from "@/utils/contentfulUtils";
+import { SITE_URL } from "@/constants";
 import styles from "@/styles/BlogPost.module.scss";
 import DateTimeFormat from "@/components/DateTimeFormat";
 import { Layout } from "@/components/Layout/Layout";
@@ -36,19 +37,49 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, prevPost, 
   const metaImageDesc = post.fields.image?.fields.description || "";
   const authorProfileImageSrc = `https:${post.fields.author?.fields.image?.fields.file?.url}?w=50`;
   const authorName = post.fields.author?.fields.name;
+  const canonicalUrl = `${SITE_URL}/post/${post.fields.slug}`;
+  const publishedTime = post.fields.date || post.sys.createdAt;
+  const modifiedTime = post.sys.updatedAt;
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": post.fields.title,
+    "description": post.fields.description,
+    "image": metaImage,
+    "url": canonicalUrl,
+    "datePublished": publishedTime,
+    "dateModified": modifiedTime,
+    "author": {
+      "@type": "Person",
+      "name": authorName,
+      "url": SITE_URL,
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Audeos",
+      "url": SITE_URL,
+    },
+  };
   return (
     <>
       <Head>
         <title>{ metaTitle }</title>
+        <link rel="canonical" href={ canonicalUrl } />
         <meta name="description" content={ post.fields.description } key="desc" />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content={ canonicalUrl } />
         <meta property="og:title" content={ metaTitle } />
-        <meta
-          property="og:description"
-          content={ post.fields.description }
-        />
-        <meta
-          property="og:image"
-          content={ metaImage }
+        <meta property="og:description" content={ post.fields.description } />
+        <meta property="og:image" content={ metaImage } />
+        <meta property="article:published_time" content={ publishedTime } />
+        <meta property="article:modified_time" content={ modifiedTime } />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={ metaTitle } />
+        <meta name="twitter:description" content={ post.fields.description } />
+        <meta name="twitter:image" content={ metaImage } />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={ { __html: JSON.stringify( jsonLd ) } }
         />
       </Head>
       <Layout>


### PR DESCRIPTION
## Summary

- Adds `<link rel="canonical">` to prevent duplicate content penalties
- Completes Open Graph set with `og:type: article` and `og:url`
- Adds `article:published_time` and `article:modified_time` for Google freshness signals
- Adds Twitter/X card meta tags for rich social previews (`summary_large_image`)
- Adds `Article` JSON-LD structured data for Google rich results (headline, author, dates, image)

## Test plan

- [x] All existing tests pass (`yarn test`)
- [ ] View source on a post page and confirm all new meta tags are present
- [ ] Validate JSON-LD output with [Google's Rich Results Test](https://search.google.com/test/rich-results)