### PR TITLE
Optimize image delivery and add describe-assets skill

### DIFF
--- a/.claude/skills/describe-assets/SKILL.md
+++ b/.claude/skills/describe-assets/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: describe-assets
+description: Add SEO-friendly descriptions to Contentful media assets that are missing them. Picks random assets, shows the image, suggests a description, and lets the user refine before saving.
+disable-model-invocation: true
+argument-hint: [count]
+---
+
+# Describe Media Assets
+
+Help the user add descriptions to Contentful media assets that are missing them. This improves SEO (alt text) and accessibility.
+
+## Setup
+
+- Space ID: `pvyz1kbxgmyk`
+- Environment: `master`
+- Locale: `en-US`
+
+## Workflow
+
+### 1. Determine batch size
+
+- If `$ARGUMENTS` contains a number, use that as the batch size (how many assets to describe in this session)
+- If `$ARGUMENTS` is empty, default to **1**
+
+### 2. Find an asset missing a description
+
+Use `mcp__contentful__list_assets` to find assets without descriptions. The tool returns a max of 3 assets per call.
+
+**Strategy for random selection:**
+
+1. First call `mcp__contentful__list_assets` with `limit: 1` to get the `total` count of assets
+2. Generate a random `skip` value between 0 and total - 1
+3. Call `mcp__contentful__list_assets` with `skip: <random>`, `limit: 3`
+4. Check if any returned asset has an empty description
+5. If all have descriptions, try another random skip value
+6. After 10 failed attempts, report that most assets appear to have descriptions already
+
+### 3. Show the asset to the user
+
+For each asset missing a description:
+
+1. **Display the image** — use the `Read` tool on the image URL (`https:<url>`) so Claude can see the image content. Also show the URL so the user can view it.
+2. **Show metadata:**
+   - Title (filename)
+   - Asset ID
+   - Contentful URL: `https://app.contentful.com/spaces/pvyz1kbxgmyk/assets/<assetId>`
+3. **Suggest a description** — based on what you see in the image, draft an SEO-friendly alt text description (1-2 sentences, 80-160 characters). Consider:
+   - What is depicted (people, objects, setting)
+   - The context from the filename/title (event names, locations, dates)
+   - Keep it descriptive and specific, not generic
+4. **Ask the user to approve, edit, or provide their own description** — the user has context you don't (names, event details, inside knowledge)
+
+### 4. Update the asset
+
+Once the user approves a description, update the asset using `mcp__contentful__update_asset`:
+
+```json
+{
+  "assetId": "<assetId>",
+  "fields": {
+    "description": {
+      "en-US": "<approved description>"
+    }
+  }
+}
+```
+
+Then publish the updated asset using `mcp__contentful__publish_asset`.
+
+### 5. Loop or finish
+
+- Show a running count: "Done: 3/5 assets described"
+- If batch size is not reached, go back to step 2 for the next random asset
+- After completing the batch, report:
+  - How many assets were described
+  - How many total assets still need descriptions (if known)
+
+## Important Rules
+
+- **Always show the image and suggested description before updating** — never update without user approval
+- **Use context from the filename** — filenames are descriptive and contain event names, dates, and locations
+- **Keep descriptions concise** — 1-2 sentences, optimized for alt text / SEO
+- **Publish after updating** — always publish the asset after updating the description so changes go live
+- **Don't skip assets** — if the user says "skip" or "next", move to the next random asset without updating, but still count it toward the batch for UX purposes

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,6 +1,7 @@
 import { FC, useState, useCallback, useEffect, useRef } from "react";
 import Image from "next/image";
 import { Asset } from "contentful";
+import { CONTENT_IMAGE_WIDTH } from "@/constants";
 import styles from "@/styles/Gallery.module.scss";
 
 export interface GalleryItem {
@@ -14,7 +15,6 @@ interface GalleryProps {
   items: GalleryItem[];
 }
 
-const GALLERY_IMAGE_WIDTH = 1200;
 
 function assetToGalleryItem(
   asset: Asset<"WITHOUT_UNRESOLVABLE_LINKS", string>,
@@ -25,7 +25,7 @@ function assetToGalleryItem(
   const isVideo = mimeType.startsWith( "video/" );
   const url = isVideo
     ? `https:${file.url}`
-    : `https:${file.url}?w=${GALLERY_IMAGE_WIDTH}`;
+    : `https:${file.url}?w=${CONTENT_IMAGE_WIDTH}&fm=webp&q=80`;
   return {
     url,
     description: asset.fields.description || "",

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -1,3 +1,4 @@
+import { CONTENT_IMAGE_WIDTH } from "@/constants";
 
 export interface PictureProps {
   url: string;
@@ -9,7 +10,7 @@ export interface PictureProps {
 
 export default function Picture({
   url,
-  maxWidth = 750,
+  maxWidth = CONTENT_IMAGE_WIDTH,
   maxHeight,
   alt,
   breakpoints = [ 749, 600, 350 ],
@@ -60,7 +61,7 @@ const getImgSrc = ( src: string, {
   const imageUrl = new URL( `https:${src}` );
 
   // Set "quality"
-  imageUrl.searchParams.set( "q", "100" );
+  imageUrl.searchParams.set( "q", "80" );
 
   // Set "format"
   if( format ) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,3 +8,4 @@ export const GOOGLE_ANALYTICS_ID = "G-D81YP4DGH3";
 export const COOKIE_CONSENT_KEY = "cookie-consent";
 export const POSTS_ANCHOR = "posts";
 export const PAGE_SIZE = 12;
+export const CONTENT_IMAGE_WIDTH = 750;

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 
 import { BlogPost, getBlogPost, getBlogPosts } from "@/utils/contentfulUtils";
 import { resolvePostDate, sortBlogPostsByDate } from "@/utils/blogPostUtils";
-import { SITE_URL } from "@/constants";
+import { SITE_URL, CONTENT_IMAGE_WIDTH } from "@/constants";
 import { SeoHead } from "@/components/SeoHead";
 import styles from "@/styles/BlogPost.module.scss";
 import DateTimeFormat from "@/components/DateTimeFormat";
@@ -17,7 +17,6 @@ import Playlist from "@/components/Playlist";
 import Gallery, { resolveGalleryItems } from "@/components/Gallery";
 
 
-const IMAGE_SIZE = 750;
 
 
 export interface PostNavLink {
@@ -35,7 +34,7 @@ export interface BlogPostViewProps {
 
 export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, prevPost, nextPost }) => {
   const metaTitle = `${post.fields.title} | Audeos.com`;
-  const metaImage = `https:${post.fields.image?.fields.file?.url}?w=${IMAGE_SIZE}`;
+  const metaImage = `https:${post.fields.image?.fields.file?.url}?w=${CONTENT_IMAGE_WIDTH}`;
   const metaImageDesc = post.fields.image?.fields.description || "";
   const authorImageUrl = post.fields.author?.fields.image?.fields.file?.url;
   const authorProfileImageSrc = authorImageUrl ? `https:${authorImageUrl}?w=50` : null;

--- a/src/styles/Layout.module.scss
+++ b/src/styles/Layout.module.scss
@@ -9,6 +9,7 @@ div.container {
     padding: 1rem;
 }
 
+// Keep in sync with CONTENT_IMAGE_WIDTH in src/constants.ts
 section.wrapper {
     width: 750px;
     max-width: 100%;


### PR DESCRIPTION
## Summary
- Lower image quality from 100 to 80 in `Picture.tsx` — visually identical, significantly smaller files
- Serve gallery images as WebP (`fm=webp&q=80`) instead of original format
- Reduce gallery image width from 1200px to 750px to match content container
- Extract shared `CONTENT_IMAGE_WIDTH` constant used by Picture, Gallery, and post pages
- Add `/describe-assets` skill for batch-adding SEO alt text to Contentful media assets

## Test plan
- [x] `yarn format` passes
- [x] `yarn test` passes (94/94)
- [ ] Verify images render correctly on blog posts
- [ ] Confirm gallery images load faster with reduced size