### PR TITLE
feat: restructure blog post header and move embeds below body

### DIFF
--- a/docs/superpowers/specs/2026-04-16-blog-post-page-updates-design.md
+++ b/docs/superpowers/specs/2026-04-16-blog-post-page-updates-design.md
@@ -1,0 +1,50 @@
+# Blog Post Page Updates
+
+**Date:** 2026-04-16
+**Status:** Draft
+**Scope:** Layout changes to the blog post page header and embed placement
+
+## Goal
+
+Restructure the blog post page header (remove "Last updated", reformat author/date lines) and move SoundCloud/YouTube embeds from the header to below the body content.
+
+## Changes
+
+### 1. Header — Author/Date Restructure
+
+Remove the "Last updated: [date]" line from the `<address>` block. Replace the two-line layout with:
+
+- **Line 1** (normal weight, muted): Publish date only — e.g., `January 5, 2026`
+- **Line 2** (bold): `By Author Name` (linked if author has a slug, plain text otherwise)
+
+The publish date uses the existing `resolvePostDate()` logic and `<DateTimeFormat>` component. The avatar remains to the left of both lines.
+
+### 2. Embeds — Move Below Body
+
+Remove `<SoundCloudEmbed>` and `<YouTubeEmbed>` from inside `<header>`. Place them after `<Gallery>` and before `<Playlist>`.
+
+New article content order:
+1. `<header>` (hero image, title, author/date, tags, description)
+2. `<Markdown>` (body)
+3. `<Gallery>` (image gallery)
+4. `<SoundCloudEmbed>` (moved from header)
+5. `<YouTubeEmbed>` (moved from header)
+6. `<Playlist>` (Spotify — unchanged position)
+7. `<nav>` (prev/next — unchanged position)
+
+### 3. SEO
+
+- Keep `dateModified` in the JSON-LD schema and `article:modified_time` meta tag — these are for search engines, not user-facing
+- No change to any other SEO markup
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `src/pages/post/[slug].tsx` | Move embed JSX from header to after Gallery; restructure `<address>` block to show date on line 1, author on line 2; remove "Last updated" text |
+
+## Not In Scope
+
+- No style changes (existing SCSS handles the layout)
+- No new components
+- No changes to data fetching or props

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -122,7 +122,7 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloud
                     />
                 ) }
                 <span>
-                  Last updated: <DateTimeFormat timestamp={ post.sys.updatedAt } withDayName={ false } />
+                  <DateTimeFormat timestamp={ resolvePostDate( post ) } withDayName={ false } withTime={ false } />
                   <br />
                   {
                     !!authorName &&
@@ -131,7 +131,6 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloud
                           ? <Link rel="author" href={ `/author/${authorSlug}` }>{ authorName }</Link>
                           : authorName
                         }
-                        { ` on ` } <DateTimeFormat timestamp={ resolvePostDate( post ) } />
                       </b>
                   }
                 </span>
@@ -140,11 +139,11 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloud
               <p>
                 { post.fields.description }
               </p>
-              { soundCloudOembed && post.fields.soundcloudUrl && <SoundCloudEmbed oembed={ soundCloudOembed } url={ post.fields.soundcloudUrl } /> }
-              { youTubeOembed && post.fields.youtubeUrl && <YouTubeEmbed oembed={ youTubeOembed } url={ post.fields.youtubeUrl } /> }
             </header>
             <Markdown>{ post.fields.body || "" }</Markdown>
             <Gallery items={ resolveGalleryItems( post.fields.gallery ) } />
+            { soundCloudOembed && post.fields.soundcloudUrl && <SoundCloudEmbed oembed={ soundCloudOembed } url={ post.fields.soundcloudUrl } /> }
+            { youTubeOembed && post.fields.youtubeUrl && <YouTubeEmbed oembed={ youTubeOembed } url={ post.fields.youtubeUrl } /> }
             { playlist && <Playlist playlist={ playlist } /> }
             { ( prevPost || nextPost ) && (
               <nav className={ styles.postNav }>


### PR DESCRIPTION
## Summary
- Remove "Last updated" line from post header — replace with publish date on line 1, "By Author" on line 2
- Move SoundCloud and YouTube embeds from the header to after the Gallery, before the Spotify playlist
- No style changes needed — existing SCSS handles both layouts

## Test plan
- [ ] Verify post header shows date on first line, author on second line (no "Last updated")
- [ ] Verify SoundCloud embed appears after gallery, before Spotify playlist (on posts that have one)
- [ ] Verify YouTube embed appears after gallery, before Spotify playlist (on posts that have one)
- [ ] Verify posts without embeds render normally
- [ ] `yarn lint` and `yarn test` pass