### PR TITLE
feat: improve blog post grid responsiveness

### DIFF
--- a/src/styles/Home.module.scss
+++ b/src/styles/Home.module.scss
@@ -90,12 +90,41 @@
 ul.imageGallery {
   list-style: none;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(300px, 100%), 1fr));
-  gap: 9rem;
+  grid-template-columns: 1fr;
+  gap: 5rem;
   justify-content: center;
   width: 100%;
-  padding-left: 3rem;
-  padding-right: 3rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+
+  // 2-column grid — equal gaps and page margins
+  @media (min-width: 800px) {
+    --grid-gap: 2rem;
+
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--grid-gap);
+    padding-left: var(--grid-gap);
+    padding-right: var(--grid-gap);
+  }
+
+  // Increase spacing at tablet size
+  @media (min-width: 872px) {
+    --grid-gap: 2.5rem;
+  }
+
+  // Wider screens — increase the uniform spacing
+  @media (min-width: 1100px) {
+    --grid-gap: 3.5rem;
+  }
+
+  @media (min-width: 1200px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @media (min-width: 1600px) {
+    --grid-gap: 4.5rem;
+    grid-template-columns: repeat(4, 1fr);
+  }
 
   li {
     figure {


### PR DESCRIPTION
## Summary
- Reduce side padding on small screens (< 800px) so post images take up more of the viewport
- Switch to explicit responsive breakpoints with a shared `--grid-gap` CSS variable that controls both column gaps and page margins equally
- Grid columns: 1 col (default) → 2 col (800px) → 3 col (1200px) → 4 col (1600px)

## Test plan
- [ ] Verify single-column layout at 375px (iPhone SE) — images should be wider with minimal side padding
- [ ] Verify single-column layout at 768px (iPad Mini) — should look unchanged
- [ ] Verify 2-column layout at 800px — gaps between columns should equal page margins
- [ ] Verify 3-column layout at 1200px
- [ ] Verify 4-column layout at 1600px
- [ ] Confirm spacing scales up smoothly across all breakpoints