### PR TITLE
fix: comprehensive codebase review — bugs, DRY, SOLID, cleanliness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 # misc
 .DS_Store
 .superpowers/
+.claude/projects/
 contentful/export.json
 *.pem
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ The build output goes to `dist/` (not `.next/`). Feeds (RSS/Atom/JSON) are gener
 - Run `yarn format` after every file change to keep code conformant with the ESLint styleguide, then run `yarn test` to confirm nothing is broken.
 - Do not use single-character variable names — use descriptive names even for short-lived variables (e.g., `post` not `p`, `index` not `i`).
 - Never use `eslint-disable` or `eslint-disable-next-line` comments to suppress ESLint errors — fix the underlying code instead.
+- Enforce required environment variables at module scope using `import { strict as assert } from "assert"` followed by `assert( !!VAR )`. This ensures the build fails immediately if a variable is missing. See `src/utils/contentfulUtils.ts` for the canonical example. Never defer these checks to function-level.
+- Never use TypeScript `as` type assertions — they bypass the type checker and hide bugs. Use type guards, narrowing, or `satisfies` instead. See [why `as` is harmful](https://dev.to/alexanderop/the-problem-with-as-in-typescript-why-its-a-shortcut-we-should-avoid-2km4).
 
 ## Architecture
 

--- a/src/__tests__/components/Pagination.test.tsx
+++ b/src/__tests__/components/Pagination.test.tsx
@@ -2,7 +2,10 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 
-vi.mock( "@/pages", () => ({ PAGE_SIZE: 3 }) );
+vi.mock( "@/constants", async importOriginal => ({
+  ...( await importOriginal<typeof import( "@/constants" )>() ),
+  PAGE_SIZE: 3,
+}) );
 vi.mock( "@/utils/contentfulUtils", () => ({}) );
 vi.mock( "next/link", () => ({
   default: ({ children, href, ...props }: React.ComponentProps<"a"> ) => (

--- a/src/__tests__/lib/generateSearchIndex.test.ts
+++ b/src/__tests__/lib/generateSearchIndex.test.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 
 vi.mock( "fs", () => ({
   default: {
+    mkdirSync: vi.fn(),
     writeFileSync: vi.fn(),
   },
 }) );

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,13 +1,7 @@
-"use client";
-
-import { useEffect, useSyncExternalStore, useState } from "react";
+import { useCallback, useEffect, useSyncExternalStore, useState } from "react";
 import styles from "@/styles/CookieConsent.module.scss";
-import { VT323 } from "next/font/google";
 import { COOKIE_CONSENT_KEY } from "@/constants";
-
-const fontVT323 = VT323({
-  weight: "400",
-});
+import { fontVT323 } from "@/styles/fonts";
 
 export function resetCookieConsent() {
   localStorage.removeItem( COOKIE_CONSENT_KEY );
@@ -33,7 +27,7 @@ export default function CookieConsent() {
       window.removeEventListener( "cookie-consent-reset", handler );
   }, [] );
 
-  const accept = () => {
+  const accept = useCallback( () => {
     localStorage.setItem( COOKIE_CONSENT_KEY, "accepted" );
     if( window.gtag ) {
       window.gtag( "consent", "update", {
@@ -42,9 +36,9 @@ export default function CookieConsent() {
     }
     window.dispatchEvent( new Event( "cookie-consent-granted" ) );
     setIsOpen( false );
-  };
+  }, [] );
 
-  const reject = () => {
+  const reject = useCallback( () => {
     localStorage.setItem( COOKIE_CONSENT_KEY, "rejected" );
     if( window.gtag ) {
       window.gtag( "consent", "update", {
@@ -52,7 +46,7 @@ export default function CookieConsent() {
       });
     }
     setIsOpen( false );
-  };
+  }, [] );
 
   /* keyboard shortcuts */
   useEffect( () => {
@@ -65,7 +59,7 @@ export default function CookieConsent() {
 
     window.addEventListener( "keydown", handler );
     return () => window.removeEventListener( "keydown", handler );
-  }, [ isVisible ] );
+  }, [ isVisible, accept, reject ] );
 
   if( !isVisible ) return null;
 

--- a/src/components/DateTimeFormat.tsx
+++ b/src/components/DateTimeFormat.tsx
@@ -60,7 +60,7 @@ export default function DateTimeFormat({
   const timeString = `${ doubleDigit( twelveHourFormat ) }:${ doubleDigit( minutes ) } ${ ampm }`;
 
   return (
-    <time>
+    <time dateTime={ timestamp }>
       { withDayName && `${dayName},` } { monthName } { day }, { year } { withTime && timeString }
     </time>
   );

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -142,7 +142,7 @@ const Gallery: FC<GalleryProps> = ({ items }) => {
         >
           { items.map( ( item, index ) => (
             <div
-              key={ index }
+              key={ item.url }
               className={ styles.slideItem }
               role="group"
               aria-roledescription="slide"
@@ -172,7 +172,7 @@ const Gallery: FC<GalleryProps> = ({ items }) => {
       <div className={ styles.dots } aria-label="Gallery navigation" role="group">
         { items.map( ( item, dotIndex ) => (
           <button
-            key={ dotIndex }
+            key={ item.url }
             className={ `${ styles.dot } ${ dotIndex === activeIndex ? styles.dotActive : "" }` }
             onClick={ () => setActiveIndex( dotIndex ) }
             aria-label={ `${ item.type === "video" ? "Video" : "Image" } ${ dotIndex + 1 }${ item.description ? `: ${ item.description }` : "" }` }

--- a/src/components/Home/BlogPostList.tsx
+++ b/src/components/Home/BlogPostList.tsx
@@ -1,10 +1,10 @@
 import Link from "next/link";
-import { sortBlogPostsByDate } from "@/utils/blogPostUtils";
+import { resolvePostDate, sortBlogPostsByDate } from "@/utils/blogPostUtils";
 import DateTimeFormat from "@/components/DateTimeFormat";
 import styles from "@/styles/Home.module.scss";
 import Picture from "@/components/Picture";
 import { Tags } from "@/components/Tags";
-import { PAGE_SIZE } from "@/pages";
+import { PAGE_SIZE } from "@/constants";
 import { BlogPost } from "@/utils/contentfulUtils";
 import { POSTS_ANCHOR } from "@/constants";
 
@@ -22,7 +22,7 @@ export default function BlogPostList({ posts, page, tagId }: BlogPostListProps )
   return (
     <ul id={ POSTS_ANCHOR } className={ styles.imageGallery } role="list">
       {
-        posts
+        [ ...posts ]
           .sort( sortBlogPostsByDate )
           .slice( PAGE_SIZE * ( page - 1 ), PAGE_SIZE * page )
           .map( post => {
@@ -30,7 +30,7 @@ export default function BlogPostList({ posts, page, tagId }: BlogPostListProps )
             const url = `/post/${post.fields.slug}`;
             const pictureUrl = post.fields.image?.fields.file?.url || "";
             const altText = post.fields.image?.fields.description || "";
-            const timestamp = post.fields.date || post.sys.createdAt;
+            const timestamp = resolvePostDate( post );
 
             return (
               <li key={ post.sys.id }>

--- a/src/components/Home/Pagination.tsx
+++ b/src/components/Home/Pagination.tsx
@@ -1,4 +1,4 @@
-import { PAGE_SIZE } from "@/pages";
+import { PAGE_SIZE } from "@/constants";
 import Link from "next/link";
 import styles from "@/styles/Home.module.scss";
 import { BlogPost } from "@/utils/contentfulUtils";
@@ -39,7 +39,7 @@ export default function Pagination({ posts, page, tagId }: PaginationProps ) {
           .map( pageNumber => {
             const isCurrentPage: boolean = pageNumber === page;
             const href: string = getPaginatorUrl( pageNumber, tagId );
-            const className: string|undefined = isCurrentPage ? styles.isTagged : undefined;
+            const className: string|undefined = isCurrentPage ? styles.isCurrentPage : undefined;
             return (
               <Link key={ pageNumber }
                 href={ href }

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -9,10 +9,10 @@ interface LayoutProps {
   isFullwidth?: boolean
 }
 
-export const Container: FC<LayoutProps> = ({ children }) =>
+export const Container: FC<{ children?: ReactNode }> = ({ children }) =>
   <div className={ styles.container }>{ children }</div>;
 
-export const Wrapper: FC<LayoutProps> = ({ children }) =>
+export const Wrapper: FC<{ children?: ReactNode }> = ({ children }) =>
   <section className={ styles.wrapper }>{ children }</section>;
 
 /**

--- a/src/components/MediaFigure.tsx
+++ b/src/components/MediaFigure.tsx
@@ -35,7 +35,7 @@ export const MediaFigure: FC<MediaFigureProps> = ({ src, alt }) => {
   if( extension && VIDEO_FILE_FORMAT_EXTENSIONS.includes( extension ) ) {
     return (
       <>
-        <video controls preload="metadata">
+        <video controls preload="metadata" aria-label={ alt || undefined }>
           <source src={ `${src}#t=0.001` } type={ `video/${extension}` } />
         </video>
         { alt && <p>{ alt }</p> }

--- a/src/components/OldSchoolButton.tsx
+++ b/src/components/OldSchoolButton.tsx
@@ -1,12 +1,8 @@
 import styles from "@/styles/OldSchoolButton.module.scss";
 import { Url } from "next/dist/shared/lib/router/router";
-import { VT323 } from "next/font/google";
 import Link from "next/link";
 import { FC } from "react";
-
-const fontVT323 = VT323({
-  weight: "400",
-});
+import { fontVT323 } from "@/styles/fonts";
 
 interface OldSchoolButtonProps {
   label: string
@@ -20,14 +16,14 @@ export const OldSchoolButton: FC<OldSchoolButtonProps> = ({
   href,
   label,
   onClick,
-  className,
+  className = "",
 }) => {
 
-  const _className = `${styles.button} ${fontVT323.className} ${className}`;
+  const combinedClassName = `${styles.button} ${fontVT323.className} ${className}`.trim();
 
-  if( !!href ) {
+  if( href ) {
     return (
-      <Link className={ _className }
+      <Link className={ combinedClassName }
         href={ href }
       >
         { label }
@@ -35,13 +31,11 @@ export const OldSchoolButton: FC<OldSchoolButtonProps> = ({
     );
   }
 
-  if( !!onClick ) {
-    return (
-      <button className={ _className }
-        onClick={ onClick }
-      >
-        { label }
-      </button>
-    );
-  }
+  return (
+    <button className={ combinedClassName }
+      onClick={ onClick }
+    >
+      { label }
+    </button>
+  );
 };

--- a/src/components/Playlist.tsx
+++ b/src/components/Playlist.tsx
@@ -42,7 +42,7 @@ export default function Playlist({ playlist }: SpotifyPlaylistProps ) {
             .map( track => {
 
               const albumCover = track.track.album.images
-                .find( image => image.width == 300 );
+                .find( image => image.width === 300 );
 
               const artists = track.track.artists
                 .map( artist => artist.name )

--- a/src/components/SeoHead.tsx
+++ b/src/components/SeoHead.tsx
@@ -1,0 +1,38 @@
+import Head from "next/head";
+import { FC, ReactNode } from "react";
+
+export interface SeoHeadProps {
+  title: string
+  canonicalUrl: string
+  description: string
+  ogType?: string
+  ogImage?: string
+  twitterCard?: "summary" | "summary_large_image"
+  children?: ReactNode
+}
+
+export const SeoHead: FC<SeoHeadProps> = ({
+  title,
+  canonicalUrl,
+  description,
+  ogType = "website",
+  ogImage,
+  twitterCard = "summary_large_image",
+  children,
+}) => (
+  <Head>
+    <title>{ title }</title>
+    <link rel="canonical" href={ canonicalUrl } />
+    <meta name="description" content={ description } key="desc" />
+    <meta property="og:type" content={ ogType } />
+    <meta property="og:url" content={ canonicalUrl } />
+    <meta property="og:title" content={ title } />
+    <meta property="og:description" content={ description } />
+    { ogImage && <meta property="og:image" content={ ogImage } /> }
+    <meta name="twitter:card" content={ twitterCard } />
+    <meta name="twitter:title" content={ title } />
+    <meta name="twitter:description" content={ description } />
+    { ogImage && <meta name="twitter:image" content={ ogImage } /> }
+    { children }
+  </Head>
+);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,9 +1,10 @@
 export const META_TITLE = "Audeos.com";
 export const META_DESCRIPTION = "Official website of DJ Audeos";
-export const META_IMAGE = "/images/audeos.jpg";
+export const META_IMAGE = "https://www.audeos.com/images/audeos.jpg";
 export const SITE_URL = "https://www.audeos.com";
 export const CONTENT_TYPE_BLOG_POST = "blogPost";
 export const CONTENT_TYPE_AUTHOR = "author";
 export const GOOGLE_ANALYTICS_ID = "G-D81YP4DGH3";
 export const COOKIE_CONSENT_KEY = "cookie-consent";
 export const POSTS_ANCHOR = "posts";
+export const PAGE_SIZE = 12;

--- a/src/lib/GoogleAnalytics.tsx
+++ b/src/lib/GoogleAnalytics.tsx
@@ -2,7 +2,7 @@ import { COOKIE_CONSENT_KEY, GOOGLE_ANALYTICS_ID } from "@/constants";
 import Script from "next/script";
 import { FC } from "react";
 
-export const GoogleAnalyics: FC = () => {
+export const GoogleAnalytics: FC = () => {
   return (
     <>
       <Script

--- a/src/lib/generateFeeds.ts
+++ b/src/lib/generateFeeds.ts
@@ -97,7 +97,7 @@ ${rssItems}
 <title>${item.title}</title>
 <link href="${item.url}"/>
 <id>${item.url}</id>
-<updated>${new Date( lastBuildDate ).toISOString()}</updated>
+<updated>${new Date( item.date ).toISOString()}</updated>
 </entry>` ).join( "" );
 
   const atomFeed: string = `<?xml version="1.0" encoding="utf-8"?>

--- a/src/lib/generateSearchIndex.ts
+++ b/src/lib/generateSearchIndex.ts
@@ -3,6 +3,8 @@ import path from "path";
 import { SearchPost } from "@/lib/searchTypes";
 
 export function generateSearchIndex( posts: SearchPost[] ) {
-  const filePath = path.join( process.cwd(), "public", "search-index.json" );
+  const publicDir = path.join( process.cwd(), "public" );
+  fs.mkdirSync( publicDir, { recursive: true });
+  const filePath = path.join( publicDir, "search-index.json" );
   fs.writeFileSync( filePath, JSON.stringify( posts ) );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import type { AppProps } from "next/app";
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 import * as gtag from "../lib/google-analytics";
-import { GoogleAnalyics } from "@/lib/GoogleAnalyics";
+import { GoogleAnalytics } from "@/lib/GoogleAnalytics";
 import CookieConsent from "@/components/CookieConsent";
 
 const fontMona_Sans = Mona_Sans({
@@ -25,7 +25,7 @@ export default function App({ Component, pageProps }: AppProps ) {
   return (
     <>
       <CookieConsent />
-      <GoogleAnalyics />
+      <GoogleAnalytics />
       <div className={ fontMona_Sans.className }>
         <Component { ...pageProps } />
       </div>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,7 +3,10 @@ import { Html, Head, Main, NextScript } from "next/document";
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" href="/favicon.png" />
+      </Head>
       <body>
         <Main />
         <NextScript />

--- a/src/pages/author/[slug].tsx
+++ b/src/pages/author/[slug].tsx
@@ -1,6 +1,5 @@
 import { FC } from "react";
 import { GetStaticPropsContext } from "next";
-import Head from "next/head";
 import Image from "next/image";
 import { Author, getAuthor, getAuthors } from "@/utils/contentfulUtils";
 import { META_TITLE, SITE_URL } from "@/constants";
@@ -8,6 +7,7 @@ import { stripMarkdown } from "@/utils/stringUtils";
 import styles from "@/styles/Author.module.scss";
 import { Layout } from "@/components/Layout/Layout";
 import { Markdown } from "@/components/Markdown";
+import { SeoHead } from "@/components/SeoHead";
 
 const AVATAR_SIZE = 80;
 const OG_IMAGE_SIZE = 1200;
@@ -35,27 +35,21 @@ export const AuthorPage: FC<AuthorPageProps> = ({ author }) => {
 
   return (
     <>
-      <Head>
-        <title>{ metaTitle }</title>
-        <link rel="canonical" href={ canonicalUrl } />
-        <link rel="icon" href="/favicon.png" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="description" content={ metaDescription } key="desc" />
-        <meta property="og:type" content="profile" />
-        <meta property="og:url" content={ canonicalUrl } />
-        <meta property="og:title" content={ metaTitle } />
-        <meta property="og:description" content={ metaDescription } />
-        <meta name="twitter:card" content="summary" />
-        <meta name="twitter:title" content={ metaTitle } />
-        <meta name="twitter:description" content={ metaDescription } />
-        { ogImageSrc && <meta property="og:image" content={ ogImageSrc } /> }
+      <SeoHead
+        title={ metaTitle }
+        canonicalUrl={ canonicalUrl }
+        description={ metaDescription }
+        ogType="profile"
+        ogImage={ ogImageSrc || undefined }
+        twitterCard="summary"
+      >
         { ogImageSrc && <meta property="og:image:alt" content={ `Profile photo of ${authorName}` } /> }
-        { ogImageSrc && <meta name="twitter:image" content={ ogImageSrc } /> }
+        { /* JSON-LD uses trusted CMS data only — safe for static rendering */ }
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={ { __html: JSON.stringify( jsonLd ) } }
         />
-      </Head>
+      </SeoHead>
       <Layout>
         <main className={ styles.main }>
           <article>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,20 +1,17 @@
-import Head from "next/head";
 import styles from "@/styles/Home.module.scss";
 import { BlogPosts, getBlogPosts, getTags } from "@/utils/contentfulUtils";
 import BlogPostList from "@/components/Home/BlogPostList";
 import { Layout } from "@/components/Layout/Layout";
 import { TagCollection } from "contentful";
-import { sortTagsByName } from "@/utils/blogPostUtils";
+import { sortTagsById } from "@/utils/blogPostUtils";
 import { GetStaticPropsContext } from "next";
 import Pagination from "@/components/Home/Pagination";
 import { generateFeeds } from "@/lib/generateFeeds";
 import { META_DESCRIPTION, META_IMAGE, META_TITLE, POSTS_ANCHOR, SITE_URL } from "@/constants";
 import { capitalize } from "@/utils/stringUtils";
 import { OldSchoolButton } from "@/components/OldSchoolButton";
+import { SeoHead } from "@/components/SeoHead";
 import { useEffect } from "react";
-
-export const PAGE_SIZE = 12;
-
 
 export interface HomeProps {
   posts: BlogPosts
@@ -26,7 +23,7 @@ export interface HomeProps {
 export default function Home({ posts, page, tags, tagId }: HomeProps ) {
   const filteredBlogPosts = posts.items
     .filter( post => tagId === null || post.metadata.tags
-      .find( tag => tag.sys.id == tagId ) );
+      .find( tag => tag.sys.id === tagId ) );
 
   const isTagPage = Boolean( tagId );
   const isPaginated = page > 1;
@@ -62,34 +59,25 @@ export default function Home({ posts, page, tags, tagId }: HomeProps ) {
 
   return (
     <>
-      <Head>
-        <title>{ pageTitle }</title>
-        <link rel="canonical" href={ canonicalUrl } />
+      <SeoHead
+        title={ pageTitle }
+        canonicalUrl={ canonicalUrl }
+        description={ pageDescription }
+        ogImage={ META_IMAGE }
+      >
         <link rel="alternate" type="application/rss+xml" href="/rss.xml" />
         <link rel="alternate" type="application/atom+xml" href="/atom.xml" />
         <link rel="alternate" type="application/feed+json" href="/feed.json" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="/favicon.png" />
-        <meta name="description" content={ pageDescription } key="desc" />
-        <meta property="og:type" content="website" />
-        <meta property="og:url" content={ canonicalUrl } />
-        <meta property="og:title" content={ pageTitle } />
-        <meta property="og:description" content={ pageDescription } />
-        <meta property="og:image" content={ META_IMAGE } />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={ pageTitle } />
-        <meta name="twitter:description" content={ pageDescription } />
-        <meta name="twitter:image" content={ META_IMAGE } />
-      </Head>
+      </SeoHead>
       <Layout isFullwidth>
         <main className={ styles.main }>
           <nav>
             {
               tags.items
-                .sort( sortTagsByName )
+                .sort( sortTagsById )
                 .map( tag => {
-                  const className = tag.sys.id == tagId ? styles.isTagged : "";
-                  const href = tag.sys.id == tagId ? "/" : `/tags/${tag.sys.id}`;
+                  const className = tag.sys.id === tagId ? styles.isTagged : "";
+                  const href = tag.sys.id === tagId ? "/" : `/tags/${tag.sys.id}`;
                   return (
                     <div key={ tag.sys.id } className={ styles.navButtonWrapper }>
                       <OldSchoolButton
@@ -123,7 +111,9 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
   const page: number = Number( context.params?.page ) || 1;
   const tags = await getTags();
   const posts = await getBlogPosts();
-  generateFeeds( posts.items );
+  if( !tagId && page === 1 ) {
+    generateFeeds( posts.items );
+  }
   return {
     props: {
       tagId,

--- a/src/pages/page/[page].tsx
+++ b/src/pages/page/[page].tsx
@@ -1,5 +1,6 @@
 import { getBlogPosts } from "@/utils/contentfulUtils";
-import Home, { PAGE_SIZE, getStaticProps as getStaticPropsHome } from "@/pages";
+import Home, { getStaticProps as getStaticPropsHome } from "@/pages";
+import { PAGE_SIZE } from "@/constants";
 
 
 export const getStaticProps = getStaticPropsHome;

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -1,11 +1,12 @@
 import { FC } from "react";
 import { GetStaticPropsContext } from "next";
-import Head from "next/head";
 import Link from "next/link";
 import Image from "next/image";
 
 import { BlogPost, getBlogPost, getBlogPosts } from "@/utils/contentfulUtils";
+import { resolvePostDate, sortBlogPostsByDate } from "@/utils/blogPostUtils";
 import { SITE_URL } from "@/constants";
+import { SeoHead } from "@/components/SeoHead";
 import styles from "@/styles/BlogPost.module.scss";
 import DateTimeFormat from "@/components/DateTimeFormat";
 import { Layout } from "@/components/Layout/Layout";
@@ -41,7 +42,7 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, prevPost, 
   const authorName = post.fields.author?.fields.name;
   const authorSlug = post.fields.author?.fields.slug;
   const canonicalUrl = `${SITE_URL}/post/${post.fields.slug}`;
-  const publishedTime = post.fields.date || post.sys.createdAt;
+  const publishedTime = resolvePostDate( post );
   const modifiedTime = post.sys.updatedAt;
   const jsonLd = {
     "@context": "https://schema.org",
@@ -65,26 +66,20 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, prevPost, 
   };
   return (
     <>
-      <Head>
-        <title>{ metaTitle }</title>
-        <link rel="canonical" href={ canonicalUrl } />
-        <meta name="description" content={ post.fields.description } key="desc" />
-        <meta property="og:type" content="article" />
-        <meta property="og:url" content={ canonicalUrl } />
-        <meta property="og:title" content={ metaTitle } />
-        <meta property="og:description" content={ post.fields.description } />
-        <meta property="og:image" content={ metaImage } />
+      <SeoHead
+        title={ metaTitle }
+        canonicalUrl={ canonicalUrl }
+        description={ post.fields.description ?? "" }
+        ogType="article"
+        ogImage={ metaImage }
+      >
         <meta property="article:published_time" content={ publishedTime } />
         <meta property="article:modified_time" content={ modifiedTime } />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={ metaTitle } />
-        <meta name="twitter:description" content={ post.fields.description } />
-        <meta name="twitter:image" content={ metaImage } />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={ { __html: JSON.stringify( jsonLd ) } }
         />
-      </Head>
+      </SeoHead>
       <Layout>
         <main className={ styles.main }>
           <article>
@@ -131,7 +126,7 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, prevPost, 
                           ? <Link rel="author" href={ `/author/${authorSlug}` }>{ authorName }</Link>
                           : authorName
                         }
-                        { ` on ` } <DateTimeFormat timestamp={ post.fields.date || post.sys.createdAt } />
+                        { ` on ` } <DateTimeFormat timestamp={ resolvePostDate( post ) } />
                       </b>
                   }
                 </span>
@@ -171,46 +166,48 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, prevPost, 
 export async function getStaticProps( context: GetStaticPropsContext ) {
   const slug = context.params?.slug;
   if( typeof slug !== "string" ) {
-    return { props: {} };
-  } else {
-    const [ post, allPosts ] = await Promise.all( [
-      getBlogPost( slug ),
-      getBlogPosts(),
-    ] );
-    const playlist = post?.fields.spotifyPlaylistId
-      ? await getPlaylist( post.fields.spotifyPlaylistId ) : null;
-
-    const sortedPosts = allPosts.items
-      .slice()
-      .sort( ( postA, postB ) => {
-        const dateA = new Date( postA.fields.date || postA.sys.createdAt ).getTime();
-        const dateB = new Date( postB.fields.date || postB.sys.createdAt ).getTime();
-        return dateA - dateB;
-      });
-
-    const currentIndex = sortedPosts.findIndex(
-      sortedPost => sortedPost.fields.slug === slug,
-    );
-
-    const prevPostEntry = currentIndex > 0 ? sortedPosts[currentIndex - 1] : null;
-    const nextPostEntry = currentIndex < sortedPosts.length - 1 ? sortedPosts[currentIndex + 1] : null;
-
-    const prevPost: PostNavLink | null = prevPostEntry
-      ? { slug: prevPostEntry.fields.slug as string, title: prevPostEntry.fields.title as string }
-      : null;
-    const nextPost: PostNavLink | null = nextPostEntry
-      ? { slug: nextPostEntry.fields.slug as string, title: nextPostEntry.fields.title as string }
-      : null;
-
-    return {
-      props: {
-        post,
-        playlist,
-        prevPost,
-        nextPost,
-      },
-    };
+    return { notFound: true };
   }
+
+  const [ post, allPosts ] = await Promise.all( [
+    getBlogPost( slug ),
+    getBlogPosts(),
+  ] );
+
+  if( !post ) {
+    return { notFound: true };
+  }
+
+  const playlist = post.fields.spotifyPlaylistId
+    ? await getPlaylist( post.fields.spotifyPlaylistId ) : null;
+
+  const sortedPosts = allPosts.items
+    .slice()
+    .sort( sortBlogPostsByDate )
+    .reverse();
+
+  const currentIndex = sortedPosts.findIndex(
+    sortedPost => sortedPost.fields.slug === slug,
+  );
+
+  const prevPostEntry = currentIndex > 0 ? sortedPosts[currentIndex - 1] : null;
+  const nextPostEntry = currentIndex < sortedPosts.length - 1 ? sortedPosts[currentIndex + 1] : null;
+
+  const prevPost: PostNavLink | null = prevPostEntry
+    ? { slug: prevPostEntry.fields.slug, title: prevPostEntry.fields.title }
+    : null;
+  const nextPost: PostNavLink | null = nextPostEntry
+    ? { slug: nextPostEntry.fields.slug, title: nextPostEntry.fields.title }
+    : null;
+
+  return {
+    props: {
+      post,
+      playlist,
+      prevPost,
+      nextPost,
+    },
+  };
 }
 
 export async function getStaticPaths() {

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -1,10 +1,10 @@
-import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useMemo } from "react";
 import Fuse from "fuse.js";
 
 import { getBlogPosts } from "@/utils/contentfulUtils";
+import { resolvePostDate } from "@/utils/blogPostUtils";
 import { getPlaylist } from "@/utils/spotify/getPlaylist";
 import { generateSearchIndex } from "@/lib/generateSearchIndex";
 import { SearchPost } from "@/lib/searchTypes";
@@ -14,6 +14,7 @@ import DateTimeFormat from "@/components/DateTimeFormat";
 import styles from "@/styles/Home.module.scss";
 import searchStyles from "@/styles/Search.module.scss";
 import { META_DESCRIPTION, META_IMAGE, META_TITLE, SITE_URL } from "@/constants";
+import { SeoHead } from "@/components/SeoHead";
 import { stripMarkdown } from "@/utils/stringUtils";
 
 export interface SearchProps {
@@ -49,22 +50,12 @@ export default function Search({ posts }: SearchProps ) {
 
   return (
     <>
-      <Head>
-        <title>Search — Audeos.com</title>
-        <link rel="canonical" href={ `${SITE_URL}/search` } />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="/favicon.png" />
-        <meta name="description" content={ META_DESCRIPTION } key="desc" />
-        <meta property="og:type" content="website" />
-        <meta property="og:url" content={ `${SITE_URL}/search` } />
-        <meta property="og:title" content={ `Search | ${META_TITLE}` } />
-        <meta property="og:description" content={ META_DESCRIPTION } />
-        <meta property="og:image" content={ META_IMAGE } />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={ `Search | ${META_TITLE}` } />
-        <meta name="twitter:description" content={ META_DESCRIPTION } />
-        <meta name="twitter:image" content={ META_IMAGE } />
-      </Head>
+      <SeoHead
+        title={ `Search | ${META_TITLE}` }
+        canonicalUrl={ `${SITE_URL}/search` }
+        description={ META_DESCRIPTION }
+        ogImage={ META_IMAGE }
+      />
       <Layout>
         <main className={ styles.main }>
           <section className={ searchStyles.searchResults }>
@@ -128,7 +119,7 @@ export async function getStaticProps() {
         author: post.fields.author?.fields?.name ?? "",
         spotifyText,
         tags: post.metadata.tags.map( tag => tag.sys.id ),
-        date: post.fields.date ?? post.sys.createdAt,
+        date: resolvePostDate( post ),
         imageUrl: post.fields.image?.fields.file?.url ?? "",
       };
     }),

--- a/src/pages/tags/[tagId].tsx
+++ b/src/pages/tags/[tagId].tsx
@@ -1,6 +1,5 @@
 import { getTags } from "@/utils/contentfulUtils";
-import Home from "@/pages";
-import { getStaticProps as getStaticPropsBase } from "@/pages";
+import Home, { getStaticProps as getStaticPropsBase } from "@/pages";
 
 
 export const getStaticProps = getStaticPropsBase;

--- a/src/pages/tags/[tagId]/page/[page].tsx
+++ b/src/pages/tags/[tagId]/page/[page].tsx
@@ -1,5 +1,6 @@
 import { getBlogPosts, getTags } from "@/utils/contentfulUtils";
-import Home, { PAGE_SIZE } from "@/pages";
+import Home from "@/pages";
+import { PAGE_SIZE } from "@/constants";
 import { getStaticProps as getStaticPropsBase } from "@/pages";
 
 
@@ -15,7 +16,7 @@ export async function getStaticPaths() {
     const tagId = tag.sys.id;
     const filteredPosts = posts.items
       .filter( post => post.metadata.tags
-        .find( __tag => __tag.sys.id == tagId ) );
+        .find( postTag => postTag.sys.id === tagId ) );
     const numPages = Math.ceil( filteredPosts.length / PAGE_SIZE );
     for( let page = 2; page <= numPages; page++ ) {
       paths.push({

--- a/src/styles/Home.module.scss
+++ b/src/styles/Home.module.scss
@@ -51,7 +51,7 @@
   margin: .5rem;
 }
 
-.isTagged, a:hover > h3, nav a:hover {
+.isTagged, .isCurrentPage, a:hover > h3, nav a:hover {
   color: lightgreen!important;
   background: #555555!important;
 }

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -1,0 +1,5 @@
+import { VT323 } from "next/font/google";
+
+export const fontVT323 = VT323({
+  weight: "400",
+});

--- a/src/utils/blogPostUtils.ts
+++ b/src/utils/blogPostUtils.ts
@@ -2,21 +2,25 @@ import { Tag } from "contentful";
 import { BlogPost } from "./contentfulUtils";
 
 /**
- * Sort function for an array of TypeBlogPost
- * @param postA
- * @param postB
- * @returns number
+ * Returns the effective publish date for a blog post,
+ * falling back to the Contentful createdAt timestamp.
+ */
+export const resolvePostDate = ( post: BlogPost ): string =>
+  post.fields.date || post.sys.createdAt;
+
+/**
+ * Sort function for an array of TypeBlogPost (newest first)
  */
 export const sortBlogPostsByDate = (
   postA: BlogPost,
   postB: BlogPost,
 ): number => {
-  const dateA = new Date( postA.fields.date || postA.sys.createdAt );
-  const dateB = new Date( postB.fields.date || postB.sys.createdAt );
+  const dateA = new Date( resolvePostDate( postA ) );
+  const dateB = new Date( resolvePostDate( postB ) );
   return dateB.getTime() - dateA.getTime();
 };
 
 
-export const sortTagsByName = ( tagA: Tag, tagB: Tag ) => {
+export const sortTagsById = ( tagA: Tag, tagB: Tag ) => {
   return tagA.sys.id.localeCompare( tagB.sys.id );
 };

--- a/src/utils/contentfulUtils.ts
+++ b/src/utils/contentfulUtils.ts
@@ -29,6 +29,7 @@ export type Author = Entry<TypeAuthorSkeleton, "WITHOUT_UNRESOLVABLE_LINKS", str
 export const getBlogPosts = async (): Promise<BlogPosts> => {
   const response = await client.withoutUnresolvableLinks.getEntries<TypeBlogPostSkeleton>({
     content_type: CONTENT_TYPE_BLOG_POST,
+    limit: 1000,
   });
   return response;
 };
@@ -54,6 +55,7 @@ export const getTags = async (): Promise<TagCollection> => {
 export const getAuthors = async (): Promise<AuthorCollection> => {
   const response = await client.withoutUnresolvableLinks.getEntries<TypeAuthorSkeleton>({
     content_type: CONTENT_TYPE_AUTHOR,
+    limit: 1000,
   });
   return response;
 };

--- a/src/utils/spotify/getPlaylist.ts
+++ b/src/utils/spotify/getPlaylist.ts
@@ -38,7 +38,7 @@ interface SpotifyPlaylistTracks {
   limit: number
   next: string|null
   offset: number
-  previous: string
+  previous: string|null
   total: number
   items: SpotifyPlaylistTrackObject[]
 }
@@ -129,11 +129,11 @@ interface SpotifyUser {
 }
 
 
-export async function getPlaylist( playlist_id: string ) {
+export async function getPlaylist( playlistId: string ) {
   return getClientCredentials()
     .then( async response => {
       const { access_token } = response;
-      const url = `https://api.spotify.com/v1/playlists/${playlist_id}`;
+      const url = `https://api.spotify.com/v1/playlists/${playlistId}`;
       const headers = {
         "Accept": "application/json",
         "Authorization": `Bearer ${access_token}`,


### PR DESCRIPTION
## Summary

Full codebase review addressing 30+ findings across SOLID, DRY, cleanliness, and bug categories.

### HIGH severity (5 fixes)
- **Contentful 100-entry limit** — `getBlogPosts()` / `getAuthors()` now pass `limit: 1000` to prevent silent truncation once posts exceed 100
- **post/[slug] crash on missing content** — returns `{ notFound: true }` instead of `{ props: {} }` for invalid/deleted slugs
- **OldSchoolButton** — always returns a valid element; no more `undefined` return or `"undefined"` in DOM class string
- **SeoHead component** — replaces ~60 lines of copy-pasted `<Head>` meta tags across 4 pages

### MEDIUM severity (9 fixes)
- Atom feed per-entry dates (was using global `lastBuildDate` for all entries)
- `META_IMAGE` absolute URL for OG/Twitter crawlers
- `BlogPostList` no longer mutates props array in-place
- `generateSearchIndex` ensures `public/` dir exists before writing
- Playlist strict equality for image width comparison
- `SpotifyPlaylistTracks.previous` typed `string|null`
- Remove `"use client"` from Pages Router component
- Fix `CookieConsent` exhaustive-deps with `useCallback`
- `generateFeeds` only runs on actual index page, not every tag/paginated path

### DRY/SOLID (6 fixes)
- `resolvePostDate()` helper replaces 5 inline date fallbacks
- Shared `fontVT323` instance in `src/styles/fonts.ts`
- `Container`/`Wrapper` use correct prop types (interface segregation)
- `PAGE_SIZE` moved from page file to `constants.ts` (fixes inverted dependency)

### Cleanliness (10 fixes)
- `GoogleAnalyics` → `GoogleAnalytics` typo fix (file + export)
- `sortTagsByName` → `sortTagsById` (sorts by ID, not name)
- `playlist_id` → `playlistId` (camelCase)
- `<time>` gets `dateTime` attribute for semantics/SEO
- `isCurrentPage` CSS class for Pagination (was reusing `isTagged`)
- `__tag` → `postTag`, `==` → `===`
- `aria-label` on MediaFigure video
- Viewport/favicon moved to `_document.tsx`
- Merged double import in `tags/[tagId].tsx`
- Gallery uses `item.url` as React key instead of array index

### CLAUDE.md updates
- Added rule: enforce env vars with module-level `assert` pattern
- Added rule: never use TypeScript `as` type assertions

## Test plan
- [x] `yarn format` — 0 errors, 0 warnings
- [x] `yarn lint` — passes (typecheck + eslint)
- [x] `yarn test` — 81/81 tests pass
- [ ] `yarn build` — verify static export succeeds
- [ ] Spot-check pages: home, post, search, author, tag, paginated
- [ ] Verify RSS/Atom/JSON feeds generate correctly
- [ ] Verify OG meta tags render with absolute image URLs