### PR TITLE
SEO: add canonical, og:type/url, and Twitter Cards to listing pages

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,6 +9,7 @@ import { GetStaticPropsContext } from "next";
 import Pagination from "@/components/Home/Pagination";
 import { generateFeeds } from "@/lib/generateFeeds";
 import { META_DESCRIPTION, META_IMAGE, META_TITLE, SITE_URL } from "@/constants";
+import { capitalize } from "@/utils/stringUtils";
 import { OldSchoolButton } from "@/components/OldSchoolButton";
 
 export const PAGE_SIZE = 12;
@@ -28,7 +29,7 @@ export default function Home({ posts, page, tags, tagId }: HomeProps ) {
 
   const isTagPage = Boolean( tagId );
   const isPaginated = page > 1;
-  const tagLabel = tagId ? tagId.charAt( 0 ).toUpperCase() + tagId.slice( 1 ) : "";
+  const tagLabel = tagId ? capitalize( tagId ) : "";
 
   const pageTitle = isTagPage && isPaginated
     ? `${tagLabel} — Page ${page} | Audeos.com`

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,17 +28,18 @@ export default function Home({ posts, page, tags, tagId }: HomeProps ) {
 
   const isTagPage = Boolean( tagId );
   const isPaginated = page > 1;
+  const tagLabel = tagId ? tagId.charAt( 0 ).toUpperCase() + tagId.slice( 1 ) : "";
 
   const pageTitle = isTagPage && isPaginated
-    ? `${tagId} — Page ${page} | Audeos.com`
+    ? `${tagLabel} — Page ${page} | Audeos.com`
     : isTagPage
-      ? `${tagId} | Audeos.com`
+      ? `${tagLabel} | Audeos.com`
       : isPaginated
         ? `Blog — Page ${page} | ${META_TITLE}`
         : META_TITLE;
 
   const pageDescription = isTagPage
-    ? `Browse all ${tagId} posts on Audeos.com`
+    ? `Browse all ${tagLabel} posts on Audeos.com`
     : META_DESCRIPTION;
 
   const canonicalUrl = isTagPage && isPaginated

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,7 +8,7 @@ import { sortTagsByName } from "@/utils/blogPostUtils";
 import { GetStaticPropsContext } from "next";
 import Pagination from "@/components/Home/Pagination";
 import { generateFeeds } from "@/lib/generateFeeds";
-import { META_DESCRIPTION, META_IMAGE, META_TITLE } from "@/constants";
+import { META_DESCRIPTION, META_IMAGE, META_TITLE, SITE_URL } from "@/constants";
 import { OldSchoolButton } from "@/components/OldSchoolButton";
 
 export const PAGE_SIZE = 12;
@@ -26,19 +26,49 @@ export default function Home({ posts, page, tags, tagId }: HomeProps ) {
     .filter( post => tagId === null || post.metadata.tags
       .find( tag => tag.sys.id == tagId ) );
 
+  const isTagPage = Boolean( tagId );
+  const isPaginated = page > 1;
+
+  const pageTitle = isTagPage && isPaginated
+    ? `Posts tagged: ${tagId} — Page ${page} | Audeos.com`
+    : isTagPage
+      ? `Posts tagged: ${tagId} | Audeos.com`
+      : isPaginated
+        ? `Blog — Page ${page} | ${META_TITLE}`
+        : META_TITLE;
+
+  const pageDescription = isTagPage
+    ? `Browse all posts tagged "${tagId}" on Audeos.com`
+    : META_DESCRIPTION;
+
+  const canonicalUrl = isTagPage && isPaginated
+    ? `${SITE_URL}/tags/${tagId}/page/${page}`
+    : isTagPage
+      ? `${SITE_URL}/tags/${tagId}`
+      : isPaginated
+        ? `${SITE_URL}/page/${page}`
+        : SITE_URL;
+
   return (
     <>
       <Head>
-        <title>Audeos.com</title>
+        <title>{ pageTitle }</title>
+        <link rel="canonical" href={ canonicalUrl } />
         <link rel="alternate" type="application/rss+xml" href="/rss.xml" />
         <link rel="alternate" type="application/atom+xml" href="/atom.xml" />
         <link rel="alternate" type="application/feed+json" href="/feed.json" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.png" />
-        <meta name="description" content={ META_DESCRIPTION } key="desc" />
-        <meta property="og:title" content={ META_TITLE } />
-        <meta property="og:description" content={ META_DESCRIPTION } />
+        <meta name="description" content={ pageDescription } key="desc" />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={ canonicalUrl } />
+        <meta property="og:title" content={ pageTitle } />
+        <meta property="og:description" content={ pageDescription } />
         <meta property="og:image" content={ META_IMAGE } />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={ pageTitle } />
+        <meta name="twitter:description" content={ pageDescription } />
+        <meta name="twitter:image" content={ META_IMAGE } />
       </Head>
       <Layout isFullwidth>
         <main className={ styles.main }>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,15 +30,15 @@ export default function Home({ posts, page, tags, tagId }: HomeProps ) {
   const isPaginated = page > 1;
 
   const pageTitle = isTagPage && isPaginated
-    ? `Posts tagged: ${tagId} — Page ${page} | Audeos.com`
+    ? `${tagId} — Page ${page} | Audeos.com`
     : isTagPage
-      ? `Posts tagged: ${tagId} | Audeos.com`
+      ? `${tagId} | Audeos.com`
       : isPaginated
         ? `Blog — Page ${page} | ${META_TITLE}`
         : META_TITLE;
 
   const pageDescription = isTagPage
-    ? `Browse all posts tagged "${tagId}" on Audeos.com`
+    ? `Browse all ${tagId} posts on Audeos.com`
     : META_DESCRIPTION;
 
   const canonicalUrl = isTagPage && isPaginated

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -13,7 +13,7 @@ import { Tags } from "@/components/Tags";
 import DateTimeFormat from "@/components/DateTimeFormat";
 import styles from "@/styles/Home.module.scss";
 import searchStyles from "@/styles/Search.module.scss";
-import { META_DESCRIPTION, META_IMAGE, META_TITLE } from "@/constants";
+import { META_DESCRIPTION, META_IMAGE, META_TITLE, SITE_URL } from "@/constants";
 
 export interface SearchProps {
   posts: SearchPost[];
@@ -50,12 +50,19 @@ export default function Search({ posts }: SearchProps ) {
     <>
       <Head>
         <title>Search — Audeos.com</title>
+        <link rel="canonical" href={ `${SITE_URL}/search` } />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.png" />
         <meta name="description" content={ META_DESCRIPTION } key="desc" />
-        <meta property="og:title" content={ META_TITLE } />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={ `${SITE_URL}/search` } />
+        <meta property="og:title" content={ `Search | ${META_TITLE}` } />
         <meta property="og:description" content={ META_DESCRIPTION } />
         <meta property="og:image" content={ META_IMAGE } />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={ `Search | ${META_TITLE}` } />
+        <meta name="twitter:description" content={ META_DESCRIPTION } />
+        <meta name="twitter:image" content={ META_IMAGE } />
       </Head>
       <Layout>
         <main className={ styles.main }>

--- a/src/utils/stringUtils.test.ts
+++ b/src/utils/stringUtils.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { capitalize } from "./stringUtils";
+
+describe( "capitalize", () => {
+  it( "capitalizes the first letter of a lowercase string", () => {
+    expect( capitalize( "house" ) ).toBe( "House" );
+  });
+
+  it( "leaves an already-capitalized string unchanged", () => {
+    expect( capitalize( "House" ) ).toBe( "House" );
+  });
+
+  it( "capitalizes only the first letter, leaving the rest as-is", () => {
+    expect( capitalize( "hOUSE" ) ).toBe( "HOUSE" );
+  });
+
+  it( "handles a single character", () => {
+    expect( capitalize( "a" ) ).toBe( "A" );
+  });
+
+  it( "returns an empty string unchanged", () => {
+    expect( capitalize( "" ) ).toBe( "" );
+  });
+});

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -1,0 +1,4 @@
+export function capitalize( str: string ): string {
+  if( !str ) return str;
+  return str.charAt( 0 ).toUpperCase() + str.slice( 1 );
+}


### PR DESCRIPTION
## Summary
- Index, tag, and pagination pages now have dynamic `<link rel="canonical">` URLs, page-specific titles/descriptions, `og:type`/`og:url`, and full Twitter Card meta tags
- Search page gets the same treatment with a static canonical (`/search`)
- Covers Phase 1 of an SEO audit that identified these as missing across all non-post pages (post pages were already well-implemented)

## Changes
- `src/pages/index.tsx` — dynamic title/description/canonical computed from `tagId` and `page` props; shared by `/`, `/page/[page]`, `/tags/[tagId]`, `/tags/[tagId]/page/[page]`
- `src/pages/search.tsx` — static canonical, og:type/url, Twitter Card tags added

## Test plan
- [ ] Homepage (`/`) — canonical is `https://www.audeos.com`, title is "Audeos.com"
- [ ] Pagination page (`/page/2`) — canonical is `https://www.audeos.com/page/2`, title is "Blog — Page 2 | Audeos.com"
- [ ] Tag page (`/tags/house`) — canonical is `https://www.audeos.com/tags/house`, title is "Posts tagged: house | Audeos.com"
- [ ] Tag pagination (`/tags/house/page/2`) — canonical and title reflect both tag and page
- [ ] Search page — canonical is `https://www.audeos.com/search`, og:title is "Search | Audeos.com"
- [ ] Post pages unchanged