### PR TITLE
Scroll to post grid on mobile when filtering by tag

### DIFF
--- a/src/components/Home/BlogPostList.tsx
+++ b/src/components/Home/BlogPostList.tsx
@@ -6,6 +6,7 @@ import Picture from "@/components/Picture";
 import { Tags } from "@/components/Tags";
 import { PAGE_SIZE } from "@/pages";
 import { BlogPost } from "@/utils/contentfulUtils";
+import { POSTS_ANCHOR } from "@/constants";
 
 
 const IMAGE_HEIGHT = 350;
@@ -19,7 +20,7 @@ export interface BlogPostListProps {
 
 export default function BlogPostList({ posts, page, tagId }: BlogPostListProps ) {
   return (
-    <ul className={ styles.imageGallery } role="list">
+    <ul id={ POSTS_ANCHOR } className={ styles.imageGallery } role="list">
       {
         posts
           .sort( sortBlogPostsByDate )

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -3,6 +3,7 @@ import { FC } from "react";
 
 import styles from "@/styles/Tags.module.scss";
 import Link from "next/link";
+import { POSTS_ANCHOR } from "@/constants";
 
 
 export interface TagProps {
@@ -12,7 +13,7 @@ export interface TagProps {
 
 const TagComponent: FC<TagProps> = ({ tagName, isTagged }) => {
   const className = isTagged ? styles.isTagged : undefined;
-  const href = isTagged ? "/" : `/tags/${tagName}`;
+  const href = isTagged ? `/#${POSTS_ANCHOR}` : `/tags/${tagName}#${POSTS_ANCHOR}`;
   return (
     <Link href={ href }>
       <code className={ className }>#{ tagName }</code>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,3 +5,4 @@ export const SITE_URL = "https://www.audeos.com";
 export const CONTENT_TYPE_BLOG_POST = "blogPost";
 export const GOOGLE_ANALYTICS_ID = "G-D81YP4DGH3";
 export const COOKIE_CONSENT_KEY = "cookie-consent";
+export const POSTS_ANCHOR = "posts";

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,7 +8,7 @@ import { sortTagsByName } from "@/utils/blogPostUtils";
 import { GetStaticPropsContext } from "next";
 import Pagination from "@/components/Home/Pagination";
 import { generateFeeds } from "@/lib/generateFeeds";
-import { META_DESCRIPTION, META_IMAGE, META_TITLE, SITE_URL } from "@/constants";
+import { META_DESCRIPTION, META_IMAGE, META_TITLE, POSTS_ANCHOR, SITE_URL } from "@/constants";
 import { capitalize } from "@/utils/stringUtils";
 import { OldSchoolButton } from "@/components/OldSchoolButton";
 
@@ -80,7 +80,7 @@ export default function Home({ posts, page, tags, tagId }: HomeProps ) {
                 .sort( sortTagsByName )
                 .map( tag => {
                   const className = tag.sys.id == tagId ? styles.isTagged : "";
-                  const href = tag.sys.id == tagId ? "/" : `/tags/${tag.sys.id}`;
+                  const href = tag.sys.id == tagId ? `/#${POSTS_ANCHOR}` : `/tags/${tag.sys.id}#${POSTS_ANCHOR}`;
                   return (
                     <div key={ tag.sys.id } className={ styles.navButtonWrapper }>
                       <OldSchoolButton


### PR DESCRIPTION
## Summary

- Adds `id="posts"` anchor to the post list `<ul>` via the `POSTS_ANCHOR` constant
- Appends `#posts` to all tag nav links (both the home page nav and per-post tag chips) so the browser auto-scrolls to the content after navigating to a new static page
- Extracts `POSTS_ANCHOR` constant to `constants.ts` so the anchor ID and all references stay in sync

## Test plan

- [ ] On mobile, tap a tag from the home page — post grid should be visible without manual scrolling
- [ ] On mobile, tap a tag chip on a post card — same behaviour
- [ ] Tapping an already-active tag (deselect) returns to `/#posts` and scrolls to the grid on the home page
- [ ] No visual regressions on desktop