### PR TITLE
Fix gallery caption fallback and img lint warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,14 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 
 const eslintConfig = defineConfig( [ ...nextTypescript, ...nextVitals, {
+  // Picture.tsx uses a native <picture>/<source> pattern to serve WebP via Contentful's
+  // Images API, which is more effective than next/image here since static export requires
+  // `images.unoptimized: true` (making next/image render a plain <img> with no optimization).
+  files: [ "src/components/Picture.tsx", "src/__tests__/**/*.tsx" ],
+  rules: {
+    "@next/next/no-img-element": "off",
+  },
+}, {
   rules: {
     "indent": [ "error", 2 ],
     "array-bracket-spacing": [ 2, "always" ],

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -112,7 +112,7 @@ const Gallery: FC<GalleryProps> = ({ items }) => {
           </div>
         </div>
         <figcaption className={ styles.captionArea }>
-          { singleItem.description }
+          { singleItem.description || singleItem.title }
         </figcaption>
       </figure>
     );
@@ -166,7 +166,7 @@ const Gallery: FC<GalleryProps> = ({ items }) => {
 
       { /* Always rendered — min-height prevents layout shift when caption is empty */ }
       <figcaption className={ styles.captionArea }>
-        { activeItem.description }
+        { activeItem.description || activeItem.title }
       </figcaption>
 
       <div className={ styles.dots } aria-label="Gallery navigation" role="group">


### PR DESCRIPTION
## Summary

- **Gallery captions**: fall back to the image title when `description` is empty, so captions are always shown
- **ESLint**: disable `no-img-element` for `Picture.tsx` (uses native `<picture>`/`<source>` for WebP via Contentful's Images API — more effective than `next/image` given `unoptimized: true` in static export) and `src/__tests__/**/*.tsx` (standard `next/image` mock pattern)

## Test plan

- [ ] View a gallery with images that have no description — confirm the title appears as caption
- [ ] Run `yarn format` — confirm zero warnings