### PR TITLE
Fix abrupt scroll when filtering by tag

### DIFF
--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -3,7 +3,6 @@ import { FC } from "react";
 
 import styles from "@/styles/Tags.module.scss";
 import Link from "next/link";
-import { POSTS_ANCHOR } from "@/constants";
 
 
 export interface TagProps {
@@ -13,7 +12,7 @@ export interface TagProps {
 
 const TagComponent: FC<TagProps> = ({ tagName, isTagged }) => {
   const className = isTagged ? styles.isTagged : undefined;
-  const href = isTagged ? `/#${POSTS_ANCHOR}` : `/tags/${tagName}#${POSTS_ANCHOR}`;
+  const href = isTagged ? "/" : `/tags/${tagName}`;
   return (
     <Link href={ href }>
       <code className={ className }>#{ tagName }</code>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,6 +11,7 @@ import { generateFeeds } from "@/lib/generateFeeds";
 import { META_DESCRIPTION, META_IMAGE, META_TITLE, POSTS_ANCHOR, SITE_URL } from "@/constants";
 import { capitalize } from "@/utils/stringUtils";
 import { OldSchoolButton } from "@/components/OldSchoolButton";
+import { useEffect } from "react";
 
 export const PAGE_SIZE = 12;
 
@@ -29,6 +30,14 @@ export default function Home({ posts, page, tags, tagId }: HomeProps ) {
 
   const isTagPage = Boolean( tagId );
   const isPaginated = page > 1;
+
+  useEffect( () => {
+    if( !tagId ) return;
+    const isMobile = window.innerWidth <= 768;
+    if( !isMobile ) return;
+    const postsElement = document.getElementById( POSTS_ANCHOR );
+    postsElement?.scrollIntoView({ behavior: "smooth" });
+  }, [ tagId ] );
   const tagLabel = tagId ? capitalize( tagId ) : "";
 
   const pageTitle = isTagPage && isPaginated
@@ -80,7 +89,7 @@ export default function Home({ posts, page, tags, tagId }: HomeProps ) {
                 .sort( sortTagsByName )
                 .map( tag => {
                   const className = tag.sys.id == tagId ? styles.isTagged : "";
-                  const href = tag.sys.id == tagId ? `/#${POSTS_ANCHOR}` : `/tags/${tag.sys.id}#${POSTS_ANCHOR}`;
+                  const href = tag.sys.id == tagId ? "/" : `/tags/${tag.sys.id}`;
                   return (
                     <div key={ tag.sys.id } className={ styles.navButtonWrapper }>
                       <OldSchoolButton


### PR DESCRIPTION
## Summary

- Removes the `#posts` hash anchor from tag nav link hrefs, eliminating the jarring browser-native jump on navigation
- On mobile (≤768px), a `useEffect` smooth-scrolls to the post grid after mount — replacing the abrupt jump with an animated scroll
- On desktop, no scroll happens at all — the post grid is already visible in the viewport

## Test plan

- [ ] Desktop: click a tag — page navigates, no scroll occurs, posts are visible in place
- [ ] Mobile: click a tag — page navigates, post grid smoothly scrolls into view
- [ ] Mobile: clicking an active tag (deselect) returns to `/` with no scroll