### PR TITLE
feat: rebuild upload-images script with v12 SDK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,15 @@ make upgrade         # yarn outdated + upgrade to latest minor/patch (~)
 make upgrade-latest  # yarn outdated + upgrade to latest including majors
 ```
 
+Contentful asset management (Makefile):
+
+```bash
+make upload-images DIR="/path/to/dir"         # Upload all images in a directory to Contentful
+make upload-images DIR="/path/to/image.jpg"   # Upload a single image to Contentful
+```
+
+Outputs a JSON array of `{ filename, assetId, url }` to stdout. Reads credentials from `.env` automatically. Always rename images to descriptive filenames before uploading.
+
 The build output goes to `dist/` (not `.next/`). Feeds (RSS/Atom/JSON) are generated at build time into `public/`.
 
 ## Code style

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,17 @@ types:
 		-o src/types/contentful
 	$(MAKE) format
 
+# Upload images from a local directory (or single file) to Contentful.
+# Outputs a JSON array of { filename, assetId, url } to stdout.
+# Usage:
+#   make upload-images DIR="/path/to/images"
+#   make upload-images DIR="/path/to/single-image.jpg"
+upload-images:
+	@export CONTENTFUL_SPACE_ID=$(CONTENTFUL_SPACE_ID) \
+		CONTENTFUL_ENVIRONMENT=$(CONTENTFUL_ENVIRONMENT) \
+		CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN=$(CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN); \
+		node scripts/upload-images.mjs "$(DIR)"
+
 # Run ESLint + TypeScript typecheck
 lint:
 	@yarn lint

--- a/docs/superpowers/plans/2026-04-13-upload-images.md
+++ b/docs/superpowers/plans/2026-04-13-upload-images.md
@@ -1,0 +1,649 @@
+# Upload Images to Contentful — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the `make upload-images` script to reliably upload local images to Contentful as published assets.
+
+**Architecture:** A single Node.js ES module script (`scripts/upload-images.mjs`) that reads image files, uploads each to Contentful via the Management API (buffer-based upload, not streams), processes and publishes them, and outputs JSON metadata. Invoked via a Makefile target that injects env vars from `.env`.
+
+**Tech Stack:** Node.js (ES modules), `contentful-management` SDK, Vitest for tests, Make for task runner.
+
+---
+
+### Task 1: Add `contentful-management` devDependency
+
+**Files:**
+- Modify: `package.json`
+- Modify: `yarn.lock`
+
+- [ ] **Step 1: Install the dependency**
+
+```bash
+yarn add --dev contentful-management
+```
+
+- [ ] **Step 2: Verify installation**
+
+```bash
+node -e "import('contentful-management').then(m => console.log('ok'))"
+```
+
+Expected: `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json yarn.lock
+git commit -m "chore: add contentful-management devDependency"
+```
+
+---
+
+### Task 2: Write and test the image file discovery utility
+
+**Files:**
+- Create: `scripts/upload-images.mjs`
+- Create: `scripts/upload-images.test.mjs`
+
+- [ ] **Step 1: Write the failing test for `getImageFiles`**
+
+Create `scripts/upload-images.test.mjs`:
+
+```javascript
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { getImageFiles } from "./upload-images.mjs";
+
+describe( "getImageFiles", () => {
+  let tempDir;
+
+  beforeEach( () => {
+    tempDir = mkdtempSync( join( tmpdir(), "upload-test-" ) );
+  });
+
+  afterEach( () => {
+    rmSync( tempDir, { recursive: true, force: true } );
+  });
+
+  it( "returns a single file when given a file path", () => {
+    const filePath = join( tempDir, "photo.jpg" );
+    writeFileSync( filePath, "fake image data" );
+
+    const result = getImageFiles( filePath );
+    expect( result ).toEqual( [ filePath ] );
+  });
+
+  it( "returns all supported image files from a directory, sorted alphabetically", () => {
+    const fileNames = [ "charlie.png", "alpha.jpg", "bravo.webp" ];
+    for( const name of fileNames ) {
+      writeFileSync( join( tempDir, name ), "fake" );
+    }
+
+    const result = getImageFiles( tempDir );
+    expect( result ).toEqual( [
+      join( tempDir, "alpha.jpg" ),
+      join( tempDir, "bravo.webp" ),
+      join( tempDir, "charlie.png" ),
+    ] );
+  });
+
+  it( "excludes non-image files from a directory", () => {
+    writeFileSync( join( tempDir, "readme.txt" ), "text" );
+    writeFileSync( join( tempDir, "photo.jpg" ), "image" );
+    writeFileSync( join( tempDir, "data.json" ), "{}" );
+
+    const result = getImageFiles( tempDir );
+    expect( result ).toEqual( [ join( tempDir, "photo.jpg" ) ] );
+  });
+
+  it( "supports all five image extensions", () => {
+    const extensions = [ ".jpg", ".jpeg", ".png", ".gif", ".webp" ];
+    for( const ext of extensions ) {
+      writeFileSync( join( tempDir, `image${ext}` ), "fake" );
+    }
+
+    const result = getImageFiles( tempDir );
+    expect( result ).toHaveLength( 5 );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+yarn vitest run scripts/upload-images.test.mjs
+```
+
+Expected: FAIL — `getImageFiles` is not exported / file doesn't exist.
+
+- [ ] **Step 3: Write the `getImageFiles` function**
+
+Create `scripts/upload-images.mjs`:
+
+```javascript
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync, statSync } from "fs";
+import { basename, extname, join } from "path";
+
+const SUPPORTED_EXTENSIONS = new Set( [ ".jpg", ".jpeg", ".png", ".gif", ".webp" ] );
+
+export function getImageFiles( dirOrFile ) {
+  const stat = statSync( dirOrFile );
+  if( stat.isFile() ) return [ dirOrFile ];
+
+  return readdirSync( dirOrFile )
+    .filter( ( name ) => SUPPORTED_EXTENSIONS.has( extname( name ).toLowerCase() ) )
+    .sort()
+    .map( ( name ) => join( dirOrFile, name ) );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+yarn vitest run scripts/upload-images.test.mjs
+```
+
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/upload-images.mjs scripts/upload-images.test.mjs
+git commit -m "feat: add getImageFiles utility for upload script"
+```
+
+---
+
+### Task 3: Write and test the MIME type utility
+
+**Files:**
+- Modify: `scripts/upload-images.mjs`
+- Modify: `scripts/upload-images.test.mjs`
+
+- [ ] **Step 1: Write the failing test for `mimeTypeForPath`**
+
+Add to `scripts/upload-images.test.mjs`:
+
+```javascript
+import { getImageFiles, mimeTypeForPath } from "./upload-images.mjs";
+
+describe( "mimeTypeForPath", () => {
+  it( "returns image/jpeg for .jpg", () => {
+    expect( mimeTypeForPath( "photo.jpg" ) ).toBe( "image/jpeg" );
+  });
+
+  it( "returns image/jpeg for .jpeg", () => {
+    expect( mimeTypeForPath( "photo.jpeg" ) ).toBe( "image/jpeg" );
+  });
+
+  it( "returns image/png for .png", () => {
+    expect( mimeTypeForPath( "photo.png" ) ).toBe( "image/png" );
+  });
+
+  it( "returns image/gif for .gif", () => {
+    expect( mimeTypeForPath( "photo.gif" ) ).toBe( "image/gif" );
+  });
+
+  it( "returns image/webp for .webp", () => {
+    expect( mimeTypeForPath( "photo.webp" ) ).toBe( "image/webp" );
+  });
+
+  it( "handles uppercase extensions", () => {
+    expect( mimeTypeForPath( "photo.PNG" ) ).toBe( "image/png" );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+yarn vitest run scripts/upload-images.test.mjs
+```
+
+Expected: FAIL — `mimeTypeForPath` is not exported.
+
+- [ ] **Step 3: Write `mimeTypeForPath`**
+
+Add to `scripts/upload-images.mjs`:
+
+```javascript
+const MIME_TYPES = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
+export function mimeTypeForPath( filePath ) {
+  const extension = extname( filePath ).toLowerCase();
+  return MIME_TYPES[extension];
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+yarn vitest run scripts/upload-images.test.mjs
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/upload-images.mjs scripts/upload-images.test.mjs
+git commit -m "feat: add mimeTypeForPath utility for upload script"
+```
+
+---
+
+### Task 4: Write and test the upload-and-publish function
+
+**Files:**
+- Modify: `scripts/upload-images.mjs`
+- Modify: `scripts/upload-images.test.mjs`
+
+- [ ] **Step 1: Write the failing test for `uploadAndPublishImage`**
+
+Add to `scripts/upload-images.test.mjs`:
+
+```javascript
+import { getImageFiles, mimeTypeForPath, uploadAndPublishImage } from "./upload-images.mjs";
+
+describe( "uploadAndPublishImage", () => {
+  it( "creates an upload, creates an asset, processes, polls, and publishes", async () => {
+    const mockPublishedAsset = {
+      sys: { id: "asset-123" },
+      fields: {
+        file: { "en-US": { url: "//images.ctfassets.net/space/asset-123/photo.jpg" } },
+      },
+    };
+
+    const mockProcessedAsset = {
+      sys: { id: "asset-123" },
+      fields: {
+        file: { "en-US": { url: "//images.ctfassets.net/space/asset-123/photo.jpg" } },
+      },
+      publish: vi.fn().mockResolvedValue( mockPublishedAsset ),
+    };
+
+    const mockUnprocessedAsset = {
+      sys: { id: "asset-123" },
+      fields: { file: { "en-US": {} } },
+    };
+
+    const mockEnvironment = {
+      createUpload: vi.fn().mockResolvedValue( { sys: { id: "upload-456" } } ),
+      createAsset: vi.fn().mockResolvedValue( {
+        sys: { id: "asset-123" },
+        processForAllLocales: vi.fn().mockResolvedValue( undefined ),
+      } ),
+      getAsset: vi.fn()
+        .mockResolvedValueOnce( mockUnprocessedAsset )
+        .mockResolvedValueOnce( mockProcessedAsset ),
+    };
+
+    const tempDir = mkdtempSync( join( tmpdir(), "upload-test-" ) );
+    const filePath = join( tempDir, "photo.jpg" );
+    writeFileSync( filePath, "fake image data" );
+
+    const result = await uploadAndPublishImage( mockEnvironment, filePath );
+
+    expect( mockEnvironment.createUpload ).toHaveBeenCalledOnce();
+    expect( mockEnvironment.createAsset ).toHaveBeenCalledWith( {
+      fields: {
+        title: { "en-US": "photo" },
+        file: {
+          "en-US": {
+            contentType: "image/jpeg",
+            fileName: "photo.jpg",
+            uploadFrom: {
+              sys: { type: "Link", linkType: "Upload", id: "upload-456" },
+            },
+          },
+        },
+      },
+    } );
+    expect( result ).toEqual( {
+      filename: "photo.jpg",
+      assetId: "asset-123",
+      url: "https://images.ctfassets.net/space/asset-123/photo.jpg",
+    } );
+
+    rmSync( tempDir, { recursive: true, force: true } );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+yarn vitest run scripts/upload-images.test.mjs
+```
+
+Expected: FAIL — `uploadAndPublishImage` is not exported.
+
+- [ ] **Step 3: Write `uploadAndPublishImage`**
+
+Add to `scripts/upload-images.mjs`:
+
+```javascript
+const LOCALE = "en-US";
+const POLL_MAX_WAIT_MS = 30_000;
+const POLL_INITIAL_INTERVAL_MS = 1_000;
+const POLL_MAX_INTERVAL_MS = 10_000;
+
+async function waitForProcessing( environment, assetId ) {
+  let elapsed = 0;
+  let interval = POLL_INITIAL_INTERVAL_MS;
+
+  while( elapsed < POLL_MAX_WAIT_MS ) {
+    await new Promise( ( resolve ) => setTimeout( resolve, interval ) );
+    elapsed += interval;
+
+    const asset = await environment.getAsset( assetId );
+    if( asset.fields.file?.[LOCALE]?.url ) return asset;
+
+    interval = Math.min( interval * 2, POLL_MAX_INTERVAL_MS );
+  }
+
+  throw new Error( `Asset ${assetId} did not finish processing within ${POLL_MAX_WAIT_MS / 1000}s` );
+}
+
+export async function uploadAndPublishImage( environment, filePath ) {
+  const filename = basename( filePath );
+  const title = basename( filePath, extname( filePath ) );
+  const buffer = readFileSync( filePath );
+
+  const upload = await environment.createUpload( { file: buffer } );
+
+  const asset = await environment.createAsset( {
+    fields: {
+      title: { [LOCALE]: title },
+      file: {
+        [LOCALE]: {
+          contentType: mimeTypeForPath( filePath ),
+          fileName: filename,
+          uploadFrom: {
+            sys: { type: "Link", linkType: "Upload", id: upload.sys.id },
+          },
+        },
+      },
+    },
+  } );
+
+  await asset.processForAllLocales();
+  const processed = await waitForProcessing( environment, asset.sys.id );
+  const published = await processed.publish();
+
+  return {
+    filename,
+    assetId: published.sys.id,
+    url: `https:${published.fields.file[LOCALE].url}`,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+yarn vitest run scripts/upload-images.test.mjs
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/upload-images.mjs scripts/upload-images.test.mjs
+git commit -m "feat: add uploadAndPublishImage with exponential backoff polling"
+```
+
+---
+
+### Task 5: Write and test the `main` function
+
+**Files:**
+- Modify: `scripts/upload-images.mjs`
+- Modify: `scripts/upload-images.test.mjs`
+
+- [ ] **Step 1: Write the failing test for `main`**
+
+Add to `scripts/upload-images.test.mjs`:
+
+```javascript
+import { main } from "./upload-images.mjs";
+
+describe( "main", () => {
+  it( "exits with code 1 when no directory argument is provided", async () => {
+    const mockExit = vi.spyOn( process, "exit" ).mockImplementation( () => {} );
+    const mockStderr = vi.spyOn( process.stderr, "write" ).mockImplementation( () => {} );
+
+    await main( [] );
+
+    expect( mockExit ).toHaveBeenCalledWith( 1 );
+    expect( mockStderr ).toHaveBeenCalledWith(
+      expect.stringContaining( "Usage:" ),
+    );
+
+    mockExit.mockRestore();
+    mockStderr.mockRestore();
+  });
+
+  it( "exits with code 1 when required env vars are missing", async () => {
+    const mockExit = vi.spyOn( process, "exit" ).mockImplementation( () => {} );
+    const mockStderr = vi.spyOn( process.stderr, "write" ).mockImplementation( () => {} );
+
+    const originalEnv = { ...process.env };
+    delete process.env.CONTENTFUL_SPACE_ID;
+    delete process.env.CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN;
+
+    await main( [ "/some/path" ] );
+
+    expect( mockExit ).toHaveBeenCalledWith( 1 );
+    expect( mockStderr ).toHaveBeenCalledWith(
+      expect.stringContaining( "CONTENTFUL_SPACE_ID" ),
+    );
+
+    process.env = originalEnv;
+    mockExit.mockRestore();
+    mockStderr.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+yarn vitest run scripts/upload-images.test.mjs
+```
+
+Expected: FAIL — `main` is not exported.
+
+- [ ] **Step 3: Write the `main` function**
+
+Add to `scripts/upload-images.mjs`:
+
+```javascript
+import contentfulManagement from "contentful-management";
+
+export async function main( args ) {
+  const dirOrFile = args[0];
+
+  if( !dirOrFile ) {
+    process.stderr.write( "Usage: node scripts/upload-images.mjs <path-to-images>\n" );
+    process.exit( 1 );
+    return;
+  }
+
+  const spaceId = process.env.CONTENTFUL_SPACE_ID;
+  const accessToken = process.env.CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN;
+  const environmentId = process.env.CONTENTFUL_ENVIRONMENT || "master";
+
+  if( !spaceId || !accessToken ) {
+    process.stderr.write(
+      "Missing required env vars: CONTENTFUL_SPACE_ID, CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN\n",
+    );
+    process.exit( 1 );
+    return;
+  }
+
+  const client = contentfulManagement.createClient( { accessToken } );
+  const space = await client.getSpace( spaceId );
+  const environment = await space.getEnvironment( environmentId );
+
+  const filePaths = getImageFiles( dirOrFile );
+  process.stderr.write( `Uploading ${filePaths.length} image(s) from ${dirOrFile}...\n` );
+
+  const results = [];
+  const failures = [];
+
+  for( const filePath of filePaths ) {
+    const filename = basename( filePath );
+    process.stderr.write( `  [${results.length + failures.length + 1}/${filePaths.length}] ${filename}...` );
+
+    try {
+      const result = await uploadAndPublishImage( environment, filePath );
+      process.stderr.write( ` done (${result.assetId})\n` );
+      results.push( result );
+    } catch( error ) {
+      process.stderr.write( ` FAILED: ${error.message}\n` );
+      failures.push( { filename, error: error.message } );
+    }
+  }
+
+  process.stdout.write( JSON.stringify( results, null, 2 ) + "\n" );
+
+  if( failures.length > 0 ) {
+    process.stderr.write( `\n${failures.length} upload(s) failed:\n` );
+    for( const failure of failures ) {
+      process.stderr.write( `  - ${failure.filename}: ${failure.error}\n` );
+    }
+  }
+
+  process.stderr.write( `\nDone: ${results.length} succeeded, ${failures.length} failed.\n` );
+  process.exit( failures.length > 0 ? 1 : 0 );
+}
+
+// Run when executed directly (not imported by tests)
+const isDirectRun = process.argv[1]?.endsWith( "upload-images.mjs" );
+if( isDirectRun ) {
+  main( process.argv.slice( 2 ) );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+yarn vitest run scripts/upload-images.test.mjs
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+yarn test
+```
+
+Expected: All tests PASS, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/upload-images.mjs scripts/upload-images.test.mjs
+git commit -m "feat: add main function with per-image error handling"
+```
+
+---
+
+### Task 6: Add Makefile target and update CLAUDE.md
+
+**Files:**
+- Modify: `Makefile`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add the `upload-images` target to the Makefile**
+
+Add after the `types` target in `Makefile`:
+
+```makefile
+# Upload images from a local directory (or single file) to Contentful.
+# Outputs a JSON array of { filename, assetId, url } to stdout.
+# Usage:
+#   make upload-images DIR="/path/to/images"
+#   make upload-images DIR="/path/to/single-image.jpg"
+upload-images:
+	@export CONTENTFUL_SPACE_ID=$(CONTENTFUL_SPACE_ID) \
+		CONTENTFUL_ENVIRONMENT=$(CONTENTFUL_ENVIRONMENT) \
+		CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN=$(CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN); \
+		node scripts/upload-images.mjs "$(DIR)"
+```
+
+- [ ] **Step 2: Update CLAUDE.md with upload-images documentation**
+
+Add after the "Dependency management (Makefile)" section in `CLAUDE.md`:
+
+```markdown
+Contentful asset management (Makefile):
+
+\`\`\`bash
+make upload-images DIR="/path/to/dir"         # Upload all images in a directory to Contentful
+make upload-images DIR="/path/to/image.jpg"   # Upload a single image to Contentful
+\`\`\`
+
+Outputs a JSON array of `{ filename, assetId, url }` to stdout. Reads credentials from `.env` automatically. Always rename images to descriptive filenames before uploading.
+```
+
+- [ ] **Step 3: Run lint to verify formatting**
+
+```bash
+yarn format
+```
+
+- [ ] **Step 4: Verify the Makefile target parses correctly**
+
+```bash
+make -n upload-images DIR="/tmp/test"
+```
+
+Expected: Prints the commands it would run, no syntax errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Makefile CLAUDE.md
+git commit -m "feat: add make upload-images target and docs"
+```
+
+---
+
+### Task 7: Manual integration test
+
+- [ ] **Step 1: Create a test image**
+
+```bash
+convert -size 100x100 xc:red /tmp/test-upload.jpg 2>/dev/null || \
+  printf '\xff\xd8\xff\xe0' > /tmp/test-upload.jpg
+```
+
+- [ ] **Step 2: Run the upload**
+
+```bash
+make upload-images DIR="/tmp/test-upload.jpg"
+```
+
+Expected: JSON output with `filename`, `assetId`, and `url` fields. Asset visible in Contentful.
+
+- [ ] **Step 3: Verify the asset in Contentful**
+
+Check that the asset is published and the URL resolves to an image.
+
+- [ ] **Step 4: Clean up test asset in Contentful**
+
+Delete the test asset from the Contentful UI.

--- a/docs/superpowers/specs/2026-04-13-upload-images-design.md
+++ b/docs/superpowers/specs/2026-04-13-upload-images-design.md
@@ -1,0 +1,66 @@
+# Upload Images to Contentful — Design Spec
+
+## Purpose
+
+A CLI script to upload local images to Contentful as published assets, invoked via `make upload-images DIR="..."`. Outputs structured JSON with asset metadata for use in blog post creation.
+
+## Interface
+
+```bash
+make upload-images DIR="/path/to/images"       # Upload all images in a directory
+make upload-images DIR="/path/to/image.jpg"    # Upload a single image
+```
+
+- Accepts a directory (uploads all supported images, sorted alphabetically) or a single file
+- Supported extensions: `.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`
+- **stdout**: JSON array of `{ filename, assetId, url }` for successful uploads
+- **stderr**: Progress messages and errors
+- **Exit code**: 0 if all images succeed, 1 if any fail
+
+## Upload Flow (per image)
+
+1. Read file into a `Buffer` using `readFileSync` (not a stream — more reliable with the Contentful upload API)
+2. Create upload via `environment.createUpload({ file: buffer })`
+3. Create asset linking to the upload, with title derived from the filename (minus extension)
+4. Process via `asset.processForAllLocales()`
+5. Poll for completion — check `asset.fields.file["en-US"].url` exists
+6. Publish the processed asset
+
+## Error Handling
+
+- **Per-image try/catch**: A failure on one image logs to stderr and continues with the rest. The final JSON output includes all successful uploads.
+- **Exponential backoff on processing poll**: Start at 1s, double each attempt, cap at 10s, max 30s total wait. If processing never completes, that image counts as a failure.
+- **SDK built-in retry**: `contentful-management` has `retryOnError: true` by default, handling 429 rate limits and 500 errors automatically.
+- **No partial cleanup**: If an asset is created but processing fails, it remains as a draft in Contentful. Simpler than cascading delete attempts.
+
+## Dependencies
+
+- Add `contentful-management` as a devDependency in `package.json`
+- No other new dependencies — env vars come from `.env` via the Makefile's existing `-include .env`
+
+## Makefile Target
+
+Uses `export` to pass env vars to the script, following the same pattern as the existing `types` target:
+
+```makefile
+upload-images:
+	@export CONTENTFUL_SPACE_ID=$(CONTENTFUL_SPACE_ID) \
+		CONTENTFUL_ENVIRONMENT=$(CONTENTFUL_ENVIRONMENT) \
+		CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN=$(CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN); \
+		node scripts/upload-images.mjs "$(DIR)"
+```
+
+The script receives the directory/file path as a positional argument (no `--dir` flag needed).
+
+## CLAUDE.md Update
+
+Re-add the `make upload-images` documentation under the "Contentful asset management" section in CLAUDE.md.
+
+## File Structure
+
+```
+scripts/upload-images.mjs    # The upload script (ES module)
+Makefile                     # New upload-images target
+CLAUDE.md                    # Updated docs
+package.json / yarn.lock     # contentful-management devDependency
+```

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@vitest/coverage-v8": "^4.1.3",
     "cf-content-types-generator": "^3.0.1",
     "contentful-cli": "^3.10.4",
+    "contentful-management": "^12.3.0",
     "eslint": "^9",
     "eslint-config-next": "^16.2.1",
     "jsdom": "^29.0.1",

--- a/scripts/upload-images.mjs
+++ b/scripts/upload-images.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { readdirSync, statSync } from "fs";
-import { extname, join } from "path";
+import { readdirSync, readFileSync, statSync } from "fs";
+import { basename, extname, join } from "path";
 
 const SUPPORTED_EXTENSIONS = new Set( [ ".jpg", ".jpeg", ".png", ".gif", ".webp" ] );
 
@@ -26,4 +26,59 @@ export function getImageFiles( dirOrFile ) {
 export function mimeTypeForPath( filePath ) {
   const extension = extname( filePath ).toLowerCase();
   return MIME_TYPES[extension];
+}
+
+const LOCALE = "en-US";
+const POLL_MAX_WAIT_MS = 30_000;
+const POLL_INITIAL_INTERVAL_MS = 1_000;
+const POLL_MAX_INTERVAL_MS = 10_000;
+
+async function waitForProcessing( environment, assetId ) {
+  let elapsed = 0;
+  let interval = POLL_INITIAL_INTERVAL_MS;
+
+  while( elapsed < POLL_MAX_WAIT_MS ) {
+    await new Promise( ( resolve ) => setTimeout( resolve, interval ) );
+    elapsed += interval;
+
+    const asset = await environment.getAsset( assetId );
+    if( asset.fields.file?.[LOCALE]?.url ) return asset;
+
+    interval = Math.min( interval * 2, POLL_MAX_INTERVAL_MS );
+  }
+
+  throw new Error( `Asset ${assetId} did not finish processing within ${POLL_MAX_WAIT_MS / 1000}s` );
+}
+
+export async function uploadAndPublishImage( environment, filePath ) {
+  const filename = basename( filePath );
+  const title = basename( filePath, extname( filePath ) );
+  const buffer = readFileSync( filePath );
+
+  const upload = await environment.createUpload( { file: buffer } );
+
+  const asset = await environment.createAsset( {
+    fields: {
+      title: { [LOCALE]: title },
+      file: {
+        [LOCALE]: {
+          contentType: mimeTypeForPath( filePath ),
+          fileName: filename,
+          uploadFrom: {
+            sys: { type: "Link", linkType: "Upload", id: upload.sys.id },
+          },
+        },
+      },
+    },
+  } );
+
+  await asset.processForAllLocales();
+  const processed = await waitForProcessing( environment, asset.sys.id );
+  const published = await processed.publish();
+
+  return {
+    filename,
+    assetId: published.sys.id,
+    url: `https:${published.fields.file[LOCALE].url}`,
+  };
 }

--- a/scripts/upload-images.mjs
+++ b/scripts/upload-images.mjs
@@ -3,7 +3,7 @@
 import { readdirSync, readFileSync, statSync } from "fs";
 import { basename, extname, join } from "path";
 import { fileURLToPath } from "url";
-import contentfulManagement from "contentful-management";
+import { createClient } from "contentful-management";
 
 const SUPPORTED_EXTENSIONS = new Set( [ ".jpg", ".jpeg", ".png", ".gif", ".webp" ] );
 
@@ -35,7 +35,7 @@ const POLL_MAX_WAIT_MS = 30_000;
 const POLL_INITIAL_INTERVAL_MS = 1_000;
 const POLL_MAX_INTERVAL_MS = 10_000;
 
-async function waitForProcessing( environment, assetId ) {
+async function waitForProcessing( client, assetId ) {
   let elapsed = 0;
   let interval = POLL_INITIAL_INTERVAL_MS;
 
@@ -43,7 +43,7 @@ async function waitForProcessing( environment, assetId ) {
     await new Promise( resolve => setTimeout( resolve, interval ) );
     elapsed += interval;
 
-    const asset = await environment.getAsset( assetId );
+    const asset = await client.asset.get({ assetId });
     if( asset.fields.file?.[LOCALE]?.url ) return asset;
 
     interval = Math.min( interval * 2, POLL_MAX_INTERVAL_MS );
@@ -52,31 +52,40 @@ async function waitForProcessing( environment, assetId ) {
   throw new Error( `Asset ${assetId} did not finish processing within ${POLL_MAX_WAIT_MS / 1000}s` );
 }
 
-export async function uploadAndPublishImage( environment, filePath ) {
+export async function uploadAndPublishImage( client, filePath ) {
   const filename = basename( filePath );
   const title = basename( filePath, extname( filePath ) );
   const buffer = readFileSync( filePath );
 
-  const upload = await environment.createUpload({ file: buffer });
+  const upload = await client.upload.create(
+    {},
+    { file: buffer },
+  );
 
-  const asset = await environment.createAsset({
-    fields: {
-      title: { [LOCALE]: title },
-      file: {
-        [LOCALE]: {
-          contentType: mimeTypeForPath( filePath ),
-          fileName: filename,
-          uploadFrom: {
-            sys: { type: "Link", linkType: "Upload", id: upload.sys.id },
+  const asset = await client.asset.create(
+    {},
+    {
+      fields: {
+        title: { [LOCALE]: title },
+        file: {
+          [LOCALE]: {
+            contentType: mimeTypeForPath( filePath ),
+            fileName: filename,
+            uploadFrom: {
+              sys: { type: "Link", linkType: "Upload", id: upload.sys.id },
+            },
           },
         },
       },
     },
-  });
+  );
 
-  await asset.processForAllLocales();
-  const processed = await waitForProcessing( environment, asset.sys.id );
-  const published = await processed.publish();
+  await client.asset.processForAllLocales({}, asset );
+  const processed = await waitForProcessing( client, asset.sys.id );
+  const published = await client.asset.publish(
+    { assetId: processed.sys.id },
+    processed,
+  );
 
   return {
     filename,
@@ -106,9 +115,13 @@ export async function main( args ) {
     return;
   }
 
-  const client = contentfulManagement.createClient({ accessToken });
-  const space = await client.getSpace( spaceId );
-  const environment = await space.getEnvironment( environmentId );
+  const client = createClient(
+    { accessToken },
+    {
+      type: "plain",
+      defaults: { spaceId, environmentId },
+    },
+  );
 
   const filePaths = getImageFiles( dirOrFile );
   process.stderr.write( `Uploading ${filePaths.length} image(s) from ${dirOrFile}...\n` );
@@ -121,7 +134,7 @@ export async function main( args ) {
     process.stderr.write( `  [${results.length + failures.length + 1}/${filePaths.length}] ${filename}...` );
 
     try {
-      const result = await uploadAndPublishImage( environment, filePath );
+      const result = await uploadAndPublishImage( client, filePath );
       process.stderr.write( ` done (${result.assetId})\n` );
       results.push( result );
     } catch ( error ) {

--- a/scripts/upload-images.mjs
+++ b/scripts/upload-images.mjs
@@ -5,6 +5,14 @@ import { extname, join } from "path";
 
 const SUPPORTED_EXTENSIONS = new Set( [ ".jpg", ".jpeg", ".png", ".gif", ".webp" ] );
 
+const MIME_TYPES = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
 export function getImageFiles( dirOrFile ) {
   const stat = statSync( dirOrFile );
   if( stat.isFile() ) return [ dirOrFile ];
@@ -13,4 +21,9 @@ export function getImageFiles( dirOrFile ) {
     .filter( ( name ) => SUPPORTED_EXTENSIONS.has( extname( name ).toLowerCase() ) )
     .sort()
     .map( ( name ) => join( dirOrFile, name ) );
+}
+
+export function mimeTypeForPath( filePath ) {
+  const extension = extname( filePath ).toLowerCase();
+  return MIME_TYPES[extension];
 }

--- a/scripts/upload-images.mjs
+++ b/scripts/upload-images.mjs
@@ -2,6 +2,7 @@
 
 import { readdirSync, readFileSync, statSync } from "fs";
 import { basename, extname, join } from "path";
+import contentfulManagement from "contentful-management";
 
 const SUPPORTED_EXTENSIONS = new Set( [ ".jpg", ".jpeg", ".png", ".gif", ".webp" ] );
 
@@ -81,4 +82,68 @@ export async function uploadAndPublishImage( environment, filePath ) {
     assetId: published.sys.id,
     url: `https:${published.fields.file[LOCALE].url}`,
   };
+}
+
+export async function main( args ) {
+  const dirOrFile = args[0];
+
+  if( !dirOrFile ) {
+    process.stderr.write( "Usage: node scripts/upload-images.mjs <path-to-images>\n" );
+    process.exit( 1 );
+    return;
+  }
+
+  const spaceId = process.env.CONTENTFUL_SPACE_ID;
+  const accessToken = process.env.CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN;
+  const environmentId = process.env.CONTENTFUL_ENVIRONMENT || "master";
+
+  if( !spaceId || !accessToken ) {
+    process.stderr.write(
+      "Missing required env vars: CONTENTFUL_SPACE_ID, CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN\n",
+    );
+    process.exit( 1 );
+    return;
+  }
+
+  const client = contentfulManagement.createClient( { accessToken } );
+  const space = await client.getSpace( spaceId );
+  const environment = await space.getEnvironment( environmentId );
+
+  const filePaths = getImageFiles( dirOrFile );
+  process.stderr.write( `Uploading ${filePaths.length} image(s) from ${dirOrFile}...\n` );
+
+  const results = [];
+  const failures = [];
+
+  for( const filePath of filePaths ) {
+    const filename = basename( filePath );
+    process.stderr.write( `  [${results.length + failures.length + 1}/${filePaths.length}] ${filename}...` );
+
+    try {
+      const result = await uploadAndPublishImage( environment, filePath );
+      process.stderr.write( ` done (${result.assetId})\n` );
+      results.push( result );
+    } catch( error ) {
+      process.stderr.write( ` FAILED: ${error.message}\n` );
+      failures.push( { filename, error: error.message } );
+    }
+  }
+
+  process.stdout.write( JSON.stringify( results, null, 2 ) + "\n" );
+
+  if( failures.length > 0 ) {
+    process.stderr.write( `\n${failures.length} upload(s) failed:\n` );
+    for( const failure of failures ) {
+      process.stderr.write( `  - ${failure.filename}: ${failure.error}\n` );
+    }
+  }
+
+  process.stderr.write( `\nDone: ${results.length} succeeded, ${failures.length} failed.\n` );
+  process.exit( failures.length > 0 ? 1 : 0 );
+}
+
+// Run when executed directly (not imported by tests)
+const isDirectRun = process.argv[1]?.endsWith( "upload-images.mjs" );
+if( isDirectRun ) {
+  main( process.argv.slice( 2 ) );
 }

--- a/scripts/upload-images.mjs
+++ b/scripts/upload-images.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+import { readdirSync, statSync } from "fs";
+import { extname, join } from "path";
+
+const SUPPORTED_EXTENSIONS = new Set( [ ".jpg", ".jpeg", ".png", ".gif", ".webp" ] );
+
+export function getImageFiles( dirOrFile ) {
+  const stat = statSync( dirOrFile );
+  if( stat.isFile() ) return [ dirOrFile ];
+
+  return readdirSync( dirOrFile )
+    .filter( ( name ) => SUPPORTED_EXTENSIONS.has( extname( name ).toLowerCase() ) )
+    .sort()
+    .map( ( name ) => join( dirOrFile, name ) );
+}

--- a/scripts/upload-images.mjs
+++ b/scripts/upload-images.mjs
@@ -2,6 +2,7 @@
 
 import { readdirSync, readFileSync, statSync } from "fs";
 import { basename, extname, join } from "path";
+import { fileURLToPath } from "url";
 import contentfulManagement from "contentful-management";
 
 const SUPPORTED_EXTENSIONS = new Set( [ ".jpg", ".jpeg", ".png", ".gif", ".webp" ] );
@@ -19,9 +20,9 @@ export function getImageFiles( dirOrFile ) {
   if( stat.isFile() ) return [ dirOrFile ];
 
   return readdirSync( dirOrFile )
-    .filter( ( name ) => SUPPORTED_EXTENSIONS.has( extname( name ).toLowerCase() ) )
+    .filter( name => SUPPORTED_EXTENSIONS.has( extname( name ).toLowerCase() ) )
     .sort()
-    .map( ( name ) => join( dirOrFile, name ) );
+    .map( name => join( dirOrFile, name ) );
 }
 
 export function mimeTypeForPath( filePath ) {
@@ -38,8 +39,8 @@ async function waitForProcessing( environment, assetId ) {
   let elapsed = 0;
   let interval = POLL_INITIAL_INTERVAL_MS;
 
-  while( elapsed < POLL_MAX_WAIT_MS ) {
-    await new Promise( ( resolve ) => setTimeout( resolve, interval ) );
+  while ( elapsed < POLL_MAX_WAIT_MS ) {
+    await new Promise( resolve => setTimeout( resolve, interval ) );
     elapsed += interval;
 
     const asset = await environment.getAsset( assetId );
@@ -56,9 +57,9 @@ export async function uploadAndPublishImage( environment, filePath ) {
   const title = basename( filePath, extname( filePath ) );
   const buffer = readFileSync( filePath );
 
-  const upload = await environment.createUpload( { file: buffer } );
+  const upload = await environment.createUpload({ file: buffer });
 
-  const asset = await environment.createAsset( {
+  const asset = await environment.createAsset({
     fields: {
       title: { [LOCALE]: title },
       file: {
@@ -71,7 +72,7 @@ export async function uploadAndPublishImage( environment, filePath ) {
         },
       },
     },
-  } );
+  });
 
   await asset.processForAllLocales();
   const processed = await waitForProcessing( environment, asset.sys.id );
@@ -95,17 +96,17 @@ export async function main( args ) {
 
   const spaceId = process.env.CONTENTFUL_SPACE_ID;
   const accessToken = process.env.CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN;
-  const environmentId = process.env.CONTENTFUL_ENVIRONMENT || "master";
+  const environmentId = process.env.CONTENTFUL_ENVIRONMENT;
 
-  if( !spaceId || !accessToken ) {
+  if( !spaceId || !accessToken || !environmentId ) {
     process.stderr.write(
-      "Missing required env vars: CONTENTFUL_SPACE_ID, CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN\n",
+      "Missing required env vars: CONTENTFUL_SPACE_ID, CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN, CONTENTFUL_ENVIRONMENT\n",
     );
     process.exit( 1 );
     return;
   }
 
-  const client = contentfulManagement.createClient( { accessToken } );
+  const client = contentfulManagement.createClient({ accessToken });
   const space = await client.getSpace( spaceId );
   const environment = await space.getEnvironment( environmentId );
 
@@ -123,9 +124,9 @@ export async function main( args ) {
       const result = await uploadAndPublishImage( environment, filePath );
       process.stderr.write( ` done (${result.assetId})\n` );
       results.push( result );
-    } catch( error ) {
+    } catch ( error ) {
       process.stderr.write( ` FAILED: ${error.message}\n` );
-      failures.push( { filename, error: error.message } );
+      failures.push({ filename, error: error.message });
     }
   }
 
@@ -143,7 +144,6 @@ export async function main( args ) {
 }
 
 // Run when executed directly (not imported by tests)
-const isDirectRun = process.argv[1]?.endsWith( "upload-images.mjs" );
-if( isDirectRun ) {
+if( process.argv[1] === fileURLToPath( import.meta.url ) ) {
   main( process.argv.slice( 2 ) );
 }

--- a/scripts/upload-images.test.mjs
+++ b/scripts/upload-images.test.mjs
@@ -96,57 +96,72 @@ describe( "uploadAndPublishImage", () => {
   });
 
   it( "creates an upload, creates an asset, processes, polls, and publishes", async () => {
-    const mockPublishedAsset = {
+    const createdAsset = {
       sys: { id: "asset-123" },
       fields: {
-        file: { "en-US": { url: "//images.ctfassets.net/space/asset-123/photo.jpg" } },
+        title: { "en-US": "photo" },
+        file: { "en-US": { contentType: "image/jpeg", fileName: "photo.jpg" } },
       },
     };
 
-    const mockProcessedAsset = {
-      sys: { id: "asset-123" },
-      fields: {
-        file: { "en-US": { url: "//images.ctfassets.net/space/asset-123/photo.jpg" } },
-      },
-      publish: vi.fn().mockResolvedValue( mockPublishedAsset ),
-    };
-
-    const mockUnprocessedAsset = {
+    const unprocessedAsset = {
       sys: { id: "asset-123" },
       fields: { file: { "en-US": {} } },
     };
 
-    const mockEnvironment = {
-      createUpload: vi.fn().mockResolvedValue({ sys: { id: "upload-456" } }),
-      createAsset: vi.fn().mockResolvedValue({
-        sys: { id: "asset-123" },
+    const processedAsset = {
+      sys: { id: "asset-123" },
+      fields: {
+        file: { "en-US": { url: "//images.ctfassets.net/space/asset-123/photo.jpg" } },
+      },
+    };
+
+    const publishedAsset = {
+      sys: { id: "asset-123" },
+      fields: {
+        file: { "en-US": { url: "//images.ctfassets.net/space/asset-123/photo.jpg" } },
+      },
+    };
+
+    const mockClient = {
+      upload: {
+        create: vi.fn().mockResolvedValue({ sys: { id: "upload-456" } }),
+      },
+      asset: {
+        create: vi.fn().mockResolvedValue( createdAsset ),
         processForAllLocales: vi.fn().mockResolvedValue( undefined ),
-      }),
-      getAsset: vi.fn()
-        .mockResolvedValueOnce( mockUnprocessedAsset )
-        .mockResolvedValueOnce( mockProcessedAsset ),
+        get: vi.fn()
+          .mockResolvedValueOnce( unprocessedAsset )
+          .mockResolvedValueOnce( processedAsset ),
+        publish: vi.fn().mockResolvedValue( publishedAsset ),
+      },
     };
 
     const filePath = join( tempDir, "photo.jpg" );
     writeFileSync( filePath, "fake image data" );
 
-    const result = await uploadAndPublishImage( mockEnvironment, filePath );
+    const result = await uploadAndPublishImage( mockClient, filePath );
 
-    expect( mockEnvironment.createUpload ).toHaveBeenCalledOnce();
-    expect( mockEnvironment.createAsset ).toHaveBeenCalledWith({
-      fields: {
-        title: { "en-US": "photo" },
-        file: {
-          "en-US": {
-            contentType: "image/jpeg",
-            fileName: "photo.jpg",
-            uploadFrom: {
-              sys: { type: "Link", linkType: "Upload", id: "upload-456" },
+    expect( mockClient.upload.create ).toHaveBeenCalledOnce();
+    expect( mockClient.asset.create ).toHaveBeenCalledWith(
+      {},
+      {
+        fields: {
+          title: { "en-US": "photo" },
+          file: {
+            "en-US": {
+              contentType: "image/jpeg",
+              fileName: "photo.jpg",
+              uploadFrom: {
+                sys: { type: "Link", linkType: "Upload", id: "upload-456" },
+              },
             },
           },
         },
       },
-    });
+    );
+    expect( mockClient.asset.processForAllLocales ).toHaveBeenCalledOnce();
+    expect( mockClient.asset.publish ).toHaveBeenCalledOnce();
     expect( result ).toEqual({
       filename: "photo.jpg",
       assetId: "asset-123",

--- a/scripts/upload-images.test.mjs
+++ b/scripts/upload-images.test.mjs
@@ -1,9 +1,9 @@
 // @vitest-environment node
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { getImageFiles, mimeTypeForPath } from "./upload-images.mjs";
+import { getImageFiles, mimeTypeForPath, uploadAndPublishImage } from "./upload-images.mjs";
 
 describe( "getImageFiles", () => {
   let tempDir;
@@ -81,5 +81,69 @@ describe( "mimeTypeForPath", () => {
 
   it( "handles uppercase extensions", () => {
     expect( mimeTypeForPath( "photo.PNG" ) ).toBe( "image/png" );
+  });
+});
+
+describe( "uploadAndPublishImage", () => {
+  it( "creates an upload, creates an asset, processes, polls, and publishes", async () => {
+    const mockPublishedAsset = {
+      sys: { id: "asset-123" },
+      fields: {
+        file: { "en-US": { url: "//images.ctfassets.net/space/asset-123/photo.jpg" } },
+      },
+    };
+
+    const mockProcessedAsset = {
+      sys: { id: "asset-123" },
+      fields: {
+        file: { "en-US": { url: "//images.ctfassets.net/space/asset-123/photo.jpg" } },
+      },
+      publish: vi.fn().mockResolvedValue( mockPublishedAsset ),
+    };
+
+    const mockUnprocessedAsset = {
+      sys: { id: "asset-123" },
+      fields: { file: { "en-US": {} } },
+    };
+
+    const mockEnvironment = {
+      createUpload: vi.fn().mockResolvedValue( { sys: { id: "upload-456" } } ),
+      createAsset: vi.fn().mockResolvedValue( {
+        sys: { id: "asset-123" },
+        processForAllLocales: vi.fn().mockResolvedValue( undefined ),
+      } ),
+      getAsset: vi.fn()
+        .mockResolvedValueOnce( mockUnprocessedAsset )
+        .mockResolvedValueOnce( mockProcessedAsset ),
+    };
+
+    const tempDir = mkdtempSync( join( tmpdir(), "upload-test-" ) );
+    const filePath = join( tempDir, "photo.jpg" );
+    writeFileSync( filePath, "fake image data" );
+
+    const result = await uploadAndPublishImage( mockEnvironment, filePath );
+
+    expect( mockEnvironment.createUpload ).toHaveBeenCalledOnce();
+    expect( mockEnvironment.createAsset ).toHaveBeenCalledWith( {
+      fields: {
+        title: { "en-US": "photo" },
+        file: {
+          "en-US": {
+            contentType: "image/jpeg",
+            fileName: "photo.jpg",
+            uploadFrom: {
+              sys: { type: "Link", linkType: "Upload", id: "upload-456" },
+            },
+          },
+        },
+      },
+    } );
+    expect( result ).toEqual( {
+      filename: "photo.jpg",
+      assetId: "asset-123",
+      url: "https://images.ctfassets.net/space/asset-123/photo.jpg",
+    } );
+
+    rmSync( tempDir, { recursive: true, force: true } );
   });
 });

--- a/scripts/upload-images.test.mjs
+++ b/scripts/upload-images.test.mjs
@@ -1,0 +1,59 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { getImageFiles } from "./upload-images.mjs";
+
+describe( "getImageFiles", () => {
+  let tempDir;
+
+  beforeEach( () => {
+    tempDir = mkdtempSync( join( tmpdir(), "upload-test-" ) );
+  });
+
+  afterEach( () => {
+    rmSync( tempDir, { recursive: true, force: true } );
+  });
+
+  it( "returns a single file when given a file path", () => {
+    const filePath = join( tempDir, "photo.jpg" );
+    writeFileSync( filePath, "fake image data" );
+
+    const result = getImageFiles( filePath );
+    expect( result ).toEqual( [ filePath ] );
+  });
+
+  it( "returns all supported image files from a directory, sorted alphabetically", () => {
+    const fileNames = [ "charlie.png", "alpha.jpg", "bravo.webp" ];
+    for( const name of fileNames ) {
+      writeFileSync( join( tempDir, name ), "fake" );
+    }
+
+    const result = getImageFiles( tempDir );
+    expect( result ).toEqual( [
+      join( tempDir, "alpha.jpg" ),
+      join( tempDir, "bravo.webp" ),
+      join( tempDir, "charlie.png" ),
+    ] );
+  });
+
+  it( "excludes non-image files from a directory", () => {
+    writeFileSync( join( tempDir, "readme.txt" ), "text" );
+    writeFileSync( join( tempDir, "photo.jpg" ), "image" );
+    writeFileSync( join( tempDir, "data.json" ), "{}" );
+
+    const result = getImageFiles( tempDir );
+    expect( result ).toEqual( [ join( tempDir, "photo.jpg" ) ] );
+  });
+
+  it( "supports all five image extensions", () => {
+    const extensions = [ ".jpg", ".jpeg", ".png", ".gif", ".webp" ];
+    for( const ext of extensions ) {
+      writeFileSync( join( tempDir, `image${ext}` ), "fake" );
+    }
+
+    const result = getImageFiles( tempDir );
+    expect( result ).toHaveLength( 5 );
+  });
+});

--- a/scripts/upload-images.test.mjs
+++ b/scripts/upload-images.test.mjs
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { getImageFiles } from "./upload-images.mjs";
+import { getImageFiles, mimeTypeForPath } from "./upload-images.mjs";
 
 describe( "getImageFiles", () => {
   let tempDir;
@@ -55,5 +55,31 @@ describe( "getImageFiles", () => {
 
     const result = getImageFiles( tempDir );
     expect( result ).toHaveLength( 5 );
+  });
+});
+
+describe( "mimeTypeForPath", () => {
+  it( "returns image/jpeg for .jpg", () => {
+    expect( mimeTypeForPath( "photo.jpg" ) ).toBe( "image/jpeg" );
+  });
+
+  it( "returns image/jpeg for .jpeg", () => {
+    expect( mimeTypeForPath( "photo.jpeg" ) ).toBe( "image/jpeg" );
+  });
+
+  it( "returns image/png for .png", () => {
+    expect( mimeTypeForPath( "photo.png" ) ).toBe( "image/png" );
+  });
+
+  it( "returns image/gif for .gif", () => {
+    expect( mimeTypeForPath( "photo.gif" ) ).toBe( "image/gif" );
+  });
+
+  it( "returns image/webp for .webp", () => {
+    expect( mimeTypeForPath( "photo.webp" ) ).toBe( "image/webp" );
+  });
+
+  it( "handles uppercase extensions", () => {
+    expect( mimeTypeForPath( "photo.PNG" ) ).toBe( "image/png" );
   });
 });

--- a/scripts/upload-images.test.mjs
+++ b/scripts/upload-images.test.mjs
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "fs";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { getImageFiles, mimeTypeForPath, uploadAndPublishImage, main } from "./upload-images.mjs";
@@ -13,7 +13,7 @@ describe( "getImageFiles", () => {
   });
 
   afterEach( () => {
-    rmSync( tempDir, { recursive: true, force: true } );
+    rmSync( tempDir, { recursive: true, force: true });
   });
 
   it( "returns a single file when given a file path", () => {
@@ -85,6 +85,16 @@ describe( "mimeTypeForPath", () => {
 });
 
 describe( "uploadAndPublishImage", () => {
+  let tempDir;
+
+  beforeEach( () => {
+    tempDir = mkdtempSync( join( tmpdir(), "upload-test-" ) );
+  });
+
+  afterEach( () => {
+    rmSync( tempDir, { recursive: true, force: true });
+  });
+
   it( "creates an upload, creates an asset, processes, polls, and publishes", async () => {
     const mockPublishedAsset = {
       sys: { id: "asset-123" },
@@ -107,24 +117,23 @@ describe( "uploadAndPublishImage", () => {
     };
 
     const mockEnvironment = {
-      createUpload: vi.fn().mockResolvedValue( { sys: { id: "upload-456" } } ),
-      createAsset: vi.fn().mockResolvedValue( {
+      createUpload: vi.fn().mockResolvedValue({ sys: { id: "upload-456" } }),
+      createAsset: vi.fn().mockResolvedValue({
         sys: { id: "asset-123" },
         processForAllLocales: vi.fn().mockResolvedValue( undefined ),
-      } ),
+      }),
       getAsset: vi.fn()
         .mockResolvedValueOnce( mockUnprocessedAsset )
         .mockResolvedValueOnce( mockProcessedAsset ),
     };
 
-    const tempDir = mkdtempSync( join( tmpdir(), "upload-test-" ) );
     const filePath = join( tempDir, "photo.jpg" );
     writeFileSync( filePath, "fake image data" );
 
     const result = await uploadAndPublishImage( mockEnvironment, filePath );
 
     expect( mockEnvironment.createUpload ).toHaveBeenCalledOnce();
-    expect( mockEnvironment.createAsset ).toHaveBeenCalledWith( {
+    expect( mockEnvironment.createAsset ).toHaveBeenCalledWith({
       fields: {
         title: { "en-US": "photo" },
         file: {
@@ -137,21 +146,19 @@ describe( "uploadAndPublishImage", () => {
           },
         },
       },
-    } );
-    expect( result ).toEqual( {
+    });
+    expect( result ).toEqual({
       filename: "photo.jpg",
       assetId: "asset-123",
       url: "https://images.ctfassets.net/space/asset-123/photo.jpg",
-    } );
-
-    rmSync( tempDir, { recursive: true, force: true } );
+    });
   });
 });
 
 describe( "main", () => {
   it( "exits with code 1 when no directory argument is provided", async () => {
-    const mockExit = vi.spyOn( process, "exit" ).mockImplementation( () => {} );
-    const mockStderr = vi.spyOn( process.stderr, "write" ).mockImplementation( () => {} );
+    const mockExit = vi.spyOn( process, "exit" ).mockImplementation( () => {});
+    const mockStderr = vi.spyOn( process.stderr, "write" ).mockImplementation( () => {});
 
     await main( [] );
 
@@ -165,12 +172,13 @@ describe( "main", () => {
   });
 
   it( "exits with code 1 when required env vars are missing", async () => {
-    const mockExit = vi.spyOn( process, "exit" ).mockImplementation( () => {} );
-    const mockStderr = vi.spyOn( process.stderr, "write" ).mockImplementation( () => {} );
+    const mockExit = vi.spyOn( process, "exit" ).mockImplementation( () => {});
+    const mockStderr = vi.spyOn( process.stderr, "write" ).mockImplementation( () => {});
 
     const originalEnv = { ...process.env };
     delete process.env.CONTENTFUL_SPACE_ID;
     delete process.env.CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN;
+    delete process.env.CONTENTFUL_ENVIRONMENT;
 
     await main( [ "/some/path" ] );
 

--- a/scripts/upload-images.test.mjs
+++ b/scripts/upload-images.test.mjs
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { getImageFiles, mimeTypeForPath, uploadAndPublishImage } from "./upload-images.mjs";
+import { getImageFiles, mimeTypeForPath, uploadAndPublishImage, main } from "./upload-images.mjs";
 
 describe( "getImageFiles", () => {
   let tempDir;
@@ -145,5 +145,42 @@ describe( "uploadAndPublishImage", () => {
     } );
 
     rmSync( tempDir, { recursive: true, force: true } );
+  });
+});
+
+describe( "main", () => {
+  it( "exits with code 1 when no directory argument is provided", async () => {
+    const mockExit = vi.spyOn( process, "exit" ).mockImplementation( () => {} );
+    const mockStderr = vi.spyOn( process.stderr, "write" ).mockImplementation( () => {} );
+
+    await main( [] );
+
+    expect( mockExit ).toHaveBeenCalledWith( 1 );
+    expect( mockStderr ).toHaveBeenCalledWith(
+      expect.stringContaining( "Usage:" ),
+    );
+
+    mockExit.mockRestore();
+    mockStderr.mockRestore();
+  });
+
+  it( "exits with code 1 when required env vars are missing", async () => {
+    const mockExit = vi.spyOn( process, "exit" ).mockImplementation( () => {} );
+    const mockStderr = vi.spyOn( process.stderr, "write" ).mockImplementation( () => {} );
+
+    const originalEnv = { ...process.env };
+    delete process.env.CONTENTFUL_SPACE_ID;
+    delete process.env.CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN;
+
+    await main( [ "/some/path" ] );
+
+    expect( mockExit ).toHaveBeenCalledWith( 1 );
+    expect( mockStderr ).toHaveBeenCalledWith(
+      expect.stringContaining( "CONTENTFUL_SPACE_ID" ),
+    );
+
+    process.env = originalEnv;
+    mockExit.mockRestore();
+    mockStderr.mockRestore();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2426,7 +2426,7 @@ contentful-management@^11.39.0, contentful-management@^11.48.1, contentful-manag
     fast-copy "^3.0.0"
     globals "^15.15.0"
 
-contentful-management@^12.0.0:
+contentful-management@^12.0.0, contentful-management@^12.3.0:
   version "12.3.0"
   resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-12.3.0.tgz#c8ee716b6175a9995d1d6f17a78ea364456dce92"
   integrity sha512-5R66RFL8cWFhLeqU4QilgFBet5+6STNHW0loTtK8kZdVTlQ6v2SCMKGZKlk9LZZEVF6GXS8EVqRRoqqkoY5WNA==


### PR DESCRIPTION
## Summary

- Rebuilds the `make upload-images` script from scratch using the `contentful-management` v12 plain client API
- Adds `scripts/upload-images.mjs` with buffer-based uploads, exponential backoff polling, and per-image error handling
- Adds 13 tests covering file discovery, MIME types, upload flow, and CLI validation
- Adds Makefile target and CLAUDE.md documentation

Key improvements over the reverted PR #50:
- Uses `readFileSync` (Buffer) instead of `createReadStream` for more reliable uploads
- Uses the modern plain client API (`client.asset.create()`) instead of the deprecated chained API (`space.getEnvironment().createAsset()`)
- Per-image error handling — one failure doesn't abort the batch
- Exponential backoff polling (1s → 2s → 4s → ..., capped at 10s, 30s max)
- Strict env var validation (no fallback defaults)

## Test plan

- [x] All 13 unit tests pass (`yarn vitest run scripts/upload-images.test.mjs`)
- [x] Full test suite passes (94 tests across 9 files)
- [x] Manual integration test: uploaded `artwalk-flyer-may-2013.jpg` to Contentful successfully
- [x] Verified asset appeared published in Contentful with correct URL
- [x] Cleaned up test asset