### PR TITLE
feat: UI polish — hover states, tag pills, profile backgrounds, captions

### DIFF
--- a/src/components/Home/BlogPostList.tsx
+++ b/src/components/Home/BlogPostList.tsx
@@ -147,10 +147,12 @@ export default function BlogPostList({ posts, page, tagId }: BlogPostListProps )
                     />
                   </Link>
                   <figcaption>
-                    <Link href={ url }><h3>{ post.fields.title }</h3></Link>
-                    <DateTimeFormat
-                      timestamp={ timestamp }
-                    />
+                    <Link href={ url }>
+                      <h3>{ post.fields.title }</h3>
+                      <DateTimeFormat
+                        timestamp={ timestamp }
+                      />
+                    </Link>
                   </figcaption>
                   <Tags
                     tags={ post.metadata.tags }

--- a/src/styles/Author.module.scss
+++ b/src/styles/Author.module.scss
@@ -14,6 +14,10 @@
         border-radius: 100%;
         border: 0.2rem solid gold;
         flex-shrink: 0;
+        background: #000;
+        @media (prefers-color-scheme: light) {
+          background: #fff;
+        }
       }
 
       > h1 {

--- a/src/styles/BlogPost.module.scss
+++ b/src/styles/BlogPost.module.scss
@@ -11,6 +11,15 @@
     }
   }
 
+  // Remove link effects from tag pills so they match the index page
+  section a {
+    @media (prefers-color-scheme: light) {
+      filter: none;
+      text-shadow: none;
+      color: inherit;
+    }
+  }
+
   .postNav {
     display: flex;
     justify-content: space-between;
@@ -29,6 +38,16 @@
       gap: 0.25rem;
       max-width: 45%;
       text-decoration: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 8px;
+      transition: background 0.15s ease;
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.1);
+        @media (prefers-color-scheme: light) {
+          background: rgba(0, 0, 0, 0.08);
+        }
+      }
 
       > span:first-child {
         font-size: small;
@@ -84,6 +103,10 @@
           border-radius: 100%;
           border: .2rem solid gold;
           margin: 0 .5rem 0 0;
+          background: #000;
+          @media (prefers-color-scheme: light) {
+            background: #fff;
+          }
         }
       }
       > p {

--- a/src/styles/Home.module.scss
+++ b/src/styles/Home.module.scss
@@ -189,6 +189,19 @@ ul.imageGallery {
           text-decoration: none;
         }
       }
+      > figcaption > a {
+        display: block;
+        padding: 0.2rem 0.4rem;
+        border-radius: 6px;
+        transition: background 0.15s ease;
+
+        &:hover {
+          background: rgba(255, 255, 255, 0.15);
+          @media (prefers-color-scheme: light) {
+            background: rgba(0, 0, 0, 0.1);
+          }
+        }
+      }
     }
   }
 

--- a/src/styles/Markdown.module.scss
+++ b/src/styles/Markdown.module.scss
@@ -2,9 +2,18 @@
 
   a {
     color: lightgreen;
+    padding: 0.1rem 0.25rem;
+    border-radius: 4px;
+    transition: background 0.15s ease;
     @media (prefers-color-scheme: light) {
       filter: drop-shadow(.1rem .1rem .1rem black);
       text-shadow: -1px -1px 1px #000, 1px -1px 1px #000, -1px 1px 1px #000, 1px 1px 1px #000;
+    }
+    &:hover {
+      background: rgba(255, 255, 255, 0.1);
+      @media (prefers-color-scheme: light) {
+        background: rgba(0, 0, 0, 0.08);
+      }
     }
   }
 
@@ -38,6 +47,13 @@
         max-width: 100%;
         border: .5rem solid white;
     }
+    > figcaption {
+        font-size: 0.85rem;
+        font-style: italic;
+        opacity: 0.6;
+        text-align: center;
+        margin-top: 0.5rem;
+    }
   }
 
   > video {
@@ -55,6 +71,13 @@
     > p {
       margin-bottom: 1rem;
     }
+  }
+
+  hr {
+    border: none;
+    height: 4px;
+    background: currentColor;
+    margin: 2rem 0;
   }
 
   ul {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -113,6 +113,7 @@ body {
 a {
   color: inherit;
   text-decoration: underline;
+  text-underline-offset: 0.25em;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
- **Hover backgrounds**: subtle background highlight on blog index post titles, markdown inline links, and prev/next post navigation
- **Tag pill fix**: remove inherited `drop-shadow`/`text-shadow` from tag pills on blog post page in light mode, restore readable dark text
- **Profile image backgrounds**: black in dark mode, white in light mode on author avatars (blog post + author pages) for transparent PNGs
- **Markdown figcaptions**: smaller, italic, centered, muted — visually distinct from body text
- **Markdown `<hr>`**: thick solid bar
- **Underline offset**: `text-underline-offset: 0.25em` globally for breathing room
- **Index titles**: date wrapped inside title link for cleaner hover block

## Test plan
- [ ] Hover over post titles on index — should show subtle background
- [ ] Hover over inline links in a blog post — should show subtle background
- [ ] Hover over prev/next nav links — should show subtle background
- [ ] Check tag pills on blog post page in light mode — should have dark text, no shadow artifacts
- [ ] Check author avatar on blog post and author pages with transparent PNG — should have solid background
- [ ] Check markdown figcaptions — should be smaller, italic, centered
- [ ] Check `<hr>` in markdown — should be a thick solid bar
- [ ] Check underlined links — should have spacing between text and underline
- [ ] `yarn lint` and `yarn test` pass