### PR TITLE
chore: add JSX prop formatting ESLint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,6 +49,8 @@ const eslintConfig = defineConfig( [ ...nextTypescript, ...nextVitals, {
       },
     } ],
 
+    "react/jsx-max-props-per-line": [ 2, { maximum: 1, when: "multiline" } ],
+    "react/jsx-first-prop-new-line": [ 2, "multiline" ],
     semi: [ 2, "always" ],
 
     "space-in-parens": [ 2, "always", {

--- a/src/components/Home/Pagination.tsx
+++ b/src/components/Home/Pagination.tsx
@@ -41,7 +41,8 @@ export default function Pagination({ posts, page, tagId }: PaginationProps ) {
             const href: string = getPaginatorUrl( pageNumber, tagId );
             const className: string|undefined = isCurrentPage ? styles.isCurrentPage : undefined;
             return (
-              <Link key={ pageNumber }
+              <Link
+                key={ pageNumber }
                 href={ href }
                 className={ className }
               >{ pageNumber }

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -61,7 +61,8 @@ export const Footer: FC = () => {
       </div>
 
       <div>
-        <OldSchoolButton onClick={ resetCookieConsent }
+        <OldSchoolButton
+          onClick={ resetCookieConsent }
           label="Update Cookie Preferences"
         />
       </div>

--- a/src/components/OldSchoolButton.tsx
+++ b/src/components/OldSchoolButton.tsx
@@ -23,7 +23,8 @@ export const OldSchoolButton: FC<OldSchoolButtonProps> = ({
 
   if( href ) {
     return (
-      <Link className={ combinedClassName }
+      <Link
+        className={ combinedClassName }
         href={ href }
       >
         { label }
@@ -32,7 +33,8 @@ export const OldSchoolButton: FC<OldSchoolButtonProps> = ({
   }
 
   return (
-    <button className={ combinedClassName }
+    <button
+      className={ combinedClassName }
       onClick={ onClick }
     >
       { label }

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -21,7 +21,8 @@ export default function Picture({
         breakpoints
           // @TODO: I hate this.
           .map( breakpoint => shouldRenderSourceSet( breakpoint, maxWidth, maxHeight ) ?
-            <source key={ breakpoint }
+            <source
+              key={ breakpoint }
               media={ `(max-width: ${ breakpoint }px)` }
               srcSet={ getImgSrc( url, { width: breakpoint, format: "webp" }) }
               type={ "image/webp" }


### PR DESCRIPTION
## Summary
- Adds `react/jsx-max-props-per-line` and `react/jsx-first-prop-new-line` ESLint rules
- Reformats 4 components that had multiline JSX with multiple props on one line

## Test Plan
- [x] `yarn lint` passes
- [x] `yarn test` passes (103 tests)