### PR TITLE
Add gallery/slideshow to blog posts

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,0 +1,187 @@
+import { FC, useState, useCallback, useEffect, useRef } from "react";
+import Image from "next/image";
+import { Asset } from "contentful";
+import styles from "@/styles/Gallery.module.scss";
+
+export interface GalleryItem {
+  url: string;
+  description: string;
+  title: string;
+  type: "image" | "video";
+}
+
+interface GalleryProps {
+  items: GalleryItem[];
+}
+
+const GALLERY_IMAGE_WIDTH = 1200;
+
+function assetToGalleryItem(
+  asset: Asset<"WITHOUT_UNRESOLVABLE_LINKS", string>,
+): GalleryItem | null {
+  const file = asset.fields.file;
+  if( !file?.url ) return null;
+  const mimeType = file.contentType || "";
+  const isVideo = mimeType.startsWith( "video/" );
+  const url = isVideo
+    ? `https:${file.url}`
+    : `https:${file.url}?w=${GALLERY_IMAGE_WIDTH}`;
+  return {
+    url,
+    description: asset.fields.description || "",
+    title: asset.fields.title || "",
+    type: isVideo ? "video" : "image",
+  };
+}
+
+export function resolveGalleryItems(
+  assets: ( Asset<"WITHOUT_UNRESOLVABLE_LINKS", string> | undefined )[] | undefined,
+): GalleryItem[] {
+  if( !assets ) return [];
+  return assets.flatMap( asset => {
+    if( !asset ) return [];
+    const item = assetToGalleryItem( asset );
+    return item ? [ item ] : [];
+  });
+}
+
+interface SlideProps {
+  item: GalleryItem;
+  isNearActive: boolean;
+  isActive: boolean;
+}
+
+const Slide: FC<SlideProps> = ({ item, isNearActive, isActive }) => {
+  const videoRef = useRef<HTMLVideoElement>( null );
+
+  useEffect( () => {
+    if( !isActive ) videoRef.current?.pause();
+  }, [ isActive ] );
+
+  if( item.type === "video" ) {
+    return (
+      <video
+        ref={ videoRef }
+        className={ styles.video }
+        src={ item.url }
+        controls
+        playsInline
+        aria-label={ item.description || item.title }
+      />
+    );
+  }
+  return (
+    <Image
+      src={ item.url }
+      alt={ item.description || item.title }
+      fill
+      sizes="(max-width: 768px) 100vw, 800px"
+      loading={ isNearActive ? "eager" : "lazy" }
+    />
+  );
+};
+
+const Gallery: FC<GalleryProps> = ({ items }) => {
+  const [ activeIndex, setActiveIndex ] = useState( 0 );
+
+  const goToPrev = useCallback( () => {
+    setActiveIndex( current => ( current - 1 + items.length ) % items.length );
+  }, [ items.length ] );
+
+  const goToNext = useCallback( () => {
+    setActiveIndex( current => ( current + 1 ) % items.length );
+  }, [ items.length ] );
+
+  const handleKeyDown = useCallback( ( event: React.KeyboardEvent ) => {
+    if( event.key === "ArrowLeft" ) goToPrev();
+    if( event.key === "ArrowRight" ) goToNext();
+  }, [ goToPrev, goToNext ] );
+
+  if( items.length === 0 ) return null;
+
+  if( items.length === 1 ) {
+    const singleItem = items[0];
+    return (
+      <figure
+        className={ styles.gallery }
+        aria-label="Photo gallery"
+      >
+        <div className={ styles.viewport }>
+          <div className={ styles.singleSlide }>
+            <Slide item={ singleItem } isNearActive isActive />
+          </div>
+        </div>
+        <figcaption className={ styles.captionArea }>
+          { singleItem.description }
+        </figcaption>
+      </figure>
+    );
+  }
+
+  const activeItem = items[activeIndex];
+  const announcement = activeItem.description || activeItem.title
+    ? `${ activeItem.description || activeItem.title }, ${ activeIndex + 1 } of ${ items.length }`
+    : `Slide ${ activeIndex + 1 } of ${ items.length }`;
+
+  return (
+    <figure
+      className={ styles.gallery }
+      aria-roledescription="carousel"
+      aria-label="Photo gallery"
+      onKeyDown={ handleKeyDown }
+    >
+      { /* Screen-reader live announcement — visually hidden */ }
+      <p className={ styles.srOnly } aria-live="polite" aria-atomic="true">
+        { announcement }
+      </p>
+
+      <div className={ styles.viewport }>
+        <div
+          className={ styles.track }
+          style={ { transform: `translateX(-${ activeIndex * 100 }%)` } }
+        >
+          { items.map( ( item, index ) => (
+            <div
+              key={ index }
+              className={ styles.slideItem }
+              role="group"
+              aria-roledescription="slide"
+              aria-label={ `${ index + 1 } of ${ items.length }${ item.description ? `: ${ item.description }` : "" }` }
+              aria-hidden={ index !== activeIndex }
+            >
+              <Slide item={ item } isNearActive={ Math.abs( index - activeIndex ) <= 1 } isActive={ index === activeIndex } />
+            </div>
+          ) ) }
+        </div>
+        <button className={ styles.navPrev } onClick={ goToPrev } aria-label="Previous image">
+          ‹
+        </button>
+        <button className={ styles.navNext } onClick={ goToNext } aria-label="Next image">
+          ›
+        </button>
+        <span className={ styles.counter } aria-hidden="true">
+          { activeIndex + 1 } / { items.length }
+        </span>
+      </div>
+
+      { /* Always rendered — min-height prevents layout shift when caption is empty */ }
+      <figcaption className={ styles.captionArea }>
+        { activeItem.description }
+      </figcaption>
+
+      <div className={ styles.dots } aria-label="Gallery navigation" role="group">
+        { items.map( ( item, dotIndex ) => (
+          <button
+            key={ dotIndex }
+            className={ `${ styles.dot } ${ dotIndex === activeIndex ? styles.dotActive : "" }` }
+            onClick={ () => setActiveIndex( dotIndex ) }
+            aria-label={ `${ item.type === "video" ? "Video" : "Image" } ${ dotIndex + 1 }${ item.description ? `: ${ item.description }` : "" }` }
+            aria-current={ dotIndex === activeIndex }
+          />
+        ) ) }
+      </div>
+    </figure>
+  );
+};
+
+export default Gallery;

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -13,6 +13,7 @@ import { Markdown } from "@/components/Markdown";
 import { Tags } from "@/components/Tags";
 import { SpotifyPlaylist, getPlaylist } from "@/utils/spotify/getPlaylist";
 import Playlist from "@/components/Playlist";
+import Gallery, { resolveGalleryItems } from "@/components/Gallery";
 
 
 const IMAGE_SIZE = 750;
@@ -124,6 +125,7 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, prevPost, 
               </p>
             </header>
             <Markdown>{ post.fields.body || "" }</Markdown>
+            <Gallery items={ resolveGalleryItems( post.fields.gallery ) } />
             { playlist && <Playlist playlist={ playlist } /> }
             { ( prevPost || nextPost ) && (
               <nav className={ styles.postNav }>

--- a/src/styles/Gallery.module.scss
+++ b/src/styles/Gallery.module.scss
@@ -1,0 +1,211 @@
+.gallery {
+  margin: 2rem 0;
+  user-select: none;
+}
+
+// ── Screen-reader only ────────────────────────────────────────────────────────
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+// ── Viewport & track ──────────────────────────────────────────────────────────
+
+.viewport {
+  position: relative;
+  overflow: hidden;
+  height: 540px;
+  background: rgba(0, 0, 0, 0.08);
+
+  @media (prefers-color-scheme: light) {
+    background: rgba(0, 0, 0, 0.04);
+  }
+}
+
+.track {
+  display: flex;
+  height: 100%;
+  transition: transform 0.45s cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: transform;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}
+
+.slideItem {
+  position: relative;
+  flex: 0 0 100%;
+  width: 100%;
+  height: 100%;
+
+  > img {
+    object-fit: contain;
+  }
+}
+
+.singleSlide {
+  position: relative;
+  width: 100%;
+  height: 100%;
+
+  > img {
+    object-fit: contain;
+  }
+}
+
+.video {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+// ── Nav buttons ───────────────────────────────────────────────────────────────
+
+.navPrev,
+.navNext {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s ease, background 0.2s ease, transform 0.2s ease;
+  z-index: 2;
+
+  @media (prefers-color-scheme: light) {
+    background: rgba(255, 255, 255, 0.55);
+    color: rgba(0, 0, 0, 0.8);
+  }
+}
+
+// Always visible when hovered or keyboard-focused
+.viewport:hover .navPrev,
+.viewport:hover .navNext,
+.navPrev:focus-visible,
+.navNext:focus-visible {
+  opacity: 1;
+}
+
+.navPrev:focus-visible,
+.navNext:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 3px;
+}
+
+.navPrev {
+  left: 0.75rem;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.6);
+    transform: translateY(-50%) scale(1.08);
+
+    @media (prefers-color-scheme: light) {
+      background: rgba(255, 255, 255, 0.85);
+    }
+  }
+}
+
+.navNext {
+  right: 0.75rem;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.6);
+    transform: translateY(-50%) scale(1.08);
+
+    @media (prefers-color-scheme: light) {
+      background: rgba(255, 255, 255, 0.85);
+    }
+  }
+}
+
+// ── Counter ───────────────────────────────────────────────────────────────────
+
+.counter {
+  position: absolute;
+  bottom: 0.6rem;
+  right: 0.75rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.7);
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  pointer-events: none;
+
+  @media (prefers-color-scheme: light) {
+    color: rgba(0, 0, 0, 0.7);
+    background: rgba(255, 255, 255, 0.55);
+  }
+}
+
+// ── Caption & dots ────────────────────────────────────────────────────────────
+
+// Always rendered — min-height prevents layout shift when caption text is absent.
+// Set the asset's Description field in Contentful to populate this.
+.captionArea {
+  min-height: 1.6em;
+  margin-top: 0.6rem;
+  text-align: center;
+  font-size: small;
+  opacity: 0.65;
+  font-style: italic;
+}
+
+.dots {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.65rem;
+}
+
+.dot {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+  background: currentColor;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  opacity: 0.2;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+
+  &:hover {
+    opacity: 0.5;
+  }
+
+  &:focus-visible {
+    opacity: 1;
+    outline: 2px solid currentColor;
+    outline-offset: 3px;
+  }
+}
+
+.dotActive {
+  opacity: 1;
+  transform: scale(1.4);
+}

--- a/src/types/contentful/TypeBlogPost.ts
+++ b/src/types/contentful/TypeBlogPost.ts
@@ -68,6 +68,12 @@ export interface TypeBlogPostFields {
      * @localized false
      */
     author: EntryFieldTypes.EntryLink<TypeAuthorSkeleton>;
+    /**
+     * Field type definition for field 'gallery' (Gallery)
+     * @name Gallery
+     * @localized false
+     */
+    gallery?: EntryFieldTypes.Array<EntryFieldTypes.AssetLink>;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds an optional `gallery` field (array of images/videos) to the `blogPost` Contentful content type
- Renders a slideshow after the post body — hidden when empty, single image/video when one item, full carousel when 2+
- Slide transition with cubic-bezier easing and `prefers-reduced-motion` support
- Videos pause automatically when navigating away; adjacent slides preload with `loading="eager"`

## Accessibility

- ARIA carousel pattern: `aria-roledescription="carousel"`, `aria-hidden` on inactive slides, `aria-live` announcement region
- Keyboard navigation (arrow keys) scoped to gallery focus — not global
- `focus-visible` outlines on all controls (nav arrows + dots)
- Type-aware labels ("Image N" vs "Video N") on dot buttons

## SEO

- `<figure>` + `<figcaption>` semantic structure; caption populated via Contentful asset Description field
- `sizes` attribute on all images for correct responsive source selection
- All slides remain in the DOM so crawlers can index every image

## Test plan

- [ ] Visit `/post/gan-bei-7-year-anniversary-party-in-chinatown-seattle` — 26-image slideshow renders after body
- [ ] Visit `/post/halloween-party-at-gan-bei-seattle` — mixed video + images; video pauses on slide change
- [ ] Keyboard: tab into gallery, arrow keys navigate slides
- [ ] Verify nav arrows appear on hover and on focus
- [ ] Check dot indicators update and are labelled correctly
- [ ] Test with `prefers-reduced-motion: reduce` — transition should be instant