### PR TITLE
feat: add make upload-images script for Contentful asset uploads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,15 @@ make upgrade         # yarn outdated + upgrade to latest minor/patch (~)
 make upgrade-latest  # yarn outdated + upgrade to latest including majors
 ```
 
+Contentful asset management (Makefile):
+
+```bash
+make upload-images DIR="/path/to/dir"         # Upload all images in a directory to Contentful
+make upload-images DIR="/path/to/image.jpg"   # Upload a single image to Contentful
+```
+
+Outputs a JSON array of `{ filename, assetId, url }` to stdout. Reads credentials from `.env` automatically. Always rename images to descriptive filenames before uploading (see Blog Post Workflow below).
+
 The build output goes to `dist/` (not `.next/`). Feeds (RSS/Atom/JSON) are generated at build time into `public/`.
 
 ## Code style

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 -include .env
 
+CONTENTFUL_ENVIRONMENT ?= master
+
 # Install dependencies
 install:
 	@yarn
@@ -61,6 +63,17 @@ upgrade-latest:
 # Verify package.json dependency integrity
 check:
 	@yarn check
+
+# Upload images from a local directory (or single file) to Contentful as published assets.
+# Outputs a JSON array of { filename, assetId, url } to stdout on success.
+# Usage: make upload-images DIR="/path/to/images"
+#        make upload-images DIR="/path/to/single-image.jpg"
+upload-images:
+	@node scripts/upload-images.mjs \
+		--dir "$(DIR)" \
+		--space-id $(CONTENTFUL_SPACE_ID) \
+		--environment-id $(CONTENTFUL_ENVIRONMENT) \
+		--token $(CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN)
 
 # TypeScript-only type check (no ESLint)
 typecheck:

--- a/docs/superpowers/plans/2026-04-11-pioneer-square-art-walk-blog-post.md
+++ b/docs/superpowers/plans/2026-04-11-pioneer-square-art-walk-blog-post.md
@@ -1,0 +1,332 @@
+# Pioneer Square Art Walk Blog Post — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create and publish the "First Thursday Art Walk at The North West Clothing — May 2013" blog post in Contentful, including a renamed gallery of 55 images and an inlined cover image in the body.
+
+**Architecture:** Pure content operation — no application code changes except a CLAUDE.md update. Images are renamed locally via shell, then uploaded to Contentful as assets via MCP tools. The blog post entry is created with all fields populated, reviewed, then published.
+
+**Tech Stack:** Contentful MCP tools, Bash (file rename), Contentful Management API (via MCP)
+
+---
+
+## Reference
+
+**Spec:** `docs/superpowers/specs/2026-04-11-blog-post-creation-workflow-design.md`
+
+**Contentful:**
+- Space ID: `pvyz1kbxgmyk`
+- Environment: `master`
+- Author entry ID: `3UiOelIV233YDeKGYplmIN`
+- Content type: `blogPost`
+
+**Local files:**
+- Cover image: `/Users/benny/Downloads/artwalk-flyer-may-2013.jpg`
+- Gallery folder: `/Users/benny/Downloads/ART WALK - MAY 2013/`
+
+---
+
+## Task 1: Rename gallery images
+
+**Files:**
+- Modify (in-place): all 55 files in `/Users/benny/Downloads/ART WALK - MAY 2013/`
+
+- [ ] **Step 1: Preview the rename mapping**
+
+Run this to verify the sort order and count before renaming:
+
+```bash
+ls "/Users/benny/Downloads/ART WALK - MAY 2013/" | sort | nl
+```
+
+Expected: 55 lines, starting with `2013-05-02 190640_12966233654_o.jpg`, then `IMG_0059.JPG` through `IMG_0203.JPG`.
+
+- [ ] **Step 2: Rename all files**
+
+```bash
+cd "/Users/benny/Downloads/ART WALK - MAY 2013"
+counter=1
+for filename in $(ls | sort); do
+  ext="${filename##*.}"
+  new_name="2013-05-02 Pioneer Square Art Walk at The North West Clothing in Seattle - Image ${counter}.${ext,,}"
+  mv "$filename" "$new_name"
+  counter=$((counter + 1))
+done
+```
+
+- [ ] **Step 3: Verify rename**
+
+```bash
+ls "/Users/benny/Downloads/ART WALK - MAY 2013/" | sort
+```
+
+Expected: 55 files named `2013-05-02 Pioneer Square Art Walk at The North West Clothing in Seattle - Image 1.jpg` through `Image 55.jpg`. All extensions should be lowercase `.jpg`.
+
+---
+
+## Task 2: Upload cover image to Contentful
+
+**Files:** None (Contentful asset operation)
+
+- [ ] **Step 1: Upload the cover image asset**
+
+Call `mcp__contentful__upload_asset` with:
+- `spaceId`: `pvyz1kbxgmyk`
+- `environmentId`: `master`
+- `filePath`: `/Users/benny/Downloads/artwalk-flyer-may-2013.jpg`
+- `title`: `Art Walk Flyer — May 2, 2013 at The North West Clothing, Pioneer Square, Seattle`
+- `description`: `Event flyer for the First Thursday Art Walk at The North West Clothing, 216 Alaskan Way South, Seattle — May 2, 2013`
+- `contentType`: `image/jpeg`
+
+- [ ] **Step 2: Record the asset ID and URL**
+
+From the response, capture:
+- Asset ID (e.g. `abc123`) — needed for the `image` field on the entry
+- Asset URL (e.g. `//images.ctfassets.net/pvyz1kbxgmyk/abc123/...`) — needed for the body markdown
+
+Write both values down before proceeding to Task 3.
+
+- [ ] **Step 3: Verify the asset is published**
+
+Confirm the asset was published (status: published) in the upload response. If not, call `mcp__contentful__publish_asset` with the asset ID.
+
+---
+
+## Task 3: Upload gallery images (55 images)
+
+**Files:** None (Contentful asset operations)
+
+> **Note:** Upload in batches of 5 to stay within Contentful MCP limits. Each batch follows the same pattern.
+
+- [ ] **Step 1: Upload Images 1–5**
+
+For each of the 5 images, call `mcp__contentful__upload_asset` with:
+- `spaceId`: `pvyz1kbxgmyk`
+- `environmentId`: `master`
+- `filePath`: `/Users/benny/Downloads/ART WALK - MAY 2013/2013-05-02 Pioneer Square Art Walk at The North West Clothing in Seattle - Image N.jpg`
+- `title`: `Pioneer Square Art Walk at The North West Clothing — May 2, 2013 — Image N`
+- `description`: `Photo from the First Thursday Art Walk at The North West Clothing, Pioneer Square, Seattle — May 2, 2013`
+- `contentType`: `image/jpeg`
+
+Replace `N` with the image number. Collect all 5 asset IDs.
+
+- [ ] **Step 2: Upload Images 6–10**
+
+Same as Step 1, for images 6–10. Collect asset IDs.
+
+- [ ] **Step 3: Upload Images 11–15**
+
+Same pattern. Collect asset IDs.
+
+- [ ] **Step 4: Upload Images 16–20**
+
+Same pattern. Collect asset IDs.
+
+- [ ] **Step 5: Upload Images 21–25**
+
+Same pattern. Collect asset IDs.
+
+- [ ] **Step 6: Upload Images 26–30**
+
+Same pattern. Collect asset IDs.
+
+- [ ] **Step 7: Upload Images 31–35**
+
+Same pattern. Collect asset IDs.
+
+- [ ] **Step 8: Upload Images 36–40**
+
+Same pattern. Collect asset IDs.
+
+- [ ] **Step 9: Upload Images 41–45**
+
+Same pattern. Collect asset IDs.
+
+- [ ] **Step 10: Upload Images 46–50**
+
+Same pattern. Collect asset IDs.
+
+- [ ] **Step 11: Upload Images 51–55**
+
+Same pattern. Collect asset IDs.
+
+- [ ] **Step 12: Verify all 55 asset IDs are collected**
+
+You should have exactly 55 asset IDs from the gallery uploads, plus 1 from the cover image in Task 2. Confirm the count before proceeding.
+
+---
+
+## Task 4: Create the blog post entry
+
+**Files:** None (Contentful entry operation)
+
+- [ ] **Step 1: Build the body with the inlined cover image URL**
+
+Take the cover image URL from Task 2 Step 2 and construct the full body:
+
+```
+First Thursday Art Walk came through Pioneer Square last night and The North West Clothing was the spot. OCNotes was on the decks, we had a Super Nintendo set up with a Street Fighter II tournament running all night, and the store was wall to wall.
+
+6PM to 10PM — music, new zip-ups, refreshments, and a crowd that showed up. Pioneer Square Art Walk does it every first Thursday and this one was no exception.
+
+![Art Walk Flyer — May 2, 2013 at The North West Clothing, Pioneer Square, Seattle](https:COVER_IMAGE_URL)
+
+Photos below.
+```
+
+Replace `COVER_IMAGE_URL` with the URL captured in Task 2 (prepend `https:` since Contentful URLs are protocol-relative).
+
+- [ ] **Step 2: Create the entry**
+
+Call `mcp__contentful__create_entry` with:
+- `spaceId`: `pvyz1kbxgmyk`
+- `environmentId`: `master`
+- `contentTypeId`: `blogPost`
+- `fields`:
+
+```json
+{
+  "title": { "en-US": "First Thursday Art Walk at The North West Clothing — May 2013" },
+  "slug": { "en-US": "art-walk-pioneer-square-north-west-clothing-may-2013" },
+  "description": { "en-US": "Recap of the First Thursday Art Walk at The North West Clothing in Pioneer Square, Seattle — DJ OCNotes on the decks, a Super Nintendo Street Fighter II tournament, and good vibes all night." },
+  "body": { "en-US": "<BODY FROM STEP 1>" },
+  "date": { "en-US": "2013-05-03" },
+  "image": {
+    "en-US": { "sys": { "type": "Link", "linkType": "Asset", "id": "<COVER_ASSET_ID>" } }
+  },
+  "gallery": {
+    "en-US": [
+      { "sys": { "type": "Link", "linkType": "Asset", "id": "<GALLERY_ASSET_ID_1>" } },
+      { "sys": { "type": "Link", "linkType": "Asset", "id": "<GALLERY_ASSET_ID_2>" } }
+      // ... all 55 gallery asset IDs
+    ]
+  },
+  "author": {
+    "en-US": { "sys": { "type": "Link", "linkType": "Entry", "id": "3UiOelIV233YDeKGYplmIN" } }
+  }
+}
+```
+
+- `metadata`:
+```json
+{
+  "tags": [
+    { "sys": { "type": "Link", "linkType": "Tag", "id": "dj" } },
+    { "sys": { "type": "Link", "linkType": "Tag", "id": "nightlife" } },
+    { "sys": { "type": "Link", "linkType": "Tag", "id": "merch" } }
+  ]
+}
+```
+
+- [ ] **Step 3: Record the new entry ID**
+
+Capture the entry ID from the create response. Needed for publishing in Task 6.
+
+---
+
+## Task 5: Review before publishing
+
+**Files:** None
+
+- [ ] **Step 1: Fetch the entry and present it for review**
+
+Call `mcp__contentful__get_entry` with the entry ID from Task 4 Step 3.
+
+Display the following for user review:
+- Title
+- Slug
+- Meta description
+- Date
+- Author
+- Tags
+- Full body text
+- Gallery image count (confirm 55 links)
+- Cover image asset ID
+
+- [ ] **Step 2: Wait for explicit user approval**
+
+Do NOT proceed to Task 6 until the user says to publish. If changes are requested, use `mcp__contentful__update_entry` to apply them, then re-display for review.
+
+---
+
+## Task 6: Publish the entry
+
+**Files:** None
+
+- [ ] **Step 1: Publish the entry**
+
+Call `mcp__contentful__publish_entry` with the entry ID from Task 4 Step 3.
+
+- [ ] **Step 2: Verify publication**
+
+Confirm the response shows `publishedVersion` is set. The post is now live.
+
+---
+
+## Task 7: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md` (project root)
+
+- [ ] **Step 1: Add blog post workflow section to CLAUDE.md**
+
+Add the following section to `CLAUDE.md` under the Architecture section:
+
+```markdown
+## Blog Post Creation Workflow
+
+To create a new blog post, follow the 10-step workflow documented in:
+`docs/superpowers/specs/2026-04-11-blog-post-creation-workflow-design.md`
+
+**Summary:**
+1. Gather: topic, date, tone, key details, author, cover image, gallery folder, tags
+2. Draft body content (iterate until approved)
+3. SEO checklist: slug, title, meta description, tags
+4. Rename gallery images: `YYYY-MM-DD [Event Name] - Image N.jpg` (alphabetical sort order)
+5. Upload cover image to Contentful → capture URL for body inline
+6. Build final body with inlined cover image markdown (`![alt](https://url)`) before "Photos below."
+7. Upload all gallery images in batches of 5
+8. Create `blogPost` entry in Contentful with all fields
+9. Review full entry with user — do NOT publish without explicit approval
+10. Publish via Contentful MCP
+
+**Rules:**
+- Never create new tags — only use existing tags (check with `mcp__contentful__list_tags`)
+- Always show proposed entry for approval before publishing
+- Gallery image filenames must be descriptive for SEO (never upload `IMG_XXXX.JPG` as-is)
+- Inline the cover image at the end of the body using markdown image syntax — the Markdown component renders standalone image paragraphs as `<MediaFigure>` automatically
+```
+
+- [ ] **Step 2: Run format check**
+
+```bash
+yarn lint
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add blog post creation workflow to CLAUDE.md"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✅ 10-step workflow → Tasks 1–7
+- ✅ Image rename format → Task 1
+- ✅ Cover image upload + URL capture → Task 2
+- ✅ Gallery batch upload (55 images) → Task 3
+- ✅ Inline cover image in body → Task 4 Step 1
+- ✅ Entry creation with all fields (title, slug, description, body, date, image, gallery, author, tags) → Task 4 Step 2
+- ✅ Review gate before publish → Task 5
+- ✅ Publish → Task 6
+- ✅ CLAUDE.md update → Task 7
+
+**Placeholder scan:** No TBD or TODO present. Asset ID and URL placeholders are marked clearly with `<ANGLE_BRACKET>` convention and explained in preceding steps.
+
+**Type consistency:** Field structure in Task 4 matches `TypeBlogPostFields` exactly (`title`, `slug`, `description`, `body`, `date`, `image`, `gallery`, `author`). Tag references use Contentful tag link format.

--- a/docs/superpowers/specs/2026-04-11-blog-post-creation-workflow-design.md
+++ b/docs/superpowers/specs/2026-04-11-blog-post-creation-workflow-design.md
@@ -1,0 +1,157 @@
+# Blog Post Creation Workflow — Design Spec
+**Date:** 2026-04-11
+**Status:** Approved
+
+---
+
+## Overview
+
+This spec covers two things:
+
+1. A reusable workflow for creating blog posts on audeos.com via Claude + Contentful MCP tools
+2. The specific implementation plan for the first post using this workflow: the May 2013 Pioneer Square Art Walk
+
+Content is managed in Contentful. Claude creates entries directly using the Contentful MCP tools — no manual steps in the Contentful UI are required.
+
+---
+
+## Reusable Blog Post Creation Workflow
+
+Every blog post follows these steps in order:
+
+### Step 1 — Gather content inputs
+Collect from the user:
+- Topic and key details (people, places, events worth mentioning)
+- Tone (casual/personal, editorial, etc.)
+- Post date (may differ from today if writing retroactively)
+- Author (verify against existing Contentful author entries)
+- Cover image file path (local)
+- Gallery image folder path (local), if any
+- Tags (must already exist in Contentful — do not create new tags)
+- Body content preference: draft it, or user provides existing text
+
+### Step 2 — Draft body content
+If drafting:
+- Write in the established tone
+- Keep it short and authentic — avoid AI-sounding filler phrases
+- Iterate with the user until approved
+
+### Step 3 — SEO checklist
+Before creating the entry, confirm:
+- [ ] Slug: lowercase, hyphenated, descriptive, includes key terms and year
+- [ ] Title: clear, includes event name and date
+- [ ] Meta description: under 155 characters, summarises the post accurately
+- [ ] Body word count: sufficient for the post type
+- [ ] Tags: appropriate existing tags selected (no new tags)
+
+### Step 4 — Rename gallery images
+If a gallery folder is provided, rename all images before uploading:
+- Format: `YYYY-MM-DD [Descriptive Event Name] - Image N.jpg`
+- Example: `2013-05-02 Pioneer Square Art Walk at The North West Clothing in Seattle - Image 1.jpg`
+- Numbering follows alphabetical sort order of original filenames
+- Use a shell loop to rename in-place; do not move files out of the folder
+
+### Step 5 — Upload cover image
+- Upload the cover image to Contentful as an asset
+- Capture the resulting Contentful asset ID and URL
+- If the cover image will also be inlined in the body (before the gallery), hold the URL for Step 6
+
+### Step 6 — Draft final body with inline image (if applicable)
+If the user wants the cover image inlined before the gallery:
+- Append `![Alt text](https://contentful-asset-url)` at the end of the body, before any "Photos below" line
+- The Markdown renderer converts standalone image paragraphs into `<MediaFigure>` components automatically
+
+### Step 7 — Upload gallery images
+- Upload all renamed gallery images to Contentful as assets
+- Collect all resulting asset IDs for the `gallery` field
+
+### Step 8 — Create the Contentful entry
+Create a `blogPost` entry with:
+| Field | Value |
+|---|---|
+| `title` | Post title (localized: `en-US`) |
+| `slug` | URL slug |
+| `description` | Meta description (localized: `en-US`) |
+| `body` | Markdown body text |
+| `date` | ISO date string (YYYY-MM-DD) |
+| `image` | Link to cover asset |
+| `gallery` | Array of links to gallery assets |
+| `author` | Link to author entry |
+| `metadata.tags` | Array of tag references |
+
+### Step 9 — Review before publish
+Present a full summary of the entry to the user for approval:
+- Title, slug, description, date, tags, author
+- Full body text
+- List of gallery image filenames
+
+**Do not publish until the user explicitly approves.**
+
+### Step 10 — Publish
+Publish the entry via Contentful MCP. Confirm success.
+
+---
+
+## Contentful Space Details
+
+| Key | Value |
+|---|---|
+| Space ID | `pvyz1kbxgmyk` |
+| Environment | `master` |
+| Author entry ID (Audeos) | `3UiOelIV233YDeKGYplmIN` |
+| Blog post content type | `blogPost` |
+
+### Available tags (as of 2026-04-11)
+`graphics`, `merch`, `plantlife`, `edits`, `records`, `radio`, `technology`, `playlists`, `dj`, `nightlife`
+
+---
+
+## First Post: Pioneer Square Art Walk — May 2013
+
+### Content
+
+**Title:** `First Thursday Art Walk at The North West Clothing — May 2013`
+
+**Slug:** `art-walk-pioneer-square-north-west-clothing-may-2013`
+
+**Meta description:** `Recap of the First Thursday Art Walk at The North West Clothing in Pioneer Square, Seattle — DJ OCNotes on the decks, a Super Nintendo Street Fighter II tournament, and the last night out before Japan.`
+
+**Date:** `2013-05-03`
+
+**Author:** Audeos (`3UiOelIV233YDeKGYplmIN`)
+
+**Tags:** `dj`, `nightlife`, `merch`
+
+**Body (approved):**
+```
+First Thursday Art Walk came through Pioneer Square last night and The North West Clothing was the spot. OCNotes was on the decks, we had a Super Nintendo set up with a Street Fighter II tournament running all night, and the store was wall to wall.
+
+6PM to 10PM — music, new zip-ups, refreshments, and a crowd that showed up. Pioneer Square Art Walk does it every first Thursday and this one was no exception.
+
+![Art Walk Flyer — May 2, 2013 at The North West Clothing, Pioneer Square, Seattle](COVER_IMAGE_URL)
+
+Photos below.
+```
+*(Replace `COVER_IMAGE_URL` with the Contentful asset URL after upload)*
+
+### Images
+
+**Cover image (local path):** `/Users/benny/Downloads/artwalk-flyer-may-2013.jpg`
+
+**Gallery folder (local path):** `/Users/benny/Downloads/ART WALK - MAY 2013/`
+
+**Gallery rename format:** `2013-05-02 Pioneer Square Art Walk at The North West Clothing in Seattle - Image N.jpg`
+
+**Total gallery images:** 55
+
+Rename order follows alphabetical sort of original filenames:
+1. `2013-05-02 190640_12966233654_o.jpg` → Image 1
+2. `IMG_0059.JPG` → Image 2
+3. `IMG_0060.JPG` → Image 3
+4. ... and so on through Image 55
+
+---
+
+## CLAUDE.md Update
+
+Add a "Blog Post Workflow" section to `CLAUDE.md` that references this spec and summarises the 10-step workflow. Future sessions should invoke this workflow whenever a new blog post is requested.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@vitest/coverage-v8": "^4.1.3",
     "cf-content-types-generator": "^3.0.1",
     "contentful-cli": "^3.10.4",
+    "contentful-management": "^12.3.0",
     "eslint": "^9",
     "eslint-config-next": "^16.2.1",
     "jsdom": "^29.0.1",

--- a/scripts/upload-images.mjs
+++ b/scripts/upload-images.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+/**
+ * Upload images from a local directory (or single file) to Contentful
+ * as published assets.
+ *
+ * Usage (via Makefile):
+ *   make upload-images DIR="/path/to/images"
+ *   make upload-images DIR="/path/to/single-image.jpg"
+ *
+ * Outputs a JSON array of { filename, assetId, url } to stdout.
+ * Progress messages go to stderr so stdout can be piped/redirected cleanly.
+ */
+
+import { createReadStream, readdirSync, statSync } from "fs";
+import { basename, extname, join } from "path";
+import contentfulManagement from "contentful-management";
+
+const LOCALE = "en-US";
+const PROCESS_POLL_INTERVAL_MS = 2000;
+const PROCESS_MAX_ATTEMPTS = 20;
+
+function parseArgs() {
+  const args = process.argv.slice( 2 );
+  const parsed = {};
+  for( let index = 0; index < args.length; index++ ) {
+    if( args[index] === "--dir" ) parsed.dir = args[++index];
+    else if( args[index] === "--space-id" ) parsed.spaceId = args[++index];
+    else if( args[index] === "--environment-id" ) parsed.environmentId = args[++index];
+    else if( args[index] === "--token" ) parsed.token = args[++index];
+  }
+  return parsed;
+}
+
+function getImageFiles( dirOrFile ) {
+  const stat = statSync( dirOrFile );
+  if( stat.isFile() ) return [ dirOrFile ];
+  return readdirSync( dirOrFile )
+    .filter( name => /\.(jpg|jpeg|png|gif|webp)$/i.test( name ) )
+    .sort()
+    .map( name => join( dirOrFile, name ) );
+}
+
+function mimeTypeForPath( filePath ) {
+  const extension = extname( filePath ).toLowerCase();
+  const mimeTypes = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+  };
+  return mimeTypes[extension] ?? "image/jpeg";
+}
+
+async function waitForProcessing( environment, assetId ) {
+  for( let attempt = 0; attempt < PROCESS_MAX_ATTEMPTS; attempt++ ) {
+    await new Promise( resolve => setTimeout( resolve, PROCESS_POLL_INTERVAL_MS ) );
+    const asset = await environment.getAsset( assetId );
+    if( asset.fields.file?.[LOCALE]?.url ) return asset;
+  }
+  throw new Error(
+    `Asset ${assetId} did not finish processing within ${( PROCESS_MAX_ATTEMPTS * PROCESS_POLL_INTERVAL_MS ) / 1000}s`,
+  );
+}
+
+async function uploadAndPublishImage( environment, filePath ) {
+  const filename = basename( filePath );
+  const title = basename( filePath, extname( filePath ) );
+
+  const upload = await environment.createUpload({ file: createReadStream( filePath ) });
+
+  const asset = await environment.createAsset({
+    fields: {
+      title: { [LOCALE]: title },
+      file: {
+        [LOCALE]: {
+          contentType: mimeTypeForPath( filePath ),
+          fileName: filename,
+          uploadFrom: { sys: { type: "Link", linkType: "Upload", id: upload.sys.id } },
+        },
+      },
+    },
+  });
+
+  await asset.processForLocale( LOCALE );
+  const processed = await waitForProcessing( environment, asset.sys.id );
+  const published = await processed.publish();
+
+  return {
+    filename,
+    assetId: published.sys.id,
+    url: `https:${published.fields.file[LOCALE].url}`,
+  };
+}
+
+async function main() {
+  const { dir, spaceId, environmentId, token } = parseArgs();
+
+  if( !dir || !spaceId || !environmentId || !token ) {
+    process.stderr.write(
+      "Usage: node scripts/upload-images.mjs --dir <path> --space-id <id> --environment-id <env> --token <token>\n",
+    );
+    process.exit( 1 );
+  }
+
+  const client = contentfulManagement.createClient({ accessToken: token });
+  const space = await client.getSpace( spaceId );
+  const environment = await space.getEnvironment( environmentId );
+
+  const filePaths = getImageFiles( dir );
+  process.stderr.write( `Uploading ${filePaths.length} image(s) from ${dir}...\n` );
+
+  const results = [];
+  for( const filePath of filePaths ) {
+    const filename = basename( filePath );
+    process.stderr.write( `  [${results.length + 1}/${filePaths.length}] ${filename}...\n` );
+    const result = await uploadAndPublishImage( environment, filePath );
+    process.stderr.write( `  ✓ ${result.assetId}\n` );
+    results.push( result );
+  }
+
+  process.stdout.write( JSON.stringify( results, null, 2 ) + "\n" );
+  process.stderr.write( `\nDone! ${results.length} asset(s) uploaded.\n` );
+}
+
+main().catch( error => {
+  process.stderr.write( `Error: ${error.message}\n` );
+  process.exit( 1 );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2426,7 +2426,7 @@ contentful-management@^11.39.0, contentful-management@^11.48.1, contentful-manag
     fast-copy "^3.0.0"
     globals "^15.15.0"
 
-contentful-management@^12.0.0:
+contentful-management@^12.0.0, contentful-management@^12.3.0:
   version "12.3.0"
   resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-12.3.0.tgz#c8ee716b6175a9995d1d6f17a78ea364456dce92"
   integrity sha512-5R66RFL8cWFhLeqU4QilgFBet5+6STNHW0loTtK8kZdVTlQ6v2SCMKGZKlk9LZZEVF6GXS8EVqRRoqqkoY5WNA==


### PR DESCRIPTION
## Summary

- Adds `scripts/upload-images.mjs` — a Node.js ES module script that uploads images from a local directory (or single file) to Contentful as published assets
- Adds `make upload-images DIR="..."` Makefile target that reads credentials from `.env` automatically
- Adds `contentful-management@^12.3.0` as a devDependency
- Documents the command in `CLAUDE.md`

## How it works

1. Reads all images from the given directory (sorted alphabetically) or a single file
2. For each image: creates a Contentful Upload (raw binary), creates an Asset referencing it, triggers `processForLocale`, polls until the CDN URL is available, then publishes
3. Outputs a JSON array of `{ filename, assetId, url }` to stdout — pipe it or redirect to capture asset IDs for use in blog post entries
4. Progress messages go to stderr so stdout stays clean

## Test plan

- [ ] Run `make upload-images DIR="/path/to/test-image.jpg"` and verify a published asset appears in Contentful
- [ ] Run with a directory and verify all images in it are uploaded
- [ ] Verify JSON output contains correct `filename`, `assetId`, and `url` fields