### PR TITLE
feat: add SoundCloud embed support to blog posts

### DIFF
--- a/.claude/skills/new-post/SKILL.md
+++ b/.claude/skills/new-post/SKILL.md
@@ -63,6 +63,7 @@ Collect or derive all required fields. Show each to the user for approval:
 | **gallery** | Array of asset links from gallery upload (if any) |
 | **tags** | Fetch existing tags via `mcp__contentful__list_tags`. Suggest relevant ones. Never suggest creating new tags. |
 | **spotifyPlaylistId** | Ask if they want to embed a Spotify playlist (yes/no). Skip if no. |
+| **soundcloudUrl** | Ask if they want to embed a SoundCloud track or playlist (yes/no). If yes, collect the full SoundCloud URL. Skip if no. |
 | **location** | Ask if they want to add a location (yes/no). Skip if no. |
 
 ## SEO Check
@@ -143,7 +144,8 @@ Use `mcp__contentful__create_entry` with:
     "author": { "en-US": { "sys": { "type": "Link", "linkType": "Entry", "id": "<authorId>" } } },
     "image": { "en-US": { "sys": { "type": "Link", "linkType": "Asset", "id": "<imageAssetId>" } } },
     "gallery": { "en-US": [{ "sys": { "type": "Link", "linkType": "Asset", "id": "<assetId>" } }] },
-    "spotifyPlaylistId": { "en-US": "<playlistId>" }
+    "spotifyPlaylistId": { "en-US": "<playlistId>" },
+    "soundcloudUrl": { "en-US": "<soundcloudUrl>" }
   },
   "metadata": {
     "tags": [{ "sys": { "type": "Link", "linkType": "Tag", "id": "<tagId>" } }]
@@ -151,7 +153,7 @@ Use `mcp__contentful__create_entry` with:
 }
 ```
 
-Omit optional fields that were not provided (gallery, spotifyPlaylistId, location). Tags go in `metadata`, not `fields`.
+Omit optional fields that were not provided (gallery, spotifyPlaylistId, soundcloudUrl, location). Tags go in `metadata`, not `fields`.
 
 If the user chose **publish immediately**, follow up with `mcp__contentful__publish_entry`.
 

--- a/docs/superpowers/plans/2026-04-14-soundcloud-embed.md
+++ b/docs/superpowers/plans/2026-04-14-soundcloud-embed.md
@@ -1,0 +1,574 @@
+# SoundCloud Embed Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add optional SoundCloud track/playlist embedding to blog posts using SoundCloud's oEmbed API.
+
+**Architecture:** A new `soundcloudUrl` Contentful field triggers a build-time oEmbed fetch in `getStaticProps`. The oEmbed response is passed to a `<SoundCloudEmbed>` component that renders a sanitized iframe. The new-post skill is updated to collect the URL.
+
+**Tech Stack:** Next.js, Contentful, SoundCloud oEmbed API, Vitest, React Testing Library
+
+---
+
+### Task 1: SoundCloud oEmbed Utility
+
+**Files:**
+- Create: `src/utils/soundcloud/getOembed.ts`
+- Create: `src/utils/soundcloud/getOembed.test.ts`
+
+- [ ] **Step 1: Write the failing test for successful oEmbed fetch**
+
+Create `src/utils/soundcloud/getOembed.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal( "fetch", mockFetch );
+
+import { getOembed, SoundCloudOembed } from "./getOembed";
+
+const SOUNDCLOUD_TRACK_URL = "https://soundcloud.com/artist/track-name";
+
+const MOCK_OEMBED_RESPONSE: SoundCloudOembed = {
+  title: "Test Track",
+  author_name: "Test Artist",
+  author_url: "https://soundcloud.com/artist",
+  html: '<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/123"></iframe>',
+  thumbnail_url: "https://i1.sndcdn.com/artworks-000-t500x500.jpg",
+};
+
+describe( "getOembed", () => {
+  beforeEach( () => {
+    vi.resetAllMocks();
+  });
+
+  it( "fetches oEmbed data for a valid SoundCloud URL", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve( MOCK_OEMBED_RESPONSE ),
+    });
+
+    const result = await getOembed( SOUNDCLOUD_TRACK_URL );
+
+    expect( mockFetch ).toHaveBeenCalledWith(
+      `https://soundcloud.com/oembed?format=json&url=${encodeURIComponent( SOUNDCLOUD_TRACK_URL )}`,
+    );
+    expect( result ).toEqual( MOCK_OEMBED_RESPONSE );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test src/utils/soundcloud/getOembed.test.ts`
+Expected: FAIL — module `./getOembed` does not exist
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/utils/soundcloud/getOembed.ts`:
+
+```typescript
+export interface SoundCloudOembed {
+  title: string;
+  author_name: string;
+  author_url: string;
+  html: string;
+  thumbnail_url: string;
+}
+
+const OEMBED_ENDPOINT = "https://soundcloud.com/oembed";
+
+export async function getOembed( soundcloudUrl: string ): Promise<SoundCloudOembed | null> {
+  const url = `${OEMBED_ENDPOINT}?format=json&url=${encodeURIComponent( soundcloudUrl )}`;
+  const response = await fetch( url );
+
+  if ( !response.ok ) {
+    return null;
+  }
+
+  const data: SoundCloudOembed = await response.json();
+  return data;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn test src/utils/soundcloud/getOembed.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Write the failing test for fetch failure**
+
+Add to the existing `describe` block in `src/utils/soundcloud/getOembed.test.ts`:
+
+```typescript
+  it( "returns null when the fetch fails", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const result = await getOembed( SOUNDCLOUD_TRACK_URL );
+
+    expect( result ).toBeNull();
+  });
+
+  it( "returns null when fetch throws a network error", async () => {
+    mockFetch.mockRejectedValueOnce( new Error( "Network error" ) );
+
+    const result = await getOembed( SOUNDCLOUD_TRACK_URL );
+
+    expect( result ).toBeNull();
+  });
+```
+
+- [ ] **Step 6: Run tests to check which fail**
+
+Run: `yarn test src/utils/soundcloud/getOembed.test.ts`
+Expected: The "returns null when fetch fails" test should PASS (already handled by `!response.ok`). The "network error" test should FAIL — unhandled rejection.
+
+- [ ] **Step 7: Add try/catch for network errors**
+
+Update `getOembed` in `src/utils/soundcloud/getOembed.ts` to wrap the fetch in a try/catch:
+
+```typescript
+export async function getOembed( soundcloudUrl: string ): Promise<SoundCloudOembed | null> {
+  const url = `${OEMBED_ENDPOINT}?format=json&url=${encodeURIComponent( soundcloudUrl )}`;
+
+  try {
+    const response = await fetch( url );
+
+    if ( !response.ok ) {
+      return null;
+    }
+
+    const data: SoundCloudOembed = await response.json();
+    return data;
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 8: Run all tests to verify they pass**
+
+Run: `yarn test src/utils/soundcloud/getOembed.test.ts`
+Expected: All 3 tests PASS
+
+- [ ] **Step 9: Run format and full test suite**
+
+Run: `yarn format && yarn test`
+Expected: All pass
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/utils/soundcloud/getOembed.ts src/utils/soundcloud/getOembed.test.ts
+git commit -m "feat: add SoundCloud oEmbed fetch utility"
+```
+
+---
+
+### Task 2: SoundCloudEmbed Component
+
+**Files:**
+- Create: `src/components/SoundCloudEmbed.tsx`
+- Create: `src/styles/SoundCloudEmbed.module.scss`
+- Create: `src/__tests__/components/SoundCloudEmbed.test.tsx`
+
+- [ ] **Step 1: Write the failing test for the component**
+
+Create `src/__tests__/components/SoundCloudEmbed.test.tsx`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { SoundCloudEmbed } from "@/components/SoundCloudEmbed";
+import { SoundCloudOembed } from "@/utils/soundcloud/getOembed";
+
+const MOCK_OEMBED: SoundCloudOembed = {
+  title: "Test Track",
+  author_name: "Test Artist",
+  author_url: "https://soundcloud.com/test-artist",
+  html: '<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/123"></iframe>',
+  thumbnail_url: "https://i1.sndcdn.com/artworks-000-t500x500.jpg",
+};
+
+describe( "SoundCloudEmbed", () => {
+  it( "renders an iframe with the src extracted from oEmbed html", () => {
+    render( <SoundCloudEmbed oembed={ MOCK_OEMBED } /> );
+
+    const iframe = screen.getByTitle( "Test Track by Test Artist" );
+    expect( iframe ).toBeInTheDocument();
+    expect( iframe.tagName ).toBe( "IFRAME" );
+    expect( iframe ).toHaveAttribute(
+      "src",
+      "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/123",
+    );
+  });
+
+  it( "renders the track title and author as a heading link", () => {
+    render( <SoundCloudEmbed oembed={ MOCK_OEMBED } /> );
+
+    const link = screen.getByRole( "link", { name: /Test Artist/i } );
+    expect( link ).toHaveAttribute( "href", "https://soundcloud.com/test-artist" );
+  });
+
+  it( "does not render an iframe when the src is not from w.soundcloud.com", () => {
+    const maliciousOembed: SoundCloudOembed = {
+      ...MOCK_OEMBED,
+      html: '<iframe src="https://evil.com/exploit"></iframe>',
+    };
+
+    render( <SoundCloudEmbed oembed={ maliciousOembed } /> );
+
+    expect( screen.queryByTagName?.( "iframe" ) ?? document.querySelector( "iframe" ) ).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test src/__tests__/components/SoundCloudEmbed.test.tsx`
+Expected: FAIL — module `@/components/SoundCloudEmbed` does not exist
+
+- [ ] **Step 3: Write the component**
+
+Create `src/components/SoundCloudEmbed.tsx`:
+
+```typescript
+import { FC } from "react";
+import Link from "next/link";
+import { SoundCloudOembed } from "@/utils/soundcloud/getOembed";
+import styles from "@/styles/SoundCloudEmbed.module.scss";
+
+export interface SoundCloudEmbedProps {
+  oembed: SoundCloudOembed;
+}
+
+const ALLOWED_IFRAME_HOST = "w.soundcloud.com";
+
+function extractIframeSrc( html: string ): string | null {
+  const srcMatch = html.match( /src="([^"]+)"/ );
+  if ( !srcMatch?.[1] ) {
+    return null;
+  }
+
+  try {
+    const url = new URL( srcMatch[1] );
+    if ( url.host !== ALLOWED_IFRAME_HOST ) {
+      return null;
+    }
+    return srcMatch[1];
+  } catch {
+    return null;
+  }
+}
+
+export const SoundCloudEmbed: FC<SoundCloudEmbedProps> = ({ oembed }) => {
+  const iframeSrc = extractIframeSrc( oembed.html );
+
+  if ( !iframeSrc ) {
+    return null;
+  }
+
+  return (
+    <section className={ styles.soundcloudEmbed }>
+      <header className={ styles.soundcloudHeader }>
+        <h2>
+          Listen to &quot;{ oembed.title }&quot; by{" "}
+          <Link href={ oembed.author_url }>{ oembed.author_name }</Link>
+        </h2>
+      </header>
+      <iframe
+        title={ `${oembed.title} by ${oembed.author_name}` }
+        src={ iframeSrc }
+        width="100%"
+        height="166"
+        scrolling="no"
+        frameBorder="no"
+        allow="autoplay"
+      />
+    </section>
+  );
+};
+```
+
+- [ ] **Step 4: Create the stylesheet**
+
+Create `src/styles/SoundCloudEmbed.module.scss`:
+
+```scss
+section.soundcloudEmbed {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+
+  > iframe {
+    border: none;
+    border-radius: 4px;
+  }
+}
+
+.soundcloudHeader {
+  margin-bottom: 1rem;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `yarn test src/__tests__/components/SoundCloudEmbed.test.tsx`
+Expected: All 3 tests PASS
+
+- [ ] **Step 6: Run format and full test suite**
+
+Run: `yarn format && yarn test`
+Expected: All pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/SoundCloudEmbed.tsx src/styles/SoundCloudEmbed.module.scss src/__tests__/components/SoundCloudEmbed.test.tsx
+git commit -m "feat: add SoundCloudEmbed component"
+```
+
+---
+
+### Task 3: Integrate into Blog Post Page
+
+**Files:**
+- Modify: `src/pages/post/[slug].tsx:1-229`
+- Modify: `src/__tests__/pages/post/slug.test.tsx`
+
+- [ ] **Step 1: Write the failing test for SoundCloud oEmbed fetch in getStaticProps**
+
+Add to `src/__tests__/pages/post/slug.test.tsx`. First, add the mock at the top of the file alongside the existing mocks:
+
+```typescript
+vi.mock( "@/utils/soundcloud/getOembed", () => ({
+  getOembed: vi.fn(),
+}) );
+```
+
+Add the import alongside the existing imports:
+
+```typescript
+import { getOembed } from "@/utils/soundcloud/getOembed";
+```
+
+Update the `beforeEach` in the `"getStaticProps — post navigation"` describe block to also mock `getOembed`:
+
+```typescript
+  beforeEach( () => {
+    vi.mocked( getBlogPosts ).mockResolvedValue({ items: orderedPosts } as never );
+    vi.mocked( getPlaylist ).mockResolvedValue( null as never );
+    vi.mocked( getOembed ).mockResolvedValue( null );
+  });
+```
+
+Add a new describe block at the end of the file:
+
+```typescript
+describe( "getStaticProps — SoundCloud oEmbed", () => {
+  const postWithSoundcloud = makePost({ slug: "sc-post" });
+  Object.assign( postWithSoundcloud.fields, {
+    soundcloudUrl: "https://soundcloud.com/artist/track",
+  });
+
+  const postWithoutSoundcloud = makePost({ slug: "no-sc-post" });
+
+  beforeEach( () => {
+    vi.mocked( getBlogPosts ).mockResolvedValue({ items: [ postWithSoundcloud, postWithoutSoundcloud ] } as never );
+    vi.mocked( getPlaylist ).mockResolvedValue( null as never );
+    vi.mocked( getOembed ).mockResolvedValue( null );
+  });
+
+  it( "fetches oEmbed data when soundcloudUrl is present", async () => {
+    const mockOembed = { title: "Track", author_name: "Artist", author_url: "https://soundcloud.com/artist", html: "<iframe></iframe>", thumbnail_url: "" };
+    vi.mocked( getBlogPost ).mockResolvedValue( postWithSoundcloud as never );
+    vi.mocked( getOembed ).mockResolvedValue( mockOembed );
+
+    const result = await getStaticProps({ params: { slug: "sc-post" } } as never );
+
+    expect( getOembed ).toHaveBeenCalledWith( "https://soundcloud.com/artist/track" );
+    expect( result ).toMatchObject({
+      props: { soundCloudOembed: mockOembed },
+    });
+  });
+
+  it( "passes null when soundcloudUrl is absent", async () => {
+    vi.mocked( getBlogPost ).mockResolvedValue( postWithoutSoundcloud as never );
+
+    const result = await getStaticProps({ params: { slug: "no-sc-post" } } as never );
+
+    expect( getOembed ).not.toHaveBeenCalled();
+    expect( result ).toMatchObject({
+      props: { soundCloudOembed: null },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test src/__tests__/pages/post/slug.test.tsx`
+Expected: FAIL — `soundCloudOembed` not in props
+
+- [ ] **Step 3: Update getStaticProps to fetch SoundCloud oEmbed**
+
+In `src/pages/post/[slug].tsx`, add the import at the top:
+
+```typescript
+import { getOembed, SoundCloudOembed } from "@/utils/soundcloud/getOembed";
+```
+
+In `getStaticProps`, after the Spotify playlist fetch (line 181), add:
+
+```typescript
+  const soundCloudOembed = post.fields.soundcloudUrl
+    ? await getOembed( post.fields.soundcloudUrl ) : null;
+```
+
+Add `soundCloudOembed` to the returned props object:
+
+```typescript
+  return {
+    props: {
+      post,
+      playlist,
+      soundCloudOembed,
+      prevPost,
+      nextPost,
+    },
+  };
+```
+
+Update `BlogPostViewProps` to include:
+
+```typescript
+  soundCloudOembed?: SoundCloudOembed | null
+```
+
+Update the `BlogPostView` component signature to destructure `soundCloudOembed`:
+
+```typescript
+export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, prevPost, nextPost }) => {
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn test src/__tests__/pages/post/slug.test.tsx`
+Expected: All tests PASS (including the new SoundCloud describe block)
+
+- [ ] **Step 5: Add SoundCloudEmbed to the view**
+
+In `src/pages/post/[slug].tsx`, add the import:
+
+```typescript
+import { SoundCloudEmbed } from "@/components/SoundCloudEmbed";
+```
+
+In the JSX, add the embed after the Spotify playlist (after line 140):
+
+```tsx
+            { soundCloudOembed && <SoundCloudEmbed oembed={ soundCloudOembed } /> }
+```
+
+- [ ] **Step 6: Add the SoundCloudEmbed mock in slug.test.tsx**
+
+Add alongside the existing component mocks at the top of `src/__tests__/pages/post/slug.test.tsx`:
+
+```typescript
+vi.mock( "@/components/SoundCloudEmbed", () => ({ SoundCloudEmbed: () => null }) );
+```
+
+- [ ] **Step 7: Run format and full test suite**
+
+Run: `yarn format && yarn test`
+Expected: All pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pages/post/[slug].tsx src/__tests__/pages/post/slug.test.tsx
+git commit -m "feat: integrate SoundCloud oEmbed into blog post page"
+```
+
+---
+
+### Task 4: Update Contentful Types
+
+**Prerequisite:** The `soundcloudUrl` field must be added to the `blogPost` content type in the Contentful UI before this step.
+
+**Files:**
+- Modify: `src/types/contentful/TypeBlogPost.ts` (regenerated)
+
+- [ ] **Step 1: Add the field in Contentful**
+
+In the Contentful web UI:
+1. Go to Content Model → Blog Post
+2. Add a new field: **Short text** (Symbol), field ID `soundcloudUrl`, name "SoundCloud URL"
+3. Set it as optional
+4. Save the content type
+
+- [ ] **Step 2: Regenerate types**
+
+Run: `make types`
+
+This will export the space and regenerate `src/types/contentful/`. The `TypeBlogPostFields` interface will now include:
+
+```typescript
+soundcloudUrl?: EntryFieldTypes.Symbol;
+```
+
+- [ ] **Step 3: Verify the types compile**
+
+Run: `yarn typecheck`
+Expected: No errors. The `post.fields.soundcloudUrl` access in `[slug].tsx` should now be recognized.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `yarn test`
+Expected: All pass
+
+- [ ] **Step 5: Commit the regenerated types**
+
+```bash
+git add src/types/contentful/
+git commit -m "feat: regenerate Contentful types with soundcloudUrl field"
+```
+
+**Note:** Until this task is completed, TypeScript may show errors on `post.fields.soundcloudUrl`. The code from Tasks 1-3 is still correct — the type just needs to catch up to the Contentful model change.
+
+---
+
+### Task 5: Update New-Post Skill
+
+**Files:**
+- Modify: `.claude/skills/new-post/SKILL.md`
+
+- [ ] **Step 1: Add soundcloudUrl to the field assembly table**
+
+In `.claude/skills/new-post/SKILL.md`, add a new row to the Field Assembly table (after the `spotifyPlaylistId` row):
+
+```markdown
+| **soundcloudUrl** | Ask if they want to embed a SoundCloud track or playlist (yes/no). If yes, collect the full SoundCloud URL. Skip if no. |
+```
+
+- [ ] **Step 2: Add soundcloudUrl to the Entry Creation JSON**
+
+In the Entry Creation section, add `soundcloudUrl` to the fields object:
+
+```json
+"soundcloudUrl": { "en-US": "<soundcloudUrl>" }
+```
+
+Add a note to the "Omit optional fields" line: update it to include `soundcloudUrl`:
+
+```markdown
+Omit optional fields that were not provided (gallery, spotifyPlaylistId, soundcloudUrl, location). Tags go in `metadata`, not `fields`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/new-post/SKILL.md
+git commit -m "feat: add soundcloudUrl to new-post skill"
+```

--- a/docs/superpowers/specs/2026-04-14-soundcloud-embed-design.md
+++ b/docs/superpowers/specs/2026-04-14-soundcloud-embed-design.md
@@ -1,0 +1,122 @@
+# SoundCloud Embed Support
+
+> Date: 2026-04-14
+> Status: Approved
+
+## Overview
+
+Add optional SoundCloud track/playlist embedding to blog posts via a dedicated Contentful field and SoundCloud's oEmbed API. Follows the existing Spotify integration pattern — a content model field, build-time data fetch, and a dedicated component rendered in the post view.
+
+## Goals
+
+- Embed individual SoundCloud tracks or playlists on any blog post
+- Fetch embed data at build time (no client-side loading)
+- Graceful degradation if SoundCloud is unreachable during build
+- Support both tracks and playlists via the same field
+
+## Non-Goals
+
+- Inline SoundCloud embeds in markdown body (future enhancement)
+- Custom-designed player component (using SoundCloud's official iframe widget)
+- SoundCloud API integration (oEmbed only — no API key required)
+
+## Contentful Content Model
+
+Add one optional field to the `blogPost` content type:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `soundcloudUrl` | Symbol | No | Full SoundCloud URL for a track or playlist (e.g., `https://soundcloud.com/artist/track` or `https://soundcloud.com/artist/sets/playlist`) |
+
+After adding the field in the Contentful UI, regenerate types with `make types`.
+
+## oEmbed Integration
+
+### Endpoint
+
+```
+GET https://soundcloud.com/oembed?format=json&url={soundcloudUrl}
+```
+
+### Response Shape (relevant fields)
+
+```json
+{
+  "title": "Track or Playlist Name",
+  "author_name": "Artist Name",
+  "author_url": "https://soundcloud.com/artist",
+  "html": "<iframe ...></iframe>",
+  "thumbnail_url": "https://i1.sndcdn.com/artworks-...-t500x500.jpg"
+}
+```
+
+The `html` field contains the ready-to-use iframe embed.
+
+### Utility: `src/utils/soundcloud/getOembed.ts`
+
+- Accepts a SoundCloud URL string
+- Fetches the oEmbed endpoint
+- Returns typed oEmbed response data
+- On fetch failure: returns `null` (post builds without the embed, no build breakage)
+
+## Component: `src/components/SoundCloudEmbed.tsx`
+
+- Receives oEmbed response data as props
+- Extracts the iframe `src` URL from the oEmbed `html` field and renders a sanitized `<iframe>` element directly (no `dangerouslySetInnerHTML`) with explicit sandbox and allow attributes
+- Wrapped in a styled container with a heading/label section
+- Placed in `BlogPostView` alongside the existing `<Playlist>` component (both optional, both can coexist on the same post)
+
+### Rendering Order in Post View
+
+1. Post header (image, title, author, date, tags)
+2. Post body (markdown)
+3. Gallery (optional)
+4. Spotify playlist (optional, existing)
+5. SoundCloud embed (optional, new)
+6. Post navigation (prev/next)
+
+## Data Flow
+
+```
+[slug].tsx getStaticProps
+  └─ post.fields.soundcloudUrl exists?
+       ├─ yes → getOembed(soundcloudUrl) → pass result as prop
+       └─ no  → pass null
+```
+
+```
+BlogPostView
+  └─ soundCloudOembed prop exists?
+       ├─ yes → render <SoundCloudEmbed data={soundCloudOembed} />
+       └─ no  → skip
+```
+
+## New-Post Skill Update
+
+Add `soundcloudUrl` to the field assembly table in `.claude/skills/new-post/SKILL.md`:
+
+| Field | How to get it |
+|-------|---------------|
+| **soundcloudUrl** | Ask if they want to embed a SoundCloud track or playlist (yes/no). If yes, collect the URL. Skip if no. |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/types/contentful/TypeBlogPost.ts` | Regenerated via `make types` after Contentful field addition |
+| `src/utils/soundcloud/getOembed.ts` | New — oEmbed fetch utility with typed response |
+| `src/components/SoundCloudEmbed.tsx` | New — embed wrapper component |
+| `src/pages/post/[slug].tsx` | Add oEmbed fetch in `getStaticProps`, render `<SoundCloudEmbed>` in view |
+| `.claude/skills/new-post/SKILL.md` | Add `soundcloudUrl` to field assembly table |
+
+## Testing
+
+- Unit test for `getOembed` utility: successful fetch, failed fetch (returns null), malformed URL
+- Component test for `SoundCloudEmbed`: renders iframe, handles missing data
+- Build test: post with `soundcloudUrl` builds correctly, post without it still works
+
+## Security Considerations
+
+- The component parses the oEmbed `html` to extract the iframe `src` URL, then renders a clean `<iframe>` element with explicit `sandbox` and `allow` attributes — no raw HTML injection.
+- The iframe `src` is validated to ensure it points to `w.soundcloud.com` before rendering.
+- No API keys or secrets are needed — oEmbed is a public endpoint.

--- a/src/__tests__/components/SoundCloudEmbed.test.tsx
+++ b/src/__tests__/components/SoundCloudEmbed.test.tsx
@@ -43,12 +43,12 @@ describe( "SoundCloudEmbed", () => {
     expect( titleLink ).toHaveAttribute( "rel", "noopener noreferrer" );
   });
 
-  it( "renders the author as a link that opens in a new tab", () => {
+  it( "renders a SoundCloud link to the author page that opens in a new tab", () => {
     render( <SoundCloudEmbed oembed={ MOCK_OEMBED } url={ MOCK_SOUNDCLOUD_URL } /> );
 
-    const authorLink = screen.getByRole( "link", { name: /Test Artist/i });
-    expect( authorLink ).toHaveAttribute( "href", "https://soundcloud.com/test-artist" );
-    expect( authorLink ).toHaveAttribute( "target", "_blank" );
+    const soundcloudLink = screen.getByRole( "link", { name: /SoundCloud/i });
+    expect( soundcloudLink ).toHaveAttribute( "href", "https://soundcloud.com/test-artist" );
+    expect( soundcloudLink ).toHaveAttribute( "target", "_blank" );
   });
 
   it( "does not render an iframe when the src is not from w.soundcloud.com", () => {

--- a/src/__tests__/components/SoundCloudEmbed.test.tsx
+++ b/src/__tests__/components/SoundCloudEmbed.test.tsx
@@ -11,6 +11,8 @@ vi.mock( "next/link", () => ({
 import { SoundCloudEmbed } from "@/components/SoundCloudEmbed";
 import { SoundCloudOembed } from "@/utils/soundcloud/getOembed";
 
+const MOCK_SOUNDCLOUD_URL = "https://soundcloud.com/test-artist/test-track";
+
 const MOCK_OEMBED: SoundCloudOembed = {
   title: "Test Track",
   author_name: "Test Artist",
@@ -21,7 +23,7 @@ const MOCK_OEMBED: SoundCloudOembed = {
 
 describe( "SoundCloudEmbed", () => {
   it( "renders an iframe with the src extracted from oEmbed html", () => {
-    render( <SoundCloudEmbed oembed={ MOCK_OEMBED } /> );
+    render( <SoundCloudEmbed oembed={ MOCK_OEMBED } url={ MOCK_SOUNDCLOUD_URL } /> );
 
     const iframe = screen.getByTitle( "Test Track by Test Artist" );
     expect( iframe ).toBeInTheDocument();
@@ -32,11 +34,21 @@ describe( "SoundCloudEmbed", () => {
     );
   });
 
-  it( "renders the track title and author as a heading link", () => {
-    render( <SoundCloudEmbed oembed={ MOCK_OEMBED } /> );
+  it( "renders the title as a link to the SoundCloud URL that opens in a new tab", () => {
+    render( <SoundCloudEmbed oembed={ MOCK_OEMBED } url={ MOCK_SOUNDCLOUD_URL } /> );
 
-    const link = screen.getByRole( "link", { name: /Test Artist/i });
-    expect( link ).toHaveAttribute( "href", "https://soundcloud.com/test-artist" );
+    const titleLink = screen.getByRole( "link", { name: /Test Track/i });
+    expect( titleLink ).toHaveAttribute( "href", MOCK_SOUNDCLOUD_URL );
+    expect( titleLink ).toHaveAttribute( "target", "_blank" );
+    expect( titleLink ).toHaveAttribute( "rel", "noopener noreferrer" );
+  });
+
+  it( "renders the author as a link that opens in a new tab", () => {
+    render( <SoundCloudEmbed oembed={ MOCK_OEMBED } url={ MOCK_SOUNDCLOUD_URL } /> );
+
+    const authorLink = screen.getByRole( "link", { name: /Test Artist/i });
+    expect( authorLink ).toHaveAttribute( "href", "https://soundcloud.com/test-artist" );
+    expect( authorLink ).toHaveAttribute( "target", "_blank" );
   });
 
   it( "does not render an iframe when the src is not from w.soundcloud.com", () => {
@@ -45,7 +57,7 @@ describe( "SoundCloudEmbed", () => {
       html: '<iframe src="https://evil.com/exploit"></iframe>',
     };
 
-    render( <SoundCloudEmbed oembed={ maliciousOembed } /> );
+    render( <SoundCloudEmbed oembed={ maliciousOembed } url={ MOCK_SOUNDCLOUD_URL } /> );
 
     expect( document.querySelector( "iframe" ) ).toBeNull();
   });

--- a/src/__tests__/components/SoundCloudEmbed.test.tsx
+++ b/src/__tests__/components/SoundCloudEmbed.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock( "next/link", () => ({
+  default: ({ children, href, ...props }: React.ComponentProps<"a"> ) => (
+    <a href={ href } { ...props }>{ children }</a>
+  ),
+}) );
+
+import { SoundCloudEmbed } from "@/components/SoundCloudEmbed";
+import { SoundCloudOembed } from "@/utils/soundcloud/getOembed";
+
+const MOCK_OEMBED: SoundCloudOembed = {
+  title: "Test Track",
+  author_name: "Test Artist",
+  author_url: "https://soundcloud.com/test-artist",
+  html: '<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/123"></iframe>',
+  thumbnail_url: "https://i1.sndcdn.com/artworks-000-t500x500.jpg",
+};
+
+describe( "SoundCloudEmbed", () => {
+  it( "renders an iframe with the src extracted from oEmbed html", () => {
+    render( <SoundCloudEmbed oembed={ MOCK_OEMBED } /> );
+
+    const iframe = screen.getByTitle( "Test Track by Test Artist" );
+    expect( iframe ).toBeInTheDocument();
+    expect( iframe.tagName ).toBe( "IFRAME" );
+    expect( iframe ).toHaveAttribute(
+      "src",
+      "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/123",
+    );
+  });
+
+  it( "renders the track title and author as a heading link", () => {
+    render( <SoundCloudEmbed oembed={ MOCK_OEMBED } /> );
+
+    const link = screen.getByRole( "link", { name: /Test Artist/i });
+    expect( link ).toHaveAttribute( "href", "https://soundcloud.com/test-artist" );
+  });
+
+  it( "does not render an iframe when the src is not from w.soundcloud.com", () => {
+    const maliciousOembed: SoundCloudOembed = {
+      ...MOCK_OEMBED,
+      html: '<iframe src="https://evil.com/exploit"></iframe>',
+    };
+
+    render( <SoundCloudEmbed oembed={ maliciousOembed } /> );
+
+    expect( document.querySelector( "iframe" ) ).toBeNull();
+  });
+});

--- a/src/__tests__/pages/post/slug.test.tsx
+++ b/src/__tests__/pages/post/slug.test.tsx
@@ -9,6 +9,10 @@ vi.mock( "@/utils/contentfulUtils", () => ({
 vi.mock( "@/utils/spotify/getPlaylist", () => ({
   getPlaylist: vi.fn(),
 }) );
+vi.mock( "@/utils/soundcloud/getOembed", () => ({
+  getOembed: vi.fn(),
+}) );
+vi.mock( "@/components/SoundCloudEmbed", () => ({ SoundCloudEmbed: () => null }) );
 vi.mock( "next/link", () => ({
   default: ({ children, href, ...props }: React.ComponentProps<"a"> ) => (
     <a href={ href } { ...props }>{ children }</a>
@@ -33,6 +37,7 @@ vi.mock( "@/components/Playlist", () => ({ default: () => null }) );
 import { BlogPostView, getStaticProps } from "@/pages/post/[slug]";
 import { getBlogPost, getBlogPosts } from "@/utils/contentfulUtils";
 import { getPlaylist } from "@/utils/spotify/getPlaylist";
+import { getOembed } from "@/utils/soundcloud/getOembed";
 
 function makePost( overrides: {
   slug?: string;
@@ -114,6 +119,7 @@ describe( "getStaticProps — post navigation", () => {
   beforeEach( () => {
     vi.mocked( getBlogPosts ).mockResolvedValue({ items: orderedPosts } as never );
     vi.mocked( getPlaylist ).mockResolvedValue( null as never );
+    vi.mocked( getOembed ).mockResolvedValue( null );
   });
 
   it( "assigns both prevPost and nextPost for a middle post", async () => {
@@ -170,6 +176,46 @@ describe( "getStaticProps — post navigation", () => {
     const result = await getStaticProps({ params: { slug: "created-second" } } as never );
     expect( result ).toMatchObject({
       props: { prevPost: { slug: "created-first" }, nextPost: null },
+    });
+  });
+});
+
+describe( "getStaticProps — SoundCloud oEmbed", () => {
+  const postWithSoundcloud = makePost({ slug: "sc-post" });
+  Object.assign( postWithSoundcloud.fields, {
+    soundcloudUrl: "https://soundcloud.com/artist/track",
+  });
+
+  const postWithoutSoundcloud = makePost({ slug: "no-sc-post" });
+
+  beforeEach( () => {
+    vi.resetAllMocks();
+    vi.mocked( getBlogPosts ).mockResolvedValue({ items: [ postWithSoundcloud, postWithoutSoundcloud ] } as never );
+    vi.mocked( getPlaylist ).mockResolvedValue( null as never );
+    vi.mocked( getOembed ).mockResolvedValue( null );
+  });
+
+  it( "fetches oEmbed data when soundcloudUrl is present", async () => {
+    const mockOembed = { title: "Track", author_name: "Artist", author_url: "https://soundcloud.com/artist", html: "<iframe></iframe>", thumbnail_url: "" };
+    vi.mocked( getBlogPost ).mockResolvedValue( postWithSoundcloud as never );
+    vi.mocked( getOembed ).mockResolvedValue( mockOembed );
+
+    const result = await getStaticProps({ params: { slug: "sc-post" } } as never );
+
+    expect( getOembed ).toHaveBeenCalledWith( "https://soundcloud.com/artist/track" );
+    expect( result ).toMatchObject({
+      props: { soundCloudOembed: mockOembed },
+    });
+  });
+
+  it( "passes null when soundcloudUrl is absent", async () => {
+    vi.mocked( getBlogPost ).mockResolvedValue( postWithoutSoundcloud as never );
+
+    const result = await getStaticProps({ params: { slug: "no-sc-post" } } as never );
+
+    expect( getOembed ).not.toHaveBeenCalled();
+    expect( result ).toMatchObject({
+      props: { soundCloudOembed: null },
     });
   });
 });

--- a/src/components/SoundCloudEmbed.tsx
+++ b/src/components/SoundCloudEmbed.tsx
@@ -1,0 +1,53 @@
+import { FC } from "react";
+import Link from "next/link";
+import { SoundCloudOembed } from "@/utils/soundcloud/getOembed";
+import styles from "@/styles/SoundCloudEmbed.module.scss";
+
+export interface SoundCloudEmbedProps {
+  oembed: SoundCloudOembed;
+}
+
+const ALLOWED_IFRAME_HOST = "w.soundcloud.com";
+
+function extractIframeSrc( html: string ): string | null {
+  const srcMatch = html.match( /src="([^"]+)"/ );
+  if( !srcMatch?.[1] ) {
+    return null;
+  }
+
+  try {
+    const url = new URL( srcMatch[1] );
+    if( url.host !== ALLOWED_IFRAME_HOST ) {
+      return null;
+    }
+    return srcMatch[1];
+  } catch {
+    return null;
+  }
+}
+
+export const SoundCloudEmbed: FC<SoundCloudEmbedProps> = ({ oembed }) => {
+  const iframeSrc = extractIframeSrc( oembed.html );
+
+  if( !iframeSrc ) {
+    return null;
+  }
+
+  return (
+    <section className={ styles.soundcloudEmbed }>
+      <header className={ styles.soundcloudHeader }>
+        <h2>
+          Listen to &quot;{ oembed.title }&quot; by{ " " }
+          <Link href={ oembed.author_url }>{ oembed.author_name }</Link>
+        </h2>
+      </header>
+      <iframe
+        title={ `${oembed.title} by ${oembed.author_name}` }
+        src={ iframeSrc }
+        width="100%"
+        height="166"
+        allow="autoplay"
+      />
+    </section>
+  );
+};

--- a/src/components/SoundCloudEmbed.tsx
+++ b/src/components/SoundCloudEmbed.tsx
@@ -5,6 +5,7 @@ import styles from "@/styles/SoundCloudEmbed.module.scss";
 
 export interface SoundCloudEmbedProps {
   oembed: SoundCloudOembed;
+  url: string;
 }
 
 const ALLOWED_IFRAME_HOST = "w.soundcloud.com";
@@ -26,7 +27,7 @@ function extractIframeSrc( html: string ): string | null {
   }
 }
 
-export const SoundCloudEmbed: FC<SoundCloudEmbedProps> = ({ oembed }) => {
+export const SoundCloudEmbed: FC<SoundCloudEmbedProps> = ({ oembed, url }) => {
   const iframeSrc = extractIframeSrc( oembed.html );
 
   if( !iframeSrc ) {
@@ -37,8 +38,8 @@ export const SoundCloudEmbed: FC<SoundCloudEmbedProps> = ({ oembed }) => {
     <section className={ styles.soundcloudEmbed }>
       <header className={ styles.soundcloudHeader }>
         <h2>
-          Listen to &quot;{ oembed.title }&quot; by{ " " }
-          <Link href={ oembed.author_url }>{ oembed.author_name }</Link>
+          Listen to &quot;<Link href={ url } target="_blank" rel="noopener noreferrer">{ oembed.title }</Link>&quot; by{ " " }
+          <Link href={ oembed.author_url } target="_blank" rel="noopener noreferrer">{ oembed.author_name }</Link>
         </h2>
       </header>
       <iframe

--- a/src/components/SoundCloudEmbed.tsx
+++ b/src/components/SoundCloudEmbed.tsx
@@ -38,8 +38,8 @@ export const SoundCloudEmbed: FC<SoundCloudEmbedProps> = ({ oembed, url }) => {
     <section className={ styles.soundcloudEmbed }>
       <header className={ styles.soundcloudHeader }>
         <h2>
-          Listen to &quot;<Link href={ url } target="_blank" rel="noopener noreferrer">{ oembed.title }</Link>&quot; by{ " " }
-          <Link href={ oembed.author_url } target="_blank" rel="noopener noreferrer">{ oembed.author_name }</Link>
+          Listen to &quot;<Link href={ url } target="_blank" rel="noopener noreferrer">{ oembed.title }</Link>&quot; on{ " " }
+          <Link href={ oembed.author_url } target="_blank" rel="noopener noreferrer">SoundCloud</Link>
         </h2>
       </header>
       <iframe

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -15,6 +15,8 @@ import { Tags } from "@/components/Tags";
 import { SpotifyPlaylist, getPlaylist } from "@/utils/spotify/getPlaylist";
 import Playlist from "@/components/Playlist";
 import Gallery, { resolveGalleryItems } from "@/components/Gallery";
+import { getOembed, SoundCloudOembed } from "@/utils/soundcloud/getOembed";
+import { SoundCloudEmbed } from "@/components/SoundCloudEmbed";
 
 
 
@@ -27,12 +29,13 @@ export interface PostNavLink {
 export interface BlogPostViewProps {
   post: BlogPost
   playlist?: SpotifyPlaylist|null
+  soundCloudOembed?: SoundCloudOembed|null
   prevPost?: PostNavLink|null
   nextPost?: PostNavLink|null
 }
 
 
-export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, prevPost, nextPost }) => {
+export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, prevPost, nextPost }) => {
   const metaTitle = `${post.fields.title} | Audeos.com`;
   const metaImage = `https:${post.fields.image?.fields.file?.url}?w=${CONTENT_IMAGE_WIDTH}`;
   const metaImageDesc = post.fields.image?.fields.description || "";
@@ -138,6 +141,7 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, prevPost, 
             <Markdown>{ post.fields.body || "" }</Markdown>
             <Gallery items={ resolveGalleryItems( post.fields.gallery ) } />
             { playlist && <Playlist playlist={ playlist } /> }
+            { soundCloudOembed && <SoundCloudEmbed oembed={ soundCloudOembed } /> }
             { ( prevPost || nextPost ) && (
               <nav className={ styles.postNav }>
                 { nextPost && (
@@ -180,6 +184,11 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
   const playlist = post.fields.spotifyPlaylistId
     ? await getPlaylist( post.fields.spotifyPlaylistId ) : null;
 
+  // soundcloudUrl will be typed properly after Task 4 regenerates Contentful types
+  const rawFields: Record<string, unknown> = { ...post.fields };
+  const soundcloudUrl = typeof rawFields["soundcloudUrl"] === "string" ? rawFields["soundcloudUrl"] : null;
+  const soundCloudOembed = soundcloudUrl ? await getOembed( soundcloudUrl ) : null;
+
   const sortedPosts = allPosts.items
     .slice()
     .sort( sortBlogPostsByDate )
@@ -203,6 +212,7 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
     props: {
       post,
       playlist,
+      soundCloudOembed,
       prevPost,
       nextPost,
     },

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -184,10 +184,8 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
   const playlist = post.fields.spotifyPlaylistId
     ? await getPlaylist( post.fields.spotifyPlaylistId ) : null;
 
-  // soundcloudUrl will be typed properly after Task 4 regenerates Contentful types
-  const rawFields: Record<string, unknown> = { ...post.fields };
-  const soundcloudUrl = typeof rawFields["soundcloudUrl"] === "string" ? rawFields["soundcloudUrl"] : null;
-  const soundCloudOembed = soundcloudUrl ? await getOembed( soundcloudUrl ) : null;
+  const soundCloudOembed = post.fields.soundcloudUrl
+    ? await getOembed( post.fields.soundcloudUrl ) : null;
 
   const sortedPosts = allPosts.items
     .slice()

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -137,11 +137,11 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloud
               <p>
                 { post.fields.description }
               </p>
+              { soundCloudOembed && <SoundCloudEmbed oembed={ soundCloudOembed } /> }
             </header>
             <Markdown>{ post.fields.body || "" }</Markdown>
             <Gallery items={ resolveGalleryItems( post.fields.gallery ) } />
             { playlist && <Playlist playlist={ playlist } /> }
-            { soundCloudOembed && <SoundCloudEmbed oembed={ soundCloudOembed } /> }
             { ( prevPost || nextPost ) && (
               <nav className={ styles.postNav }>
                 { nextPost && (

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -137,7 +137,7 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloud
               <p>
                 { post.fields.description }
               </p>
-              { soundCloudOembed && <SoundCloudEmbed oembed={ soundCloudOembed } /> }
+              { soundCloudOembed && post.fields.soundcloudUrl && <SoundCloudEmbed oembed={ soundCloudOembed } url={ post.fields.soundcloudUrl } /> }
             </header>
             <Markdown>{ post.fields.body || "" }</Markdown>
             <Gallery items={ resolveGalleryItems( post.fields.gallery ) } />

--- a/src/styles/SoundCloudEmbed.module.scss
+++ b/src/styles/SoundCloudEmbed.module.scss
@@ -1,0 +1,13 @@
+section.soundcloudEmbed {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+
+  > iframe {
+    border: none;
+    border-radius: 4px;
+  }
+}
+
+.soundcloudHeader {
+  margin-bottom: 1rem;
+}

--- a/src/types/contentful/TypeBlogPost.ts
+++ b/src/types/contentful/TypeBlogPost.ts
@@ -74,6 +74,12 @@ export interface TypeBlogPostFields {
      * @localized false
      */
     gallery?: EntryFieldTypes.Array<EntryFieldTypes.AssetLink>;
+    /**
+     * Field type definition for field 'soundcloudUrl' (soundcloudUrl)
+     * @name soundcloudUrl
+     * @localized false
+     */
+    soundcloudUrl?: EntryFieldTypes.Symbol;
 }
 
 /**
@@ -82,7 +88,7 @@ export interface TypeBlogPostFields {
  * @type {TypeBlogPostSkeleton}
  * @author 5qtbtLdlsTzODfegrwA2Ez
  * @since 2023-04-01T06:07:22.846Z
- * @version 21
+ * @version 23
  */
 export type TypeBlogPostSkeleton = EntrySkeletonType<TypeBlogPostFields, "blogPost">;
 /**
@@ -91,7 +97,7 @@ export type TypeBlogPostSkeleton = EntrySkeletonType<TypeBlogPostFields, "blogPo
  * @type {TypeBlogPost}
  * @author 5qtbtLdlsTzODfegrwA2Ez
  * @since 2023-04-01T06:07:22.846Z
- * @version 21
+ * @version 23
  */
 export type TypeBlogPost<Modifiers extends ChainModifiers, Locales extends LocaleCode = LocaleCode> = Entry<TypeBlogPostSkeleton, Modifiers, Locales>;
 

--- a/src/utils/soundcloud/getOembed.test.ts
+++ b/src/utils/soundcloud/getOembed.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal( "fetch", mockFetch );
+
+import { getOembed, SoundCloudOembed } from "./getOembed";
+
+const SOUNDCLOUD_TRACK_URL = "https://soundcloud.com/artist/track-name";
+
+const MOCK_OEMBED_RESPONSE: SoundCloudOembed = {
+  title: "Test Track",
+  author_name: "Test Artist",
+  author_url: "https://soundcloud.com/artist",
+  html: '<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/123"></iframe>',
+  thumbnail_url: "https://i1.sndcdn.com/artworks-000-t500x500.jpg",
+};
+
+describe( "getOembed", () => {
+  beforeEach( () => {
+    vi.resetAllMocks();
+  });
+
+  it( "fetches oEmbed data for a valid SoundCloud URL", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve( MOCK_OEMBED_RESPONSE ),
+    });
+
+    const result = await getOembed( SOUNDCLOUD_TRACK_URL );
+
+    expect( mockFetch ).toHaveBeenCalledWith(
+      `https://soundcloud.com/oembed?format=json&url=${encodeURIComponent( SOUNDCLOUD_TRACK_URL )}`,
+    );
+    expect( result ).toEqual( MOCK_OEMBED_RESPONSE );
+  });
+
+  it( "returns null when the fetch fails", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const result = await getOembed( SOUNDCLOUD_TRACK_URL );
+
+    expect( result ).toBeNull();
+  });
+
+  it( "returns null when fetch throws a network error", async () => {
+    mockFetch.mockRejectedValueOnce( new Error( "Network error" ) );
+
+    const result = await getOembed( SOUNDCLOUD_TRACK_URL );
+
+    expect( result ).toBeNull();
+  });
+});

--- a/src/utils/soundcloud/getOembed.ts
+++ b/src/utils/soundcloud/getOembed.ts
@@ -1,0 +1,26 @@
+export interface SoundCloudOembed {
+  title: string;
+  author_name: string;
+  author_url: string;
+  html: string;
+  thumbnail_url: string;
+}
+
+const OEMBED_ENDPOINT = "https://soundcloud.com/oembed";
+
+export async function getOembed( soundcloudUrl: string ): Promise<SoundCloudOembed | null> {
+  const url = `${OEMBED_ENDPOINT}?format=json&url=${encodeURIComponent( soundcloudUrl )}`;
+
+  try {
+    const response = await fetch( url );
+
+    if( !response.ok ) {
+      return null;
+    }
+
+    const data: SoundCloudOembed = await response.json();
+    return data;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Add optional SoundCloud track/playlist embedding via oEmbed API — new `soundcloudUrl` Contentful field triggers a build-time fetch, rendered as a sanitized iframe in a `<SoundCloudEmbed>` component
- Follows the existing Spotify integration pattern: dedicated content field, `getStaticProps` fetch, conditional component render
- Updates the new-post skill to collect SoundCloud URLs during post creation

## Test Plan
- [ ] Verify `yarn typecheck`, `yarn lint`, and `yarn test` all pass (102 tests)
- [ ] Add a `soundcloudUrl` to a blog post in Contentful, build, and confirm the embed renders
- [ ] Confirm posts without `soundcloudUrl` still build and render correctly
- [ ] Confirm a post with both Spotify and SoundCloud embeds renders both