### PR TITLE
feat: manual SEO config for tag pages

### DIFF
--- a/data/tags.json
+++ b/data/tags.json
@@ -1,0 +1,52 @@
+{
+  "graphics": {
+    "title": "Graphic Design & Visual Art",
+    "description": "Visual art, design projects, and graphic design work featured on Audeos.",
+    "ogImage": null
+  },
+  "merch": {
+    "title": "Merchandise & Store",
+    "description": "Audeos merchandise, limited edition releases, and store updates.",
+    "ogImage": null
+  },
+  "plantlife": {
+    "title": "Plants & Horticulture",
+    "description": "Plant care, gardening, and horticulture content from the Audeos blog.",
+    "ogImage": null
+  },
+  "edits": {
+    "title": "Music Edits & Remixes",
+    "description": "Original music edits, remixes, and custom bootleg versions curated by Audeos.",
+    "ogImage": null
+  },
+  "records": {
+    "title": "Vinyl Records & Discography",
+    "description": "Vinyl record reviews, recommendations, and discography highlights from Audeos.",
+    "ogImage": null
+  },
+  "radio": {
+    "title": "Radio & Broadcast",
+    "description": "Radio shows, broadcasts, and audio programming from Audeos.",
+    "ogImage": null
+  },
+  "technology": {
+    "title": "Music Technology & Gear",
+    "description": "Music production gear, audio technology, and equipment reviews on Audeos.",
+    "ogImage": null
+  },
+  "playlists": {
+    "title": "Curated Playlists",
+    "description": "Hand-curated playlists and listening guides from Audeos.",
+    "ogImage": null
+  },
+  "dj": {
+    "title": "DJ Mixes & Sets",
+    "description": "DJ mixes, live sets, and DJ performance recaps from Audeos.",
+    "ogImage": null
+  },
+  "nightlife": {
+    "title": "Nightlife & Events",
+    "description": "Nightlife coverage, event recaps, and venue highlights from Audeos.",
+    "ogImage": null
+  }
+}

--- a/data/tags.json
+++ b/data/tags.json
@@ -1,52 +1,52 @@
 {
   "graphics": {
     "title": "Graphic Design & Visual Art",
-    "description": "Visual art, design projects, and graphic design work featured on Audeos.",
+    "description": "Visual art, design projects, and graphic design work by DJ Audeos.",
     "ogImage": null
   },
   "merch": {
-    "title": "Merchandise & Store",
-    "description": "Audeos merchandise, limited edition releases, and store updates.",
+    "title": "Merch",
+    "description": "Streetwear designed by DJ Audeos",
     "ogImage": null
   },
   "plantlife": {
     "title": "Plants & Horticulture",
-    "description": "Plant care, gardening, and horticulture content from the Audeos blog.",
+    "description": "Cannabis content from the garden of Audeos",
     "ogImage": null
   },
   "edits": {
     "title": "Music Edits & Remixes",
-    "description": "Original music edits, remixes, and custom bootleg versions curated by Audeos.",
+    "description": "Original music edits, remixes, and custom bootleg versions by DJ Audeos.",
     "ogImage": null
   },
   "records": {
-    "title": "Vinyl Records & Discography",
-    "description": "Vinyl record reviews, recommendations, and discography highlights from Audeos.",
+    "title": "Records",
+    "description": "Music releases produced and written DJ Audeos.",
     "ogImage": null
   },
   "radio": {
-    "title": "Radio & Broadcast",
-    "description": "Radio shows, broadcasts, and audio programming from Audeos.",
+    "title": "Radio",
+    "description": "DJ mix shows and broadcasts from DJ Audeos.",
     "ogImage": null
   },
   "technology": {
-    "title": "Music Technology & Gear",
-    "description": "Music production gear, audio technology, and equipment reviews on Audeos.",
+    "title": "Technology",
+    "description": "Tech blog posts, software engineering, and more.",
     "ogImage": null
   },
   "playlists": {
-    "title": "Curated Playlists",
-    "description": "Hand-curated playlists and listening guides from Audeos.",
+    "title": "Playlists",
+    "description": "Hand-curated playlists from DJ Audeos available on Spotify.",
     "ogImage": null
   },
   "dj": {
-    "title": "DJ Mixes & Sets",
-    "description": "DJ mixes, live sets, and DJ performance recaps from Audeos.",
+    "title": "DJ gigs",
+    "description": "DJ performances and recaps of events featuring DJ Audeos.",
     "ogImage": null
   },
   "nightlife": {
-    "title": "Nightlife & Events",
-    "description": "Nightlife coverage, event recaps, and venue highlights from Audeos.",
+    "title": "Nightlife",
+    "description": "Nightlife promo and recaps of events featuring DJ Audeos.",
     "ogImage": null
   }
 }

--- a/docs/superpowers/plans/2026-04-21-tag-seo-config.md
+++ b/docs/superpowers/plans/2026-04-21-tag-seo-config.md
@@ -1,0 +1,358 @@
+# Tag SEO Config — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace dynamically generated tag page SEO descriptions with manually authored content stored in a local JSON config file.
+
+**Architecture:** A `data/tags.json` file holds per-tag SEO metadata (title, description, ogImage). A TypeScript interface in `src/types/tagConfig.ts` types the config. The existing `getStaticProps` in `src/pages/index.tsx` imports the config, validates every Contentful tag has an entry, and passes the tag's SEO data as a prop. The component uses it for the page title, meta description, and OG image.
+
+**Tech Stack:** Next.js, TypeScript, Vitest
+
+---
+
+### Task 1: Create the TagSeoConfig type
+
+**Files:**
+- Create: `src/types/tagConfig.ts`
+
+- [ ] **Step 1: Create the type file**
+
+```typescript
+export interface TagSeoConfig {
+  title: string
+  description: string
+  ogImage: string | null
+}
+
+export type TagSeoConfigMap = Record<string, TagSeoConfig>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/types/tagConfig.ts
+git commit -m "feat: add TagSeoConfig type for manual tag SEO metadata"
+```
+
+---
+
+### Task 2: Create data/tags.json with placeholder entries
+
+**Files:**
+- Create: `data/tags.json`
+
+We need to know the actual tag IDs from Contentful. Run the dev server or build to see which tags exist — they appear in the tag nav on the home page. Alternatively, check the Contentful dashboard.
+
+- [ ] **Step 1: Create the JSON file**
+
+Create `data/tags.json` with an entry for every tag that exists in Contentful. Example structure (replace with real tag IDs and real SEO copy):
+
+```json
+{
+  "example-tag": {
+    "title": "Example Tag",
+    "description": "Description for example tag pages on Audeos.com.",
+    "ogImage": null
+  }
+}
+```
+
+Every tag ID from Contentful must have an entry. The `ogImage` field should be `null` unless a custom image is desired — `null` falls back to the site-wide `META_IMAGE`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add data/tags.json
+git commit -m "feat: add tag SEO config data file"
+```
+
+---
+
+### Task 3: Write validation test
+
+**Files:**
+- Create: `src/__tests__/utils/tagSeoConfig.test.ts`
+
+- [ ] **Step 1: Write the test for the validation function**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { validateTagSeoConfig } from "@/utils/tagSeoConfig";
+import { TagSeoConfigMap } from "@/types/tagConfig";
+
+describe( "validateTagSeoConfig", () => {
+  it( "returns the config for a tag ID that exists in the config", () => {
+    const config: TagSeoConfigMap = {
+      jazz: {
+        title: "Jazz Music",
+        description: "Jazz posts on Audeos.com",
+        ogImage: null,
+      },
+    };
+    const tagIds = ["jazz"];
+
+    const result = validateTagSeoConfig( config, tagIds );
+
+    expect( result ).toEqual( config );
+  });
+
+  it( "throws when a tag ID is missing from the config", () => {
+    const config: TagSeoConfigMap = {
+      jazz: {
+        title: "Jazz Music",
+        description: "Jazz posts on Audeos.com",
+        ogImage: null,
+      },
+    };
+    const tagIds = ["jazz", "ambient"];
+
+    expect( () => validateTagSeoConfig( config, tagIds ) ).toThrowError(
+      'Tag "ambient" exists in Contentful but is missing from data/tags.json'
+    );
+  });
+
+  it( "passes when config has extra entries not in Contentful", () => {
+    const config: TagSeoConfigMap = {
+      jazz: {
+        title: "Jazz Music",
+        description: "Jazz posts on Audeos.com",
+        ogImage: null,
+      },
+      ambient: {
+        title: "Ambient Music",
+        description: "Ambient posts on Audeos.com",
+        ogImage: null,
+      },
+    };
+    const tagIds = ["jazz"];
+
+    const result = validateTagSeoConfig( config, tagIds );
+
+    expect( result ).toEqual( config );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test src/__tests__/utils/tagSeoConfig.test.ts`
+Expected: FAIL — `validateTagSeoConfig` does not exist yet.
+
+- [ ] **Step 3: Commit failing test**
+
+```bash
+git add src/__tests__/utils/tagSeoConfig.test.ts
+git commit -m "test: add failing tests for tag SEO config validation"
+```
+
+---
+
+### Task 4: Implement validation function
+
+**Files:**
+- Create: `src/utils/tagSeoConfig.ts`
+
+- [ ] **Step 1: Implement validateTagSeoConfig**
+
+```typescript
+import { TagSeoConfigMap } from "@/types/tagConfig";
+
+export function validateTagSeoConfig(
+  config: TagSeoConfigMap,
+  contentfulTagIds: string[]
+): TagSeoConfigMap {
+  for( const tagId of contentfulTagIds ) {
+    if( !( tagId in config ) ) {
+      throw new Error(
+        `Tag "${tagId}" exists in Contentful but is missing from data/tags.json`
+      );
+    }
+  }
+  return config;
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `yarn test src/__tests__/utils/tagSeoConfig.test.ts`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `yarn test`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/tagSeoConfig.ts
+git commit -m "feat: implement tag SEO config validation"
+```
+
+---
+
+### Task 5: Integrate tag SEO config into index.tsx
+
+**Files:**
+- Modify: `src/pages/index.tsx`
+
+This is the main integration task. Read the current file before editing.
+
+- [ ] **Step 1: Add imports and remove buildTagDescription**
+
+At the top of `src/pages/index.tsx`:
+
+1. Add these imports:
+   ```typescript
+   import { TagSeoConfig } from "@/types/tagConfig";
+   import tagSeoConfigData from "../../data/tags.json";
+   import { TagSeoConfigMap } from "@/types/tagConfig";
+   import { validateTagSeoConfig } from "@/utils/tagSeoConfig";
+   ```
+
+2. Remove the `capitalize` import:
+   ```typescript
+   // REMOVE this line:
+   import { capitalize } from "@/utils/stringUtils";
+   ```
+
+3. Remove the entire `buildTagDescription` function (lines 16-21).
+
+- [ ] **Step 2: Update HomeProps interface**
+
+Change `HomeProps` to include the tag SEO config instead of relying on the tag ID for label generation:
+
+```typescript
+export interface HomeProps {
+  posts: BlogPosts
+  tags: TagCollection
+  page: number
+  tagId?: string
+  tagSeoConfig?: TagSeoConfig
+}
+```
+
+- [ ] **Step 3: Update the Home component**
+
+Replace the tag label, page title, page description, and OG image logic:
+
+```typescript
+export default function Home({ posts, page, tags, tagId, tagSeoConfig }: HomeProps ) {
+  const filteredBlogPosts = posts.items
+    .filter( post => tagId === null || post.metadata.tags
+      .find( tag => tag.sys.id === tagId ) );
+
+  const isTagPage = Boolean( tagId );
+  const isPaginated = page > 1;
+
+  const tagLabel = tagSeoConfig?.title ?? "";
+
+  const pageTitle = isTagPage && isPaginated
+    ? `${tagLabel} — Page ${page} | Audeos.com`
+    : isTagPage
+      ? `${tagLabel} | Audeos.com`
+      : isPaginated
+        ? `Blog — Page ${page} | ${META_TITLE}`
+        : META_TITLE;
+
+  const pageDescription = isTagPage && tagSeoConfig
+    ? tagSeoConfig.description
+    : META_DESCRIPTION;
+
+  const ogImage = isTagPage && tagSeoConfig?.ogImage
+    ? tagSeoConfig.ogImage
+    : META_IMAGE;
+
+  // ... canonicalUrl logic stays the same ...
+```
+
+Update the `<SeoHead>` component to use `ogImage`:
+
+```typescript
+<SeoHead
+  title={ pageTitle }
+  canonicalUrl={ canonicalUrl }
+  description={ pageDescription }
+  ogImage={ ogImage }
+>
+```
+
+- [ ] **Step 4: Update getStaticProps**
+
+```typescript
+export async function getStaticProps( context: GetStaticPropsContext ) {
+  const tagId = context.params?.tagId || null;
+  const page: number = Number( context.params?.page ) || 1;
+  const tags = await getTags();
+  const posts = await getBlogPosts();
+
+  const tagConfig = tagSeoConfigData satisfies TagSeoConfigMap;
+  const contentfulTagIds = tags.items.map( tag => tag.sys.id );
+  validateTagSeoConfig( tagConfig, contentfulTagIds );
+
+  const tagSeoConfig = tagId ? tagConfig[tagId] : null;
+
+  if( !tagId && page === 1 ) {
+    generateFeeds( posts.items );
+  }
+  return {
+    props: {
+      tagId,
+      posts,
+      tags,
+      page,
+      tagSeoConfig,
+    },
+  };
+}
+```
+
+Note: `satisfies TagSeoConfigMap` ensures the JSON conforms to the type at build time without using an `as` assertion.
+
+- [ ] **Step 5: Run format and lint**
+
+Run: `yarn format && yarn lint`
+Expected: No errors. Fix any formatting issues.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `yarn test`
+Expected: All tests pass.
+
+- [ ] **Step 7: Run build**
+
+Run: `yarn build`
+Expected: Build succeeds. Verify that the tag pages are generated without errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pages/index.tsx
+git commit -m "feat: use manual tag SEO config for title, description, and OG image"
+```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Run the dev server and verify tag pages**
+
+Run: `yarn dev`
+
+1. Visit a tag page (e.g., `http://localhost:3000/tags/jazz`)
+2. Inspect the page source — confirm `<title>`, `<meta name="description">`, and `<meta property="og:image">` use the values from `data/tags.json`
+3. Visit the home page — confirm it still uses the default `META_DESCRIPTION` and `META_IMAGE`
+
+- [ ] **Step 2: Run all checks**
+
+Run: `yarn format && yarn lint && yarn test && yarn build`
+Expected: All pass.
+
+- [ ] **Step 3: Commit any remaining changes**
+
+If `yarn format` changed anything, commit it:
+
+```bash
+git add -A
+git commit -m "style: format"
+```

--- a/docs/superpowers/specs/2026-04-21-tag-seo-config-design.md
+++ b/docs/superpowers/specs/2026-04-21-tag-seo-config-design.md
@@ -1,0 +1,96 @@
+# Tag SEO Config — Design Spec
+
+## Problem
+
+Tag pages currently use dynamically generated meta descriptions like:
+> "5 Jazz posts on Audeos.com — including Title A, Title B, Title C"
+
+These are formulaic and don't convey the editorial voice of the site. Manual control over SEO metadata per tag allows for more intentional, higher-quality descriptions.
+
+## Solution
+
+Store per-tag SEO configuration in a local JSON file (`data/tags.json`). Each tag gets a custom title label, meta description, and optional OG image. The build validates that every Contentful tag has a corresponding entry in the config — missing entries fail the build.
+
+## Data File
+
+**`data/tags.json`** — flat object keyed by Contentful tag ID:
+
+```json
+{
+  "jazz": {
+    "title": "Jazz Music",
+    "description": "Explore jazz DJ mixes, album reviews, and curated playlists.",
+    "ogImage": "https://www.audeos.com/images/jazz.jpg"
+  },
+  "electronic": {
+    "title": "Electronic Music",
+    "description": "Electronic music mixes, production insights, and artist spotlights.",
+    "ogImage": null
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Required | Purpose |
+|---|---|---|---|
+| `title` | `string` | Yes | Label portion of the page title. Code appends ` \| Audeos.com` or ` — Page N \| Audeos.com`. |
+| `description` | `string` | Yes | Meta description for SEO (also used for OG/Twitter descriptions). |
+| `ogImage` | `string \| null` | Yes | Custom OG image URL. Falls back to `META_IMAGE` when `null`. |
+
+## Type Definition
+
+**New file: `src/types/tagConfig.ts`**
+
+```typescript
+export interface TagSeoConfig {
+  title: string
+  description: string
+  ogImage: string | null
+}
+
+export type TagSeoConfigMap = Record<string, TagSeoConfig>
+```
+
+## Build-Time Validation
+
+In `getStaticProps` (`src/pages/index.tsx`), after fetching tags from Contentful:
+
+1. Import `data/tags.json` and cast to `TagSeoConfigMap`.
+2. For each tag returned by `getTags()`, assert that `tags.json` contains a matching key.
+3. If a tag is missing, throw an error:
+   > `Tag "ambient" exists in Contentful but is missing from data/tags.json`
+
+This ensures the build fails fast when a new tag is added to the CMS but not configured locally.
+
+## Changes to `src/pages/index.tsx`
+
+### Removed
+
+- `buildTagDescription()` function
+- `capitalize` import (if unused elsewhere)
+
+### Modified — `getStaticProps`
+
+- Import `tagSeoConfig` from `data/tags.json`
+- Validate all Contentful tags have config entries
+- Pass the matching `TagSeoConfig` (or `null` for non-tag pages) as a prop
+
+### Modified — `Home` component
+
+- `pageTitle`: uses `tagConfig.title` for the label portion (replaces `capitalize(tagId)`)
+- `pageDescription`: uses `tagConfig.description` directly (replaces `buildTagDescription()`)
+- `ogImage` prop on `<SeoHead>`: uses `tagConfig.ogImage ?? META_IMAGE`
+
+### Unchanged
+
+- Tag nav labels in `<nav>` continue to render `tag.sys.id` as-is
+- `[tagId].tsx` and `[tagId]/page/[page].tsx` are unchanged (they delegate to the shared `getStaticProps`)
+
+## Files Changed
+
+| File | Action |
+|---|---|
+| `data/tags.json` | **Create** — SEO config per tag |
+| `src/types/tagConfig.ts` | **Create** — TypeScript interfaces |
+| `src/pages/index.tsx` | **Modify** — remove dynamic description, use config, validate |

--- a/src/__tests__/utils/tagSeoConfig.test.ts
+++ b/src/__tests__/utils/tagSeoConfig.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { validateTagSeoConfig } from "@/utils/tagSeoConfig";
+import { TagSeoConfigMap } from "@/types/tagConfig";
+
+describe( "validateTagSeoConfig", () => {
+  it( "returns the config for a tag ID that exists in the config", () => {
+    const config: TagSeoConfigMap = {
+      jazz: {
+        title: "Jazz Music",
+        description: "Jazz posts on Audeos.com",
+        ogImage: null,
+      },
+    };
+    const tagIds = ["jazz"];
+
+    const result = validateTagSeoConfig( config, tagIds );
+
+    expect( result ).toEqual( config );
+  });
+
+  it( "throws when a tag ID is missing from the config", () => {
+    const config: TagSeoConfigMap = {
+      jazz: {
+        title: "Jazz Music",
+        description: "Jazz posts on Audeos.com",
+        ogImage: null,
+      },
+    };
+    const tagIds = ["jazz", "ambient"];
+
+    expect( () => validateTagSeoConfig( config, tagIds ) ).toThrowError(
+      'Tag "ambient" exists in Contentful but is missing from data/tags.json'
+    );
+  });
+
+  it( "passes when config has extra entries not in Contentful", () => {
+    const config: TagSeoConfigMap = {
+      jazz: {
+        title: "Jazz Music",
+        description: "Jazz posts on Audeos.com",
+        ogImage: null,
+      },
+      ambient: {
+        title: "Ambient Music",
+        description: "Ambient posts on Audeos.com",
+        ogImage: null,
+      },
+    };
+    const tagIds = ["jazz"];
+
+    const result = validateTagSeoConfig( config, tagIds );
+
+    expect( result ).toEqual( config );
+  });
+});

--- a/src/__tests__/utils/tagSeoConfig.test.ts
+++ b/src/__tests__/utils/tagSeoConfig.test.ts
@@ -11,7 +11,7 @@ describe( "validateTagSeoConfig", () => {
         ogImage: null,
       },
     };
-    const tagIds = ["jazz"];
+    const tagIds = [ "jazz" ];
 
     const result = validateTagSeoConfig( config, tagIds );
 
@@ -26,10 +26,10 @@ describe( "validateTagSeoConfig", () => {
         ogImage: null,
       },
     };
-    const tagIds = ["jazz", "ambient"];
+    const tagIds = [ "jazz", "ambient" ];
 
     expect( () => validateTagSeoConfig( config, tagIds ) ).toThrowError(
-      'Tag "ambient" exists in Contentful but is missing from data/tags.json'
+      'Tag "ambient" exists in Contentful but is missing from data/tags.json',
     );
   });
 
@@ -46,7 +46,7 @@ describe( "validateTagSeoConfig", () => {
         ogImage: null,
       },
     };
-    const tagIds = ["jazz"];
+    const tagIds = [ "jazz" ];
 
     const result = validateTagSeoConfig( config, tagIds );
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -111,7 +111,7 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
   const tags = await getTags();
   const posts = await getBlogPosts();
 
-  const tagConfig: TagSeoConfigMap = tagSeoConfigData satisfies TagSeoConfigMap;
+  const tagConfig = tagSeoConfigData satisfies TagSeoConfigMap;
   const contentfulTagIds = tags.items.map( tag => tag.sys.id );
   validateTagSeoConfig( tagConfig, contentfulTagIds );
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -111,7 +111,7 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
   const tags = await getTags();
   const posts = await getBlogPosts();
 
-  const tagConfig = tagSeoConfigData satisfies TagSeoConfigMap;
+  const tagConfig: TagSeoConfigMap = tagSeoConfigData satisfies TagSeoConfigMap;
   const contentfulTagIds = tags.items.map( tag => tag.sys.id );
   validateTagSeoConfig( tagConfig, contentfulTagIds );
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import styles from "@/styles/Home.module.scss";
-import { BlogPost, BlogPosts, getBlogPosts, getTags } from "@/utils/contentfulUtils";
+import { BlogPosts, getBlogPosts, getTags } from "@/utils/contentfulUtils";
 import BlogPostList from "@/components/Home/BlogPostList";
 import { Layout } from "@/components/Layout/Layout";
 import { TagCollection } from "contentful";
@@ -9,25 +9,20 @@ import { GetStaticPropsContext } from "next";
 import Pagination from "@/components/Home/Pagination";
 import { generateFeeds } from "@/lib/generateFeeds";
 import { META_DESCRIPTION, META_IMAGE, META_TITLE, SITE_URL } from "@/constants";
-import { capitalize } from "@/utils/stringUtils";
 import { SeoHead } from "@/components/SeoHead";
-
-
-function buildTagDescription( tagLabel: string, posts: BlogPost[] ): string {
-  const count = posts.length;
-  const recentTitles = posts.slice( 0, 3 ).map( post => post.fields.title );
-  const titleList = recentTitles.join( ", " );
-  return `${count} ${tagLabel} posts on Audeos.com — including ${titleList}`;
-}
+import { TagSeoConfig, TagSeoConfigMap } from "@/types/tagConfig";
+import tagSeoConfigData from "../../data/tags.json";
+import { validateTagSeoConfig } from "@/utils/tagSeoConfig";
 
 export interface HomeProps {
   posts: BlogPosts
   tags: TagCollection
   page: number
   tagId?: string
+  tagSeoConfig?: TagSeoConfig
 }
 
-export default function Home({ posts, page, tags, tagId }: HomeProps ) {
+export default function Home({ posts, page, tags, tagId, tagSeoConfig }: HomeProps ) {
   const filteredBlogPosts = posts.items
     .filter( post => tagId === null || post.metadata.tags
       .find( tag => tag.sys.id === tagId ) );
@@ -35,7 +30,7 @@ export default function Home({ posts, page, tags, tagId }: HomeProps ) {
   const isTagPage = Boolean( tagId );
   const isPaginated = page > 1;
 
-  const tagLabel = tagId ? capitalize( tagId ) : "";
+  const tagLabel = tagSeoConfig?.title ?? "";
 
   const pageTitle = isTagPage && isPaginated
     ? `${tagLabel} — Page ${page} | Audeos.com`
@@ -45,9 +40,13 @@ export default function Home({ posts, page, tags, tagId }: HomeProps ) {
         ? `Blog — Page ${page} | ${META_TITLE}`
         : META_TITLE;
 
-  const pageDescription = isTagPage
-    ? buildTagDescription( tagLabel, filteredBlogPosts )
+  const pageDescription = isTagPage && tagSeoConfig
+    ? tagSeoConfig.description
     : META_DESCRIPTION;
+
+  const ogImage = isTagPage && tagSeoConfig?.ogImage
+    ? tagSeoConfig.ogImage
+    : META_IMAGE;
 
   const canonicalUrl = isTagPage && isPaginated
     ? `${SITE_URL}/tags/${tagId}/page/${page}`
@@ -63,7 +62,7 @@ export default function Home({ posts, page, tags, tagId }: HomeProps ) {
         title={ pageTitle }
         canonicalUrl={ canonicalUrl }
         description={ pageDescription }
-        ogImage={ META_IMAGE }
+        ogImage={ ogImage }
       >
         <link rel="alternate" type="application/rss+xml" href="/rss.xml" />
         <link rel="alternate" type="application/atom+xml" href="/atom.xml" />
@@ -111,6 +110,14 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
   const page: number = Number( context.params?.page ) || 1;
   const tags = await getTags();
   const posts = await getBlogPosts();
+
+  const tagConfig: TagSeoConfigMap = tagSeoConfigData satisfies TagSeoConfigMap;
+  const contentfulTagIds = tags.items.map( tag => tag.sys.id );
+  validateTagSeoConfig( tagConfig, contentfulTagIds );
+
+  const resolvedTagId = Array.isArray( tagId ) ? tagId[0] : tagId;
+  const tagSeoConfig = resolvedTagId ? tagConfig[resolvedTagId] : null;
+
   if( !tagId && page === 1 ) {
     generateFeeds( posts.items );
   }
@@ -120,6 +127,7 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
       posts,
       tags,
       page,
+      tagSeoConfig,
     },
   };
 }

--- a/src/types/tagConfig.ts
+++ b/src/types/tagConfig.ts
@@ -1,0 +1,7 @@
+export interface TagSeoConfig {
+  title: string
+  description: string
+  ogImage: string | null
+}
+
+export type TagSeoConfigMap = Record<string, TagSeoConfig>

--- a/src/utils/tagSeoConfig.ts
+++ b/src/utils/tagSeoConfig.ts
@@ -1,0 +1,15 @@
+import { TagSeoConfigMap } from "@/types/tagConfig";
+
+export function validateTagSeoConfig(
+  config: TagSeoConfigMap,
+  contentfulTagIds: string[],
+): TagSeoConfigMap {
+  for( const tagId of contentfulTagIds ) {
+    if( !( tagId in config ) ) {
+      throw new Error(
+        `Tag "${tagId}" exists in Contentful but is missing from data/tags.json`,
+      );
+    }
+  }
+  return config;
+}


### PR DESCRIPTION
## Summary

- Replaces dynamically generated tag page meta descriptions with manually authored SEO content stored in `data/tags.json`
- Each tag now has a custom `title`, `description`, and optional `ogImage` field for full SEO control
- Build-time validation ensures every Contentful tag has a corresponding entry in the config — missing entries fail the build

## Changes

| File | What |
|---|---|
| `data/tags.json` | SEO config for all 10 tags |
| `src/types/tagConfig.ts` | `TagSeoConfig` interface + `TagSeoConfigMap` type |
| `src/utils/tagSeoConfig.ts` | `validateTagSeoConfig()` — fails build on missing tags |
| `src/__tests__/utils/tagSeoConfig.test.ts` | 3 tests for validation logic |
| `src/pages/index.tsx` | Wired up config for title, description, and OG image |

## Test plan

- [x] 120 unit tests pass (`yarn test`)
- [x] TypeScript typecheck passes (`yarn lint`)
- [x] Production build succeeds (`yarn build`)
- [ ] Verify tag page meta tags in browser (view source on `/tags/dj`)
- [ ] Replace placeholder descriptions in `data/tags.json` with final copy