### PR TITLE
fix: use .nvmrc for Node version in Spotify cache workflow

### DIFF
--- a/.github/workflows/refresh-spotify-cache.yml
+++ b/.github/workflows/refresh-spotify-cache.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version-file: '.nvmrc'
           cache: yarn
 
       - name: Install dependencies

--- a/.github/workflows/refresh-spotify-cache.yml
+++ b/.github/workflows/refresh-spotify-cache.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: yarn


### PR DESCRIPTION
## Summary
- The `refresh-spotify-cache.yml` workflow hardcoded `node-version: 24`, which broke after the Node engine requirement was bumped to `>=25.8.1` in `package.json`
- Switched to `node-version-file: '.nvmrc'` to match the other workflows and keep a single source of truth

## Test plan
- [ ] Re-run the Spotify cache refresh workflow and confirm it passes the install step