### PR TITLE
feat: TikTok oEmbed video embedding for blog posts

### DIFF
--- a/.claude/skills/new-post/SKILL.md
+++ b/.claude/skills/new-post/SKILL.md
@@ -65,6 +65,7 @@ Collect or derive all required fields. Show each to the user for approval:
 | **spotifyPlaylistId** | Ask if they want to embed a Spotify playlist (yes/no). Skip if no. |
 | **soundcloudUrl** | Ask if they want to embed a SoundCloud track or playlist (yes/no). If yes, collect the full SoundCloud URL. Skip if no. |
 | **youtubeUrl** | Ask if they want to embed a YouTube video (yes/no). If yes, collect the full YouTube URL. Skip if no. |
+| **tiktokUrl** | Ask if they want to embed a TikTok video (yes/no). If yes, collect the full TikTok URL. Fetch oEmbed data via `curl -s "https://www.tiktok.com/oembed?format=json&url=<encoded-url>"` to get the title and thumbnail. Offer to use the TikTok thumbnail as the featured image — download it with `curl -o`, rename to a descriptive filename, and upload via `make upload-images`. |
 | **location** | Ask if they want to add a location (yes/no). Skip if no. |
 
 ## SEO Check
@@ -147,7 +148,8 @@ Use `mcp__contentful__create_entry` with:
     "gallery": { "en-US": [{ "sys": { "type": "Link", "linkType": "Asset", "id": "<assetId>" } }] },
     "spotifyPlaylistId": { "en-US": "<playlistId>" },
     "soundcloudUrl": { "en-US": "<soundcloudUrl>" },
-    "youtubeUrl": { "en-US": "<youtubeUrl>" }
+    "youtubeUrl": { "en-US": "<youtubeUrl>" },
+    "tiktokUrl": { "en-US": "<tiktokUrl>" }
   },
   "metadata": {
     "tags": [{ "sys": { "type": "Link", "linkType": "Tag", "id": "<tagId>" } }]
@@ -155,7 +157,7 @@ Use `mcp__contentful__create_entry` with:
 }
 ```
 
-Omit optional fields that were not provided (gallery, spotifyPlaylistId, soundcloudUrl, youtubeUrl, location). Tags go in `metadata`, not `fields`.
+Omit optional fields that were not provided (gallery, spotifyPlaylistId, soundcloudUrl, youtubeUrl, tiktokUrl, location). Tags go in `metadata`, not `fields`.
 
 If the user chose **publish immediately**, follow up with `mcp__contentful__publish_entry`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Commands
 
+**Do not start the dev server** — the user typically runs `yarn dev` themselves in a separate terminal. Never launch it from Claude Code.
+
 ```bash
 yarn dev          # Start development server
 yarn build        # Build for production (postbuild runs next-sitemap automatically)

--- a/docs/superpowers/plans/2026-04-24-tiktok-embed.md
+++ b/docs/superpowers/plans/2026-04-24-tiktok-embed.md
@@ -1,0 +1,554 @@
+# TikTok oEmbed Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add TikTok video embedding to blog posts using TikTok's oEmbed API with client-side script hydration.
+
+**Architecture:** Build-time oEmbed fetch in `getStaticProps`, static blockquote HTML rendered into the page, TikTok's `embed.js` loaded client-side via `useEffect` to hydrate the player. Follows the existing YouTube/SoundCloud embed pattern.
+
+**Tech Stack:** Next.js (static export), React, TypeScript, Vitest, Contentful CMS, SCSS modules
+
+**Security note:** `dangerouslySetInnerHTML` is used to render oEmbed HTML fetched at build time from TikTok's official oEmbed API — a trusted first-party source. This is the same trust model used by the existing YouTube and SoundCloud embed components. The HTML is never sourced from user input.
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/utils/tiktok/getOembed.ts` | Fetch TikTok oEmbed data at build time |
+| Create | `src/utils/tiktok/getOembed.test.ts` | Unit tests for oEmbed fetch utility |
+| Create | `src/components/TikTokEmbed.tsx` | Render TikTok embed with client-side script loading |
+| Create | `src/__tests__/components/TikTokEmbed.test.tsx` | Unit tests for embed component |
+| Create | `src/styles/TikTokEmbed.module.scss` | Embed styles |
+| Modify | `src/pages/post/[slug].tsx` | Wire up TikTok oEmbed fetch, props, and rendering |
+| Modify | `src/__tests__/pages/post/slug.test.tsx` | Add TikTok oEmbed tests for `getStaticProps` |
+
+---
+
+### Task 1: Add `tiktokUrl` field to Contentful and regenerate types
+
+**Files:**
+- Modify: Contentful BlogPost content type (via Contentful MCP or web UI)
+- Regenerate: `src/types/contentful/TypeBlogPost.ts` (via `make types`)
+
+- [ ] **Step 1: Add the `tiktokUrl` field to the BlogPost content type in Contentful**
+
+Use the Contentful MCP tool `update_content_type` to add a new optional field:
+- Field ID: `tiktokUrl`
+- Display name: `TikTok URL`
+- Type: Symbol (short text)
+- Required: false
+- Validation: URL pattern matching `https://www.tiktok.com/` or `https://vm.tiktok.com/`
+
+To do this, first fetch the current BlogPost content type with `get_content_type`, then call `update_content_type` with the existing fields plus the new `tiktokUrl` field appended. Do NOT remove or reorder existing fields.
+
+- [ ] **Step 2: Regenerate TypeScript types**
+
+Run: `make types`
+Expected: `src/types/contentful/TypeBlogPost.ts` now includes a `tiktokUrl` field:
+```typescript
+tiktokUrl?: EntryFieldTypes.Symbol;
+```
+
+- [ ] **Step 3: Verify the build still passes**
+
+Run: `yarn typecheck`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/contentful/
+git commit -m "feat: add tiktokUrl field to BlogPost content type"
+```
+
+---
+
+### Task 2: Create TikTok oEmbed fetch utility with tests
+
+**Files:**
+- Create: `src/utils/tiktok/getOembed.ts`
+- Create: `src/utils/tiktok/getOembed.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/utils/tiktok/getOembed.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal( "fetch", mockFetch );
+
+import { getOembed, TikTokOembed } from "./getOembed";
+
+const TIKTOK_VIDEO_URL = "https://www.tiktok.com/@testuser/video/1234567890";
+
+const MOCK_OEMBED_RESPONSE: TikTokOembed = {
+  title: "Test TikTok Video",
+  author_name: "testuser",
+  author_url: "https://www.tiktok.com/@testuser",
+  html: '<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@testuser/video/1234567890"><section>Test content</section></blockquote><script async src="https://www.tiktok.com/embed.js"></script>',
+  thumbnail_url: "https://p16-sign.tiktokcdn.com/obj/test-thumbnail.jpg",
+};
+
+describe( "getOembed", () => {
+  beforeEach( () => {
+    vi.resetAllMocks();
+  });
+
+  it( "fetches oEmbed data for a valid TikTok URL", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve( MOCK_OEMBED_RESPONSE ),
+    });
+
+    const result = await getOembed( TIKTOK_VIDEO_URL );
+
+    expect( mockFetch ).toHaveBeenCalledWith(
+      `https://www.tiktok.com/oembed?format=json&url=${encodeURIComponent( TIKTOK_VIDEO_URL )}`,
+    );
+    expect( result ).toEqual( MOCK_OEMBED_RESPONSE );
+  });
+
+  it( "returns null when the fetch fails", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const result = await getOembed( TIKTOK_VIDEO_URL );
+
+    expect( result ).toBeNull();
+  });
+
+  it( "returns null when fetch throws a network error", async () => {
+    mockFetch.mockRejectedValueOnce( new Error( "Network error" ) );
+
+    const result = await getOembed( TIKTOK_VIDEO_URL );
+
+    expect( result ).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test src/utils/tiktok/getOembed.test.ts`
+Expected: FAIL — module `./getOembed` not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/utils/tiktok/getOembed.ts`:
+
+```typescript
+export interface TikTokOembed {
+  title: string;
+  author_name: string;
+  author_url: string;
+  html: string;
+  thumbnail_url: string;
+}
+
+const OEMBED_ENDPOINT = "https://www.tiktok.com/oembed";
+
+export async function getOembed( tiktokUrl: string ): Promise<TikTokOembed | null> {
+  const url = `${OEMBED_ENDPOINT}?format=json&url=${encodeURIComponent( tiktokUrl )}`;
+
+  try {
+    const response = await fetch( url );
+
+    if( !response.ok ) {
+      return null;
+    }
+
+    const data: TikTokOembed = await response.json();
+    return data;
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `yarn test src/utils/tiktok/getOembed.test.ts`
+Expected: 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/tiktok/
+git commit -m "feat: add TikTok oEmbed fetch utility"
+```
+
+---
+
+### Task 3: Create TikTokEmbed component with tests
+
+**Files:**
+- Create: `src/components/TikTokEmbed.tsx`
+- Create: `src/__tests__/components/TikTokEmbed.test.tsx`
+- Create: `src/styles/TikTokEmbed.module.scss`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/__tests__/components/TikTokEmbed.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock( "next/link", () => ({
+  default: ({ children, href, ...props }: React.ComponentProps<"a"> ) => (
+    <a href={ href } { ...props }>{ children }</a>
+  ),
+}) );
+
+import { TikTokEmbed } from "@/components/TikTokEmbed";
+import { TikTokOembed } from "@/utils/tiktok/getOembed";
+
+const MOCK_TIKTOK_URL = "https://www.tiktok.com/@testuser/video/1234567890";
+
+const MOCK_OEMBED: TikTokOembed = {
+  title: "Test TikTok Video",
+  author_name: "testuser",
+  author_url: "https://www.tiktok.com/@testuser",
+  html: '<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@testuser/video/1234567890"><section>Test content</section></blockquote>',
+  thumbnail_url: "https://p16-sign.tiktokcdn.com/obj/test-thumbnail.jpg",
+};
+
+describe( "TikTokEmbed", () => {
+  it( "renders the oEmbed HTML content", () => {
+    render( <TikTokEmbed oembed={ MOCK_OEMBED } url={ MOCK_TIKTOK_URL } /> );
+
+    expect( screen.getByText( "Test content" ) ).toBeInTheDocument();
+  });
+
+  it( "renders the video title as a link to the TikTok URL that opens in a new tab", () => {
+    render( <TikTokEmbed oembed={ MOCK_OEMBED } url={ MOCK_TIKTOK_URL } /> );
+
+    const titleLink = screen.getByRole( "link", { name: /Test TikTok Video/i });
+    expect( titleLink ).toHaveAttribute( "href", MOCK_TIKTOK_URL );
+    expect( titleLink ).toHaveAttribute( "target", "_blank" );
+    expect( titleLink ).toHaveAttribute( "rel", "noopener noreferrer" );
+  });
+
+  it( "renders a TikTok link to the author profile that opens in a new tab", () => {
+    render( <TikTokEmbed oembed={ MOCK_OEMBED } url={ MOCK_TIKTOK_URL } /> );
+
+    const tiktokLink = screen.getByRole( "link", { name: /TikTok/i });
+    expect( tiktokLink ).toHaveAttribute( "href", "https://www.tiktok.com/@testuser" );
+    expect( tiktokLink ).toHaveAttribute( "target", "_blank" );
+  });
+
+  it( "appends the TikTok embed.js script to the container on mount", () => {
+    render( <TikTokEmbed oembed={ MOCK_OEMBED } url={ MOCK_TIKTOK_URL } /> );
+
+    const script = document.querySelector( 'script[src="https://www.tiktok.com/embed.js"]' );
+    expect( script ).not.toBeNull();
+  });
+
+  it( "removes the script on unmount", () => {
+    const { unmount } = render( <TikTokEmbed oembed={ MOCK_OEMBED } url={ MOCK_TIKTOK_URL } /> );
+
+    unmount();
+
+    const script = document.querySelector( 'script[src="https://www.tiktok.com/embed.js"]' );
+    expect( script ).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test src/__tests__/components/TikTokEmbed.test.tsx`
+Expected: FAIL — module `@/components/TikTokEmbed` not found.
+
+- [ ] **Step 3: Create the SCSS module**
+
+Create `src/styles/TikTokEmbed.module.scss`:
+
+```scss
+section.tiktokEmbed {
+  margin-top: 2rem;
+  margin-bottom: 4rem;
+}
+
+.tiktokHeader {
+  margin-bottom: 1rem;
+}
+
+.embedContainer {
+  display: flex;
+  justify-content: center;
+}
+```
+
+- [ ] **Step 4: Write the component implementation**
+
+Create `src/components/TikTokEmbed.tsx`. Note: `dangerouslySetInnerHTML` is used here to render oEmbed HTML fetched at build time from TikTok's official API — this is a trusted first-party source, not user input. This is the same trust model used by the existing YouTube and SoundCloud embed components.
+
+```tsx
+import { FC, useEffect, useRef } from "react";
+import Link from "next/link";
+import { TikTokOembed } from "@/utils/tiktok/getOembed";
+import styles from "@/styles/TikTokEmbed.module.scss";
+
+export interface TikTokEmbedProps {
+  oembed: TikTokOembed;
+  url: string;
+}
+
+const TIKTOK_EMBED_SCRIPT_SRC = "https://www.tiktok.com/embed.js";
+
+export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, url }) => {
+  const containerRef = useRef<HTMLDivElement>( null );
+
+  useEffect( () => {
+    const container = containerRef.current;
+    if( !container ) {
+      return;
+    }
+
+    const script = document.createElement( "script" );
+    script.src = TIKTOK_EMBED_SCRIPT_SRC;
+    script.async = true;
+    container.appendChild( script );
+
+    return () => {
+      script.remove();
+    };
+  }, [] );
+
+  return (
+    <section className={ styles.tiktokEmbed }>
+      <header className={ styles.tiktokHeader }>
+        <h2>
+          Watch &quot;<Link
+            href={ url }
+            target="_blank"
+            rel="noopener noreferrer"
+          >{ oembed.title }</Link>&quot; on{ " " }
+          <Link
+            href={ oembed.author_url }
+            target="_blank"
+            rel="noopener noreferrer"
+          >TikTok</Link>
+        </h2>
+      </header>
+      <div
+        ref={ containerRef }
+        className={ styles.embedContainer }
+        dangerouslySetInnerHTML={ { __html: oembed.html } }
+      />
+    </section>
+  );
+};
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `yarn test src/__tests__/components/TikTokEmbed.test.tsx`
+Expected: 5 tests PASS.
+
+- [ ] **Step 6: Run lint and format**
+
+Run: `yarn format`
+Expected: No errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/TikTokEmbed.tsx src/__tests__/components/TikTokEmbed.test.tsx src/styles/TikTokEmbed.module.scss
+git commit -m "feat: add TikTokEmbed component with client-side script hydration"
+```
+
+---
+
+### Task 4: Integrate TikTok embed into the post page
+
+**Files:**
+- Modify: `src/pages/post/[slug].tsx:1-22` (imports), `src/pages/post/[slug].tsx:34-41` (props), `src/pages/post/[slug].tsx:143-146` (render), `src/pages/post/[slug].tsx:186-194` (getStaticProps), `src/pages/post/[slug].tsx:215-224` (return props)
+- Modify: `src/__tests__/pages/post/slug.test.tsx` (add TikTok test block)
+
+- [ ] **Step 1: Write the failing tests for getStaticProps TikTok integration**
+
+Add to `src/__tests__/pages/post/slug.test.tsx`. First, add the TikTok mock at the top alongside the other mocks:
+
+After the existing `vi.mock( "@/utils/youtube/getOembed", ... )` line, add:
+```typescript
+vi.mock( "@/utils/tiktok/getOembed", () => ({
+  getOembed: vi.fn(),
+}) );
+```
+
+After the existing `vi.mock( "@/components/YouTubeEmbed", ... )` line, add:
+```typescript
+vi.mock( "@/components/TikTokEmbed", () => ({ TikTokEmbed: () => null }) );
+```
+
+Add a new import after the existing YouTube import:
+```typescript
+import { getOembed as getTikTokOembed } from "@/utils/tiktok/getOembed";
+```
+
+In every existing `beforeEach` block that mocks `getYouTubeOembed`, add:
+```typescript
+vi.mocked( getTikTokOembed ).mockResolvedValue( null );
+```
+
+Then add a new describe block at the end of the file:
+
+```typescript
+describe( "getStaticProps — TikTok oEmbed", () => {
+  const postWithTiktok = makePost({ slug: "tt-post" });
+  Object.assign( postWithTiktok.fields, {
+    tiktokUrl: "https://www.tiktok.com/@testuser/video/1234567890",
+  });
+
+  const postWithoutTiktok = makePost({ slug: "no-tt-post" });
+
+  beforeEach( () => {
+    vi.resetAllMocks();
+    vi.mocked( getBlogPosts ).mockResolvedValue({ items: [ postWithTiktok, postWithoutTiktok ] } as never );
+    vi.mocked( getPlaylist ).mockResolvedValue( null as never );
+    vi.mocked( getOembed ).mockResolvedValue( null );
+    vi.mocked( getYouTubeOembed ).mockResolvedValue( null );
+    vi.mocked( getTikTokOembed ).mockResolvedValue( null );
+  });
+
+  it( "fetches oEmbed data when tiktokUrl is present", async () => {
+    const mockOembed = { title: "TikTok Video", author_name: "testuser", author_url: "https://www.tiktok.com/@testuser", html: "<blockquote>content</blockquote>", thumbnail_url: "" };
+    vi.mocked( getBlogPost ).mockResolvedValue( postWithTiktok as never );
+    vi.mocked( getTikTokOembed ).mockResolvedValue( mockOembed );
+
+    const result = await getStaticProps({ params: { slug: "tt-post" } } as never );
+
+    expect( getTikTokOembed ).toHaveBeenCalledWith( "https://www.tiktok.com/@testuser/video/1234567890" );
+    expect( result ).toMatchObject({
+      props: { tikTokOembed: mockOembed },
+    });
+  });
+
+  it( "passes null when tiktokUrl is absent", async () => {
+    vi.mocked( getBlogPost ).mockResolvedValue( postWithoutTiktok as never );
+
+    const result = await getStaticProps({ params: { slug: "no-tt-post" } } as never );
+
+    expect( getTikTokOembed ).not.toHaveBeenCalled();
+    expect( result ).toMatchObject({
+      props: { tikTokOembed: null },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `yarn test src/__tests__/pages/post/slug.test.tsx`
+Expected: FAIL — `tikTokOembed` not found in props, `getTikTokOembed` never called.
+
+- [ ] **Step 3: Update `src/pages/post/[slug].tsx` imports**
+
+Add after the existing YouTube import lines:
+```typescript
+import { getOembed as getTikTokOembed, TikTokOembed } from "@/utils/tiktok/getOembed";
+import { TikTokEmbed } from "@/components/TikTokEmbed";
+```
+
+- [ ] **Step 4: Update `BlogPostViewProps` interface**
+
+Add `tikTokOembed` to the interface:
+```typescript
+export interface BlogPostViewProps {
+  post: BlogPost
+  playlist?: SpotifyPlaylist|null
+  soundCloudOembed?: SoundCloudOembed|null
+  youTubeOembed?: YouTubeOembed|null
+  tikTokOembed?: TikTokOembed|null
+  prevPost?: PostNavLink|null
+  nextPost?: PostNavLink|null
+}
+```
+
+- [ ] **Step 5: Update `BlogPostView` component signature and rendering**
+
+Add `tikTokOembed` to the destructured props:
+```typescript
+export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, prevPost, nextPost }) => {
+```
+
+Add the TikTok embed render **before** the `<Markdown>` component (after `</header>`):
+```tsx
+          </header>
+          { tikTokOembed && post.fields.tiktokUrl && <TikTokEmbed oembed={ tikTokOembed } url={ post.fields.tiktokUrl } /> }
+          <Markdown>{ post.fields.body || "" }</Markdown>
+```
+
+- [ ] **Step 6: Update `getStaticProps` to fetch TikTok oEmbed**
+
+Add after the YouTube oEmbed fetch:
+```typescript
+  const tikTokOembed = post.fields.tiktokUrl
+    ? await getTikTokOembed( post.fields.tiktokUrl ) : null;
+```
+
+Add `tikTokOembed` to the returned props object:
+```typescript
+  return {
+    props: {
+      post,
+      playlist,
+      soundCloudOembed,
+      youTubeOembed,
+      tikTokOembed,
+      prevPost,
+      nextPost,
+    },
+  };
+```
+
+- [ ] **Step 7: Run all tests to verify everything passes**
+
+Run: `yarn test`
+Expected: All tests PASS, including the new TikTok tests.
+
+- [ ] **Step 8: Run lint, format, and typecheck**
+
+Run: `yarn format && yarn typecheck`
+Expected: No errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/pages/post/[slug].tsx src/__tests__/pages/post/slug.test.tsx
+git commit -m "feat: integrate TikTok oEmbed into blog post page"
+```
+
+---
+
+### Task 5: Verify with a real TikTok URL
+
+**Files:** None (manual verification)
+
+- [ ] **Step 1: Test oEmbed API with a real TikTok URL**
+
+Run a quick curl to confirm the API returns expected data:
+```bash
+curl -s "https://www.tiktok.com/oembed?format=json&url=https://www.tiktok.com/@tiktok/video/7484771928498908459" | python3 -m json.tool
+```
+
+Expected: JSON response with `title`, `author_name`, `author_url`, `html` (containing a `<blockquote>`), and `thumbnail_url`.
+
+- [ ] **Step 2: Run the full build**
+
+Run: `yarn build`
+Expected: Build completes successfully. No posts currently have a `tiktokUrl`, so the TikTok embed code path is exercised but produces `null` — no errors.
+
+- [ ] **Step 3: Start the dev server and verify no regressions**
+
+Run: `yarn dev`
+Navigate to an existing post in the browser. Verify:
+- Post renders correctly
+- Existing YouTube/SoundCloud embeds (if present on any post) still work
+- No console errors

--- a/docs/superpowers/specs/2026-04-24-tiktok-embed-design.md
+++ b/docs/superpowers/specs/2026-04-24-tiktok-embed-design.md
@@ -1,0 +1,112 @@
+# TikTok oEmbed Integration
+
+## Overview
+
+Add TikTok video embedding to blog posts using TikTok's oEmbed API. The embed renders TikTok's native player widget with likes, comments, and social metadata. oEmbed data is fetched at build time; TikTok's `embed.js` script hydrates the player client-side.
+
+## Decisions
+
+- **oEmbed (script-based)** over iframe — TikTok's native widget shows likes, comments, and social metadata that an iframe embed does not
+- **Single URL field** — one `tiktokUrl` per post, consistent with `youtubeUrl` and `soundcloudUrl`
+- **Render before body** — TikTok video is primary content, not supplementary like music embeds
+- **Header with link** — `Watch "Title" on TikTok` for SEO (crawlable `<h2>` text + outbound link)
+- **Thumbnail as manual upload** — grab the thumbnail from oEmbed response and upload to Contentful as the post's `image` field; no automatic thumbnail fetching in list pages
+
+## Contentful Content Model
+
+Add an optional `tiktokUrl` field to the BlogPost content type:
+
+- **Field ID:** `tiktokUrl`
+- **Display name:** TikTok URL
+- **Type:** Symbol (short text)
+- **Required:** No
+- **Validation:** URL pattern matching `https://www.tiktok.com/@*/video/*` or `https://vm.tiktok.com/*`
+
+After adding the field, run `make types` to regenerate TypeScript types.
+
+## Data Fetching
+
+### `src/utils/tiktok/getOembed.ts`
+
+```typescript
+interface TikTokOembed {
+  title: string;
+  author_name: string;
+  author_url: string;
+  html: string;
+  thumbnail_url: string;
+}
+```
+
+- **Endpoint:** `https://www.tiktok.com/oembed?format=json&url={encodedUrl}`
+- **Returns:** `TikTokOembed | null`
+- **Error handling:** Returns `null` on fetch failure (same as YouTube/SoundCloud)
+- **Called from:** `getStaticProps` in `src/pages/post/[slug].tsx` at build time
+
+## Component
+
+### `src/components/TikTokEmbed.tsx`
+
+**Props:**
+- `oembed: TikTokOembed` — the oEmbed response data
+- `url: string` — the raw TikTok URL
+
+**Rendering:**
+- `<section>` wrapper with class `tiktokEmbed`
+- `<header>` with `<h2>`: `Watch "Title" on TikTok` — title links to the TikTok URL, "TikTok" links to the author's profile (`author_url`)
+- `<div>` container with oEmbed `html` rendered via `dangerouslySetInnerHTML`
+
+**Script loading:**
+- `useEffect` creates a `<script>` element with `src="https://www.tiktok.com/embed.js"`
+- Script is appended to the component's container `<div>` (not `<head>`) so embed.js finds and hydrates the blockquote
+- Cleanup function removes the script on unmount
+
+**Security considerations:**
+- The oEmbed HTML is fetched at build time from TikTok's official oEmbed API endpoint — this is a trusted first-party source, not user-supplied input
+- This is the same trust model used by the existing YouTube and SoundCloud embed components
+- Script src is hardcoded to `https://www.tiktok.com/embed.js` — no dynamic script URLs
+- The `dangerouslySetInnerHTML` usage is safe here because the content is build-time static output from a trusted API, never runtime user input
+
+**Graceful degradation:**
+- If embed.js fails to load, the blockquote remains visible with video caption and a link to TikTok
+
+## Styles
+
+### `src/styles/TikTokEmbed.module.scss`
+
+- `section.tiktokEmbed` — `margin-top: 2rem; margin-bottom: 4rem` (tighter spacing than post-body embeds since it sits between header and body)
+- `.tiktokHeader` — `margin-bottom: 1rem`
+- `.embedContainer` — centers the TikTok embed (renders as a fixed-width ~325px block by default)
+
+## Page Integration
+
+### `src/pages/post/[slug].tsx`
+
+**`getStaticProps`:**
+- Fetch TikTok oEmbed when `post.fields.tiktokUrl` is present
+- Add `tikTokOembed` to returned props
+
+**`BlogPostViewProps`:**
+- Add `tikTokOembed?: TikTokOembed | null`
+
+**Render position — before markdown body:**
+```
+</header>
+{ tikTokOembed && post.fields.tiktokUrl && <TikTokEmbed ... /> }
+<Markdown>{ post.fields.body || "" }</Markdown>
+```
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `src/utils/tiktok/getOembed.ts` | oEmbed API fetch utility |
+| `src/components/TikTokEmbed.tsx` | Embed component with client-side script loader |
+| `src/styles/TikTokEmbed.module.scss` | Embed styles |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/pages/post/[slug].tsx` | Add oEmbed fetch, props, and render TikTokEmbed before body |
+| `src/types/contentful/TypeBlogPost.ts` | Regenerated via `make types` after Contentful field addition |

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/jsdom": "^28.0.1",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.3",
     "cf-content-types-generator": "^3.0.1",

--- a/src/__tests__/components/TikTokEmbed.test.tsx
+++ b/src/__tests__/components/TikTokEmbed.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 
@@ -21,26 +21,7 @@ const MOCK_OEMBED: TikTokOembed = {
   thumbnail_url: "https://p16-sign.tiktokcdn.com/obj/test-thumbnail.jpg",
 };
 
-const MOCK_OEMBED_DARK: TikTokOembed = {
-  ...MOCK_OEMBED,
-  html: '<blockquote class="tiktok-embed" data-dark="1"><section>Dark content</section></blockquote>',
-};
-
-function mockMatchMedia( matches: boolean ) {
-  Object.defineProperty( window, "matchMedia", {
-    writable: true,
-    value: vi.fn().mockReturnValue({
-      matches,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    }),
-  });
-}
-
 describe( "TikTokEmbed", () => {
-  beforeEach( () => {
-    mockMatchMedia( false );
-  });
   it( "renders the oEmbed HTML content", () => {
     render( <TikTokEmbed oembed={ MOCK_OEMBED } url={ MOCK_TIKTOK_URL } /> );
 
@@ -90,31 +71,5 @@ describe( "TikTokEmbed", () => {
 
     const scripts = document.querySelectorAll( 'script[src="https://www.tiktok.com/embed.js"]' );
     expect( scripts ).toHaveLength( 1 );
-  });
-});
-
-describe( "TikTokEmbed — dark mode", () => {
-  it( "renders dark oEmbed HTML when prefers-color-scheme is dark", () => {
-    mockMatchMedia( false );
-
-    render( <TikTokEmbed oembed={ MOCK_OEMBED } oembedDark={ MOCK_OEMBED_DARK } url={ MOCK_TIKTOK_URL } /> );
-
-    expect( screen.getByText( "Dark content" ) ).toBeInTheDocument();
-  });
-
-  it( "renders light oEmbed HTML when prefers-color-scheme is light", () => {
-    mockMatchMedia( true );
-
-    render( <TikTokEmbed oembed={ MOCK_OEMBED } oembedDark={ MOCK_OEMBED_DARK } url={ MOCK_TIKTOK_URL } /> );
-
-    expect( screen.getByText( "Test content" ) ).toBeInTheDocument();
-  });
-
-  it( "falls back to light oEmbed when oembedDark is not provided", () => {
-    mockMatchMedia( false );
-
-    render( <TikTokEmbed oembed={ MOCK_OEMBED } url={ MOCK_TIKTOK_URL } /> );
-
-    expect( screen.getByText( "Test content" ) ).toBeInTheDocument();
   });
 });

--- a/src/__tests__/components/TikTokEmbed.test.tsx
+++ b/src/__tests__/components/TikTokEmbed.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock( "next/link", () => ({
+  default: ({ children, href, ...props }: React.ComponentProps<"a"> ) => (
+    <a href={ href } { ...props }>{ children }</a>
+  ),
+}) );
+
+import { TikTokEmbed } from "@/components/TikTokEmbed";
+import { TikTokOembed } from "@/utils/tiktok/getOembed";
+
+const MOCK_TIKTOK_URL = "https://www.tiktok.com/@testuser/video/1234567890";
+
+const MOCK_OEMBED: TikTokOembed = {
+  title: "Test TikTok Video",
+  author_name: "testuser",
+  author_url: "https://www.tiktok.com/@testuser",
+  html: '<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@testuser/video/1234567890"><section>Test content</section></blockquote>',
+  thumbnail_url: "https://p16-sign.tiktokcdn.com/obj/test-thumbnail.jpg",
+};
+
+describe( "TikTokEmbed", () => {
+  it( "renders the oEmbed HTML content", () => {
+    render( <TikTokEmbed oembed={ MOCK_OEMBED } url={ MOCK_TIKTOK_URL } /> );
+
+    expect( screen.getByText( "Test content" ) ).toBeInTheDocument();
+  });
+
+  it( "renders the video title as a link to the TikTok URL that opens in a new tab", () => {
+    render( <TikTokEmbed oembed={ MOCK_OEMBED } url={ MOCK_TIKTOK_URL } /> );
+
+    const titleLink = screen.getByRole( "link", { name: /Test TikTok Video/i });
+    expect( titleLink ).toHaveAttribute( "href", MOCK_TIKTOK_URL );
+    expect( titleLink ).toHaveAttribute( "target", "_blank" );
+    expect( titleLink ).toHaveAttribute( "rel", "noopener noreferrer" );
+  });
+
+  it( "renders a TikTok link to the author profile that opens in a new tab", () => {
+    render( <TikTokEmbed oembed={ MOCK_OEMBED } url={ MOCK_TIKTOK_URL } /> );
+
+    const tiktokLink = screen.getByRole( "link", { name: "TikTok" });
+    expect( tiktokLink ).toHaveAttribute( "href", "https://www.tiktok.com/@testuser" );
+    expect( tiktokLink ).toHaveAttribute( "target", "_blank" );
+  });
+
+  it( "appends the TikTok embed.js script to the container on mount", () => {
+    render( <TikTokEmbed oembed={ MOCK_OEMBED } url={ MOCK_TIKTOK_URL } /> );
+
+    const script = document.querySelector( 'script[src="https://www.tiktok.com/embed.js"]' );
+    expect( script ).not.toBeNull();
+  });
+
+  it( "removes the script on unmount", () => {
+    const { unmount } = render( <TikTokEmbed oembed={ MOCK_OEMBED } url={ MOCK_TIKTOK_URL } /> );
+
+    unmount();
+
+    const script = document.querySelector( 'script[src="https://www.tiktok.com/embed.js"]' );
+    expect( script ).toBeNull();
+  });
+});

--- a/src/__tests__/components/TikTokEmbed.test.tsx
+++ b/src/__tests__/components/TikTokEmbed.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 
@@ -21,7 +21,26 @@ const MOCK_OEMBED: TikTokOembed = {
   thumbnail_url: "https://p16-sign.tiktokcdn.com/obj/test-thumbnail.jpg",
 };
 
+const MOCK_OEMBED_DARK: TikTokOembed = {
+  ...MOCK_OEMBED,
+  html: '<blockquote class="tiktok-embed" data-dark="1"><section>Dark content</section></blockquote>',
+};
+
+function mockMatchMedia( matches: boolean ) {
+  Object.defineProperty( window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockReturnValue({
+      matches,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  });
+}
+
 describe( "TikTokEmbed", () => {
+  beforeEach( () => {
+    mockMatchMedia( false );
+  });
   it( "renders the oEmbed HTML content", () => {
     render( <TikTokEmbed oembed={ MOCK_OEMBED } url={ MOCK_TIKTOK_URL } /> );
 
@@ -71,5 +90,31 @@ describe( "TikTokEmbed", () => {
 
     const scripts = document.querySelectorAll( 'script[src="https://www.tiktok.com/embed.js"]' );
     expect( scripts ).toHaveLength( 1 );
+  });
+});
+
+describe( "TikTokEmbed — dark mode", () => {
+  it( "renders dark oEmbed HTML when prefers-color-scheme is dark", () => {
+    mockMatchMedia( false );
+
+    render( <TikTokEmbed oembed={ MOCK_OEMBED } oembedDark={ MOCK_OEMBED_DARK } url={ MOCK_TIKTOK_URL } /> );
+
+    expect( screen.getByText( "Dark content" ) ).toBeInTheDocument();
+  });
+
+  it( "renders light oEmbed HTML when prefers-color-scheme is light", () => {
+    mockMatchMedia( true );
+
+    render( <TikTokEmbed oembed={ MOCK_OEMBED } oembedDark={ MOCK_OEMBED_DARK } url={ MOCK_TIKTOK_URL } /> );
+
+    expect( screen.getByText( "Test content" ) ).toBeInTheDocument();
+  });
+
+  it( "falls back to light oEmbed when oembedDark is not provided", () => {
+    mockMatchMedia( false );
+
+    render( <TikTokEmbed oembed={ MOCK_OEMBED } url={ MOCK_TIKTOK_URL } /> );
+
+    expect( screen.getByText( "Test content" ) ).toBeInTheDocument();
   });
 });

--- a/src/__tests__/components/TikTokEmbed.test.tsx
+++ b/src/__tests__/components/TikTokEmbed.test.tsx
@@ -60,4 +60,16 @@ describe( "TikTokEmbed", () => {
     const script = document.querySelector( 'script[src="https://www.tiktok.com/embed.js"]' );
     expect( script ).toBeNull();
   });
+
+  it( "strips script tags from oEmbed HTML to avoid double-loading embed.js", () => {
+    const oembedWithScript: TikTokOembed = {
+      ...MOCK_OEMBED,
+      html: '<blockquote class="tiktok-embed"><section>Test content</section></blockquote><script async src="https://www.tiktok.com/embed.js"></script>',
+    };
+
+    render( <TikTokEmbed oembed={ oembedWithScript } url={ MOCK_TIKTOK_URL } /> );
+
+    const scripts = document.querySelectorAll( 'script[src="https://www.tiktok.com/embed.js"]' );
+    expect( scripts ).toHaveLength( 1 );
+  });
 });

--- a/src/__tests__/components/TikTokEmbed.test.tsx
+++ b/src/__tests__/components/TikTokEmbed.test.tsx
@@ -61,15 +61,4 @@ describe( "TikTokEmbed", () => {
     expect( script ).toBeNull();
   });
 
-  it( "strips script tags from oEmbed HTML to avoid double-loading embed.js", () => {
-    const oembedWithScript: TikTokOembed = {
-      ...MOCK_OEMBED,
-      html: '<blockquote class="tiktok-embed"><section>Test content</section></blockquote><script async src="https://www.tiktok.com/embed.js"></script>',
-    };
-
-    render( <TikTokEmbed oembed={ oembedWithScript } url={ MOCK_TIKTOK_URL } /> );
-
-    const scripts = document.querySelectorAll( 'script[src="https://www.tiktok.com/embed.js"]' );
-    expect( scripts ).toHaveLength( 1 );
-  });
 });

--- a/src/__tests__/pages/post/slug.test.tsx
+++ b/src/__tests__/pages/post/slug.test.tsx
@@ -293,27 +293,31 @@ describe( "getStaticProps — TikTok oEmbed", () => {
     vi.mocked( getTikTokOembed ).mockResolvedValue( null );
   });
 
-  it( "fetches oEmbed data when tiktokUrl is present", async () => {
+  it( "fetches both light and dark oEmbed data when tiktokUrl is present", async () => {
     const mockOembed = { title: "TikTok Video", author_name: "testuser", author_url: "https://www.tiktok.com/@testuser", html: "<blockquote>content</blockquote>", thumbnail_url: "" };
+    const mockOembedDark = { ...mockOembed, html: "<blockquote>dark content</blockquote>" };
     vi.mocked( getBlogPost ).mockResolvedValue( postWithTiktok as never );
-    vi.mocked( getTikTokOembed ).mockResolvedValue( mockOembed );
+    vi.mocked( getTikTokOembed )
+      .mockResolvedValueOnce( mockOembed )
+      .mockResolvedValueOnce( mockOembedDark );
 
     const result = await getStaticProps({ params: { slug: "tt-post" } } as never );
 
     expect( getTikTokOembed ).toHaveBeenCalledWith( "https://www.tiktok.com/@testuser/video/1234567890" );
+    expect( getTikTokOembed ).toHaveBeenCalledWith( "https://www.tiktok.com/@testuser/video/1234567890", { darkMode: true });
     expect( result ).toMatchObject({
-      props: { tikTokOembed: mockOembed },
+      props: { tikTokOembed: mockOembed, tikTokOembedDark: mockOembedDark },
     });
   });
 
-  it( "passes null when tiktokUrl is absent", async () => {
+  it( "passes null for both when tiktokUrl is absent", async () => {
     vi.mocked( getBlogPost ).mockResolvedValue( postWithoutTiktok as never );
 
     const result = await getStaticProps({ params: { slug: "no-tt-post" } } as never );
 
     expect( getTikTokOembed ).not.toHaveBeenCalled();
     expect( result ).toMatchObject({
-      props: { tikTokOembed: null },
+      props: { tikTokOembed: null, tikTokOembedDark: null },
     });
   });
 });

--- a/src/__tests__/pages/post/slug.test.tsx
+++ b/src/__tests__/pages/post/slug.test.tsx
@@ -15,8 +15,12 @@ vi.mock( "@/utils/soundcloud/getOembed", () => ({
 vi.mock( "@/utils/youtube/getOembed", () => ({
   getOembed: vi.fn(),
 }) );
+vi.mock( "@/utils/tiktok/getOembed", () => ({
+  getOembed: vi.fn(),
+}) );
 vi.mock( "@/components/SoundCloudEmbed", () => ({ SoundCloudEmbed: () => null }) );
 vi.mock( "@/components/YouTubeEmbed", () => ({ YouTubeEmbed: () => null }) );
+vi.mock( "@/components/TikTokEmbed", () => ({ TikTokEmbed: () => null }) );
 vi.mock( "next/link", () => ({
   default: ({ children, href, ...props }: React.ComponentProps<"a"> ) => (
     <a href={ href } { ...props }>{ children }</a>
@@ -43,6 +47,7 @@ import { getBlogPost, getBlogPosts } from "@/utils/contentfulUtils";
 import { getPlaylist } from "@/utils/spotify/getPlaylist";
 import { getOembed } from "@/utils/soundcloud/getOembed";
 import { getOembed as getYouTubeOembed } from "@/utils/youtube/getOembed";
+import { getOembed as getTikTokOembed } from "@/utils/tiktok/getOembed";
 
 function makePost( overrides: {
   slug?: string;
@@ -126,6 +131,7 @@ describe( "getStaticProps — post navigation", () => {
     vi.mocked( getPlaylist ).mockResolvedValue( null as never );
     vi.mocked( getOembed ).mockResolvedValue( null );
     vi.mocked( getYouTubeOembed ).mockResolvedValue( null );
+    vi.mocked( getTikTokOembed ).mockResolvedValue( null );
   });
 
   it( "assigns both prevPost and nextPost for a middle post", async () => {
@@ -200,6 +206,7 @@ describe( "getStaticProps — SoundCloud oEmbed", () => {
     vi.mocked( getPlaylist ).mockResolvedValue( null as never );
     vi.mocked( getOembed ).mockResolvedValue( null );
     vi.mocked( getYouTubeOembed ).mockResolvedValue( null );
+    vi.mocked( getTikTokOembed ).mockResolvedValue( null );
   });
 
   it( "fetches oEmbed data when soundcloudUrl is present", async () => {
@@ -241,6 +248,7 @@ describe( "getStaticProps — YouTube oEmbed", () => {
     vi.mocked( getPlaylist ).mockResolvedValue( null as never );
     vi.mocked( getOembed ).mockResolvedValue( null );
     vi.mocked( getYouTubeOembed ).mockResolvedValue( null );
+    vi.mocked( getTikTokOembed ).mockResolvedValue( null );
   });
 
   it( "fetches oEmbed data when youtubeUrl is present", async () => {
@@ -264,6 +272,48 @@ describe( "getStaticProps — YouTube oEmbed", () => {
     expect( getYouTubeOembed ).not.toHaveBeenCalled();
     expect( result ).toMatchObject({
       props: { youTubeOembed: null },
+    });
+  });
+});
+
+describe( "getStaticProps — TikTok oEmbed", () => {
+  const postWithTiktok = makePost({ slug: "tt-post" });
+  Object.assign( postWithTiktok.fields, {
+    tiktokUrl: "https://www.tiktok.com/@testuser/video/1234567890",
+  });
+
+  const postWithoutTiktok = makePost({ slug: "no-tt-post" });
+
+  beforeEach( () => {
+    vi.resetAllMocks();
+    vi.mocked( getBlogPosts ).mockResolvedValue({ items: [ postWithTiktok, postWithoutTiktok ] } as never );
+    vi.mocked( getPlaylist ).mockResolvedValue( null as never );
+    vi.mocked( getOembed ).mockResolvedValue( null );
+    vi.mocked( getYouTubeOembed ).mockResolvedValue( null );
+    vi.mocked( getTikTokOembed ).mockResolvedValue( null );
+  });
+
+  it( "fetches oEmbed data when tiktokUrl is present", async () => {
+    const mockOembed = { title: "TikTok Video", author_name: "testuser", author_url: "https://www.tiktok.com/@testuser", html: "<blockquote>content</blockquote>", thumbnail_url: "" };
+    vi.mocked( getBlogPost ).mockResolvedValue( postWithTiktok as never );
+    vi.mocked( getTikTokOembed ).mockResolvedValue( mockOembed );
+
+    const result = await getStaticProps({ params: { slug: "tt-post" } } as never );
+
+    expect( getTikTokOembed ).toHaveBeenCalledWith( "https://www.tiktok.com/@testuser/video/1234567890" );
+    expect( result ).toMatchObject({
+      props: { tikTokOembed: mockOembed },
+    });
+  });
+
+  it( "passes null when tiktokUrl is absent", async () => {
+    vi.mocked( getBlogPost ).mockResolvedValue( postWithoutTiktok as never );
+
+    const result = await getStaticProps({ params: { slug: "no-tt-post" } } as never );
+
+    expect( getTikTokOembed ).not.toHaveBeenCalled();
+    expect( result ).toMatchObject({
+      props: { tikTokOembed: null },
     });
   });
 });

--- a/src/__tests__/pages/post/slug.test.tsx
+++ b/src/__tests__/pages/post/slug.test.tsx
@@ -293,31 +293,27 @@ describe( "getStaticProps — TikTok oEmbed", () => {
     vi.mocked( getTikTokOembed ).mockResolvedValue( null );
   });
 
-  it( "fetches both light and dark oEmbed data when tiktokUrl is present", async () => {
+  it( "fetches oEmbed data when tiktokUrl is present", async () => {
     const mockOembed = { title: "TikTok Video", author_name: "testuser", author_url: "https://www.tiktok.com/@testuser", html: "<blockquote>content</blockquote>", thumbnail_url: "" };
-    const mockOembedDark = { ...mockOembed, html: "<blockquote>dark content</blockquote>" };
     vi.mocked( getBlogPost ).mockResolvedValue( postWithTiktok as never );
-    vi.mocked( getTikTokOembed )
-      .mockResolvedValueOnce( mockOembed )
-      .mockResolvedValueOnce( mockOembedDark );
+    vi.mocked( getTikTokOembed ).mockResolvedValue( mockOembed );
 
     const result = await getStaticProps({ params: { slug: "tt-post" } } as never );
 
     expect( getTikTokOembed ).toHaveBeenCalledWith( "https://www.tiktok.com/@testuser/video/1234567890" );
-    expect( getTikTokOembed ).toHaveBeenCalledWith( "https://www.tiktok.com/@testuser/video/1234567890", { darkMode: true });
     expect( result ).toMatchObject({
-      props: { tikTokOembed: mockOembed, tikTokOembedDark: mockOembedDark },
+      props: { tikTokOembed: mockOembed },
     });
   });
 
-  it( "passes null for both when tiktokUrl is absent", async () => {
+  it( "passes null when tiktokUrl is absent", async () => {
     vi.mocked( getBlogPost ).mockResolvedValue( postWithoutTiktok as never );
 
     const result = await getStaticProps({ params: { slug: "no-tt-post" } } as never );
 
     expect( getTikTokOembed ).not.toHaveBeenCalled();
     expect( result ).toMatchObject({
-      props: { tikTokOembed: null, tikTokOembedDark: null },
+      props: { tikTokOembed: null },
     });
   });
 });

--- a/src/components/TikTokEmbed.tsx
+++ b/src/components/TikTokEmbed.tsx
@@ -1,40 +1,21 @@
-import { FC, useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+import { FC, useEffect, useRef } from "react";
 import Link from "next/link";
 import { TikTokOembed } from "@/utils/tiktok/getOembed";
 import styles from "@/styles/TikTokEmbed.module.scss";
 
 export interface TikTokEmbedProps {
   oembed: TikTokOembed;
-  oembedDark?: TikTokOembed | null;
   url: string;
 }
 
 const TIKTOK_EMBED_SCRIPT_SRC = "https://www.tiktok.com/embed.js";
-const LIGHT_MODE_QUERY = "(prefers-color-scheme: light)";
 
 function stripScriptTags( html: string ): string {
   return html.replace( /<script[^>]*>[\s\S]*?<\/script>/gi, "" );
 }
 
-function useIsLightMode(): boolean {
-  const subscribe = useCallback( ( callback: () => void ) => {
-    const mediaQuery = window.matchMedia( LIGHT_MODE_QUERY );
-    mediaQuery.addEventListener( "change", callback );
-    return () => mediaQuery.removeEventListener( "change", callback );
-  }, [] );
-
-  const getSnapshot = useCallback(
-    () => window.matchMedia( LIGHT_MODE_QUERY ).matches,
-    [],
-  );
-
-  return useSyncExternalStore( subscribe, getSnapshot, () => false );
-}
-
-export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, oembedDark, url }) => {
+export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, url }) => {
   const scriptRef = useRef<HTMLDivElement>( null );
-  const isLight = useIsLightMode();
-  const activeOembed = isLight || !oembedDark ? oembed : oembedDark;
 
   useEffect( () => {
     const container = scriptRef.current;
@@ -50,12 +31,12 @@ export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, oembedDark, url }) =
     return () => {
       script.remove();
     };
-  }, [ activeOembed ] );
+  }, [] );
 
   // Safe: oEmbed HTML is fetched at build time from TikTok's official API —
   // a trusted first-party source, not user-supplied input. Script tags are
   // stripped since we load embed.js separately via useEffect.
-  const sanitizedHtml = { __html: stripScriptTags( activeOembed.html ) };
+  const sanitizedHtml = { __html: stripScriptTags( oembed.html ) };
 
   return (
     <section className={ styles.tiktokEmbed }>
@@ -65,9 +46,9 @@ export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, oembedDark, url }) =
             href={ url }
             target="_blank"
             rel="noopener noreferrer"
-          >{ activeOembed.title }</Link>&quot; on{ " " }
+          >{ oembed.title }</Link>&quot; on{ " " }
           <Link
-            href={ activeOembed.author_url }
+            href={ oembed.author_url }
             target="_blank"
             rel="noopener noreferrer"
           >TikTok</Link>

--- a/src/components/TikTokEmbed.tsx
+++ b/src/components/TikTokEmbed.tsx
@@ -11,7 +11,13 @@ export interface TikTokEmbedProps {
 const TIKTOK_EMBED_SCRIPT_SRC = "https://www.tiktok.com/embed.js";
 
 function stripScriptTags( html: string ): string {
-  return html.replace( /<script[^>]*>[\s\S]*?<\/script>/gi, "" );
+  let result = html;
+  let previous;
+  do {
+    previous = result;
+    result = result.replace( /<script[^>]*>[\s\S]*?<\/script>/gi, "" );
+  } while ( result !== previous );
+  return result;
 }
 
 export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, url }) => {

--- a/src/components/TikTokEmbed.tsx
+++ b/src/components/TikTokEmbed.tsx
@@ -1,21 +1,40 @@
-import { FC, useEffect, useRef } from "react";
+import { FC, useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { TikTokOembed } from "@/utils/tiktok/getOembed";
 import styles from "@/styles/TikTokEmbed.module.scss";
 
 export interface TikTokEmbedProps {
   oembed: TikTokOembed;
+  oembedDark?: TikTokOembed | null;
   url: string;
 }
 
 const TIKTOK_EMBED_SCRIPT_SRC = "https://www.tiktok.com/embed.js";
+const LIGHT_MODE_QUERY = "(prefers-color-scheme: light)";
 
 function stripScriptTags( html: string ): string {
   return html.replace( /<script[^>]*>[\s\S]*?<\/script>/gi, "" );
 }
 
-export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, url }) => {
+function useIsLightMode(): boolean {
+  const subscribe = useCallback( ( callback: () => void ) => {
+    const mediaQuery = window.matchMedia( LIGHT_MODE_QUERY );
+    mediaQuery.addEventListener( "change", callback );
+    return () => mediaQuery.removeEventListener( "change", callback );
+  }, [] );
+
+  const getSnapshot = useCallback(
+    () => window.matchMedia( LIGHT_MODE_QUERY ).matches,
+    [],
+  );
+
+  return useSyncExternalStore( subscribe, getSnapshot, () => false );
+}
+
+export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, oembedDark, url }) => {
   const scriptRef = useRef<HTMLDivElement>( null );
+  const isLight = useIsLightMode();
+  const activeOembed = isLight || !oembedDark ? oembed : oembedDark;
 
   useEffect( () => {
     const container = scriptRef.current;
@@ -31,12 +50,12 @@ export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, url }) => {
     return () => {
       script.remove();
     };
-  }, [] );
+  }, [ activeOembed ] );
 
   // Safe: oEmbed HTML is fetched at build time from TikTok's official API —
   // a trusted first-party source, not user-supplied input. Script tags are
   // stripped since we load embed.js separately via useEffect.
-  const sanitizedHtml = { __html: stripScriptTags( oembed.html ) };
+  const sanitizedHtml = { __html: stripScriptTags( activeOembed.html ) };
 
   return (
     <section className={ styles.tiktokEmbed }>
@@ -46,9 +65,9 @@ export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, url }) => {
             href={ url }
             target="_blank"
             rel="noopener noreferrer"
-          >{ oembed.title }</Link>&quot; on{ " " }
+          >{ activeOembed.title }</Link>&quot; on{ " " }
           <Link
-            href={ oembed.author_url }
+            href={ activeOembed.author_url }
             target="_blank"
             rel="noopener noreferrer"
           >TikTok</Link>

--- a/src/components/TikTokEmbed.tsx
+++ b/src/components/TikTokEmbed.tsx
@@ -15,7 +15,7 @@ function stripScriptTags( html: string ): string {
   let previous;
   do {
     previous = result;
-    result = result.replace( /<script[^>]*>[\s\S]*?<\/script>/gi, "" );
+    result = result.replace( /<script[^>]*>[\s\S]*?<\/script\s*>/gi, "" );
   } while ( result !== previous );
   return result;
 }

--- a/src/components/TikTokEmbed.tsx
+++ b/src/components/TikTokEmbed.tsx
@@ -1,0 +1,59 @@
+import { FC, useEffect, useRef } from "react";
+import Link from "next/link";
+import { TikTokOembed } from "@/utils/tiktok/getOembed";
+import styles from "@/styles/TikTokEmbed.module.scss";
+
+export interface TikTokEmbedProps {
+  oembed: TikTokOembed;
+  url: string;
+}
+
+const TIKTOK_EMBED_SCRIPT_SRC = "https://www.tiktok.com/embed.js";
+
+export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, url }) => {
+  const containerRef = useRef<HTMLDivElement>( null );
+
+  useEffect( () => {
+    const container = containerRef.current;
+    if( !container ) {
+      return;
+    }
+
+    const script = document.createElement( "script" );
+    script.src = TIKTOK_EMBED_SCRIPT_SRC;
+    script.async = true;
+    container.appendChild( script );
+
+    return () => {
+      script.remove();
+    };
+  }, [] );
+
+  // Safe: oEmbed HTML is fetched at build time from TikTok's official API —
+  // a trusted first-party source, not user-supplied input.
+  const embedHtml = { __html: oembed.html };
+
+  return (
+    <section className={ styles.tiktokEmbed }>
+      <header className={ styles.tiktokHeader }>
+        <h2>
+          Watch &quot;<Link
+            href={ url }
+            target="_blank"
+            rel="noopener noreferrer"
+          >{ oembed.title }</Link>&quot; on{ " " }
+          <Link
+            href={ oembed.author_url }
+            target="_blank"
+            rel="noopener noreferrer"
+          >TikTok</Link>
+        </h2>
+      </header>
+      <div
+        ref={ containerRef }
+        className={ styles.embedContainer }
+        dangerouslySetInnerHTML={ embedHtml }
+      />
+    </section>
+  );
+};

--- a/src/components/TikTokEmbed.tsx
+++ b/src/components/TikTokEmbed.tsx
@@ -11,13 +11,11 @@ export interface TikTokEmbedProps {
 const TIKTOK_EMBED_SCRIPT_SRC = "https://www.tiktok.com/embed.js";
 
 function stripScriptTags( html: string ): string {
-  let result = html;
-  let previous;
-  do {
-    previous = result;
-    result = result.replace( /<script[^>]*>[\s\S]*?<\/script\s*>/gi, "" );
-  } while ( result !== previous );
-  return result;
+  const doc = new DOMParser().parseFromString( html, "text/html" );
+  for( const script of Array.from( doc.querySelectorAll( "script" ) ) ) {
+    script.remove();
+  }
+  return doc.body.innerHTML;
 }
 
 export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, url }) => {

--- a/src/components/TikTokEmbed.tsx
+++ b/src/components/TikTokEmbed.tsx
@@ -10,14 +10,6 @@ export interface TikTokEmbedProps {
 
 const TIKTOK_EMBED_SCRIPT_SRC = "https://www.tiktok.com/embed.js";
 
-function stripScriptTags( html: string ): string {
-  const doc = new DOMParser().parseFromString( html, "text/html" );
-  for( const script of Array.from( doc.querySelectorAll( "script" ) ) ) {
-    script.remove();
-  }
-  return doc.body.innerHTML;
-}
-
 export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, url }) => {
   const scriptRef = useRef<HTMLDivElement>( null );
 
@@ -39,8 +31,8 @@ export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, url }) => {
 
   // Safe: oEmbed HTML is fetched at build time from TikTok's official API —
   // a trusted first-party source, not user-supplied input. Script tags are
-  // stripped since we load embed.js separately via useEffect.
-  const sanitizedHtml = { __html: stripScriptTags( oembed.html ) };
+  // stripped at build time in getOembed since we load embed.js separately.
+  const embedHtml = { __html: oembed.html };
 
   return (
     <section className={ styles.tiktokEmbed }>
@@ -60,7 +52,7 @@ export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, url }) => {
       </header>
       <div
         className={ styles.embedContainer }
-        dangerouslySetInnerHTML={ sanitizedHtml }
+        dangerouslySetInnerHTML={ embedHtml }
       />
       <div ref={ scriptRef } />
     </section>

--- a/src/components/TikTokEmbed.tsx
+++ b/src/components/TikTokEmbed.tsx
@@ -10,11 +10,15 @@ export interface TikTokEmbedProps {
 
 const TIKTOK_EMBED_SCRIPT_SRC = "https://www.tiktok.com/embed.js";
 
+function stripScriptTags( html: string ): string {
+  return html.replace( /<script[^>]*>[\s\S]*?<\/script>/gi, "" );
+}
+
 export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, url }) => {
-  const containerRef = useRef<HTMLDivElement>( null );
+  const scriptRef = useRef<HTMLDivElement>( null );
 
   useEffect( () => {
-    const container = containerRef.current;
+    const container = scriptRef.current;
     if( !container ) {
       return;
     }
@@ -30,8 +34,9 @@ export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, url }) => {
   }, [] );
 
   // Safe: oEmbed HTML is fetched at build time from TikTok's official API —
-  // a trusted first-party source, not user-supplied input.
-  const embedHtml = { __html: oembed.html };
+  // a trusted first-party source, not user-supplied input. Script tags are
+  // stripped since we load embed.js separately via useEffect.
+  const sanitizedHtml = { __html: stripScriptTags( oembed.html ) };
 
   return (
     <section className={ styles.tiktokEmbed }>
@@ -50,10 +55,10 @@ export const TikTokEmbed: FC<TikTokEmbedProps> = ({ oembed, url }) => {
         </h2>
       </header>
       <div
-        ref={ containerRef }
         className={ styles.embedContainer }
-        dangerouslySetInnerHTML={ embedHtml }
+        dangerouslySetInnerHTML={ sanitizedHtml }
       />
+      <div ref={ scriptRef } />
     </section>
   );
 };

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -19,6 +19,8 @@ import { getOembed, SoundCloudOembed } from "@/utils/soundcloud/getOembed";
 import { SoundCloudEmbed } from "@/components/SoundCloudEmbed";
 import { getOembed as getYouTubeOembed, YouTubeOembed } from "@/utils/youtube/getOembed";
 import { YouTubeEmbed } from "@/components/YouTubeEmbed";
+import { getOembed as getTikTokOembed, TikTokOembed } from "@/utils/tiktok/getOembed";
+import { TikTokEmbed } from "@/components/TikTokEmbed";
 
 
 
@@ -33,12 +35,13 @@ export interface BlogPostViewProps {
   playlist?: SpotifyPlaylist|null
   soundCloudOembed?: SoundCloudOembed|null
   youTubeOembed?: YouTubeOembed|null
+  tikTokOembed?: TikTokOembed|null
   prevPost?: PostNavLink|null
   nextPost?: PostNavLink|null
 }
 
 
-export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, prevPost, nextPost }) => {
+export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, prevPost, nextPost }) => {
   const metaTitle = `${post.fields.title} | Audeos.com`;
   const metaImage = `https:${post.fields.image?.fields.file?.url}?w=${CONTENT_IMAGE_WIDTH}`;
   const metaImageDesc = post.fields.image?.fields.description || "";
@@ -140,6 +143,7 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloud
                 { post.fields.description }
               </p>
             </header>
+            { tikTokOembed && post.fields.tiktokUrl && <TikTokEmbed oembed={ tikTokOembed } url={ post.fields.tiktokUrl } /> }
             <Markdown>{ post.fields.body || "" }</Markdown>
             <Gallery items={ resolveGalleryItems( post.fields.gallery ) } />
             { soundCloudOembed && post.fields.soundcloudUrl && <SoundCloudEmbed oembed={ soundCloudOembed } url={ post.fields.soundcloudUrl } /> }
@@ -193,6 +197,9 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
   const youTubeOembed = post.fields.youtubeUrl
     ? await getYouTubeOembed( post.fields.youtubeUrl ) : null;
 
+  const tikTokOembed = post.fields.tiktokUrl
+    ? await getTikTokOembed( post.fields.tiktokUrl ) : null;
+
   const sortedPosts = allPosts.items
     .slice()
     .sort( sortBlogPostsByDate )
@@ -218,6 +225,7 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
       playlist,
       soundCloudOembed,
       youTubeOembed,
+      tikTokOembed,
       prevPost,
       nextPost,
     },

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -36,13 +36,12 @@ export interface BlogPostViewProps {
   soundCloudOembed?: SoundCloudOembed|null
   youTubeOembed?: YouTubeOembed|null
   tikTokOembed?: TikTokOembed|null
-  tikTokOembedDark?: TikTokOembed|null
   prevPost?: PostNavLink|null
   nextPost?: PostNavLink|null
 }
 
 
-export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, tikTokOembedDark, prevPost, nextPost }) => {
+export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, prevPost, nextPost }) => {
   const metaTitle = `${post.fields.title} | Audeos.com`;
   const metaImage = `https:${post.fields.image?.fields.file?.url}?w=${CONTENT_IMAGE_WIDTH}`;
   const metaImageDesc = post.fields.image?.fields.description || "";
@@ -144,7 +143,7 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloud
                 { post.fields.description }
               </p>
             </header>
-            { tikTokOembed && post.fields.tiktokUrl && <TikTokEmbed oembed={ tikTokOembed } oembedDark={ tikTokOembedDark } url={ post.fields.tiktokUrl } /> }
+            { tikTokOembed && post.fields.tiktokUrl && <TikTokEmbed oembed={ tikTokOembed } url={ post.fields.tiktokUrl } /> }
             <Markdown>{ post.fields.body || "" }</Markdown>
             <Gallery items={ resolveGalleryItems( post.fields.gallery ) } />
             { soundCloudOembed && post.fields.soundcloudUrl && <SoundCloudEmbed oembed={ soundCloudOembed } url={ post.fields.soundcloudUrl } /> }
@@ -198,12 +197,8 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
   const youTubeOembed = post.fields.youtubeUrl
     ? await getYouTubeOembed( post.fields.youtubeUrl ) : null;
 
-  const [ tikTokOembed, tikTokOembedDark ] = post.fields.tiktokUrl
-    ? await Promise.all( [
-      getTikTokOembed( post.fields.tiktokUrl ),
-      getTikTokOembed( post.fields.tiktokUrl, { darkMode: true }),
-    ] )
-    : [ null, null ];
+  const tikTokOembed = post.fields.tiktokUrl
+    ? await getTikTokOembed( post.fields.tiktokUrl ) : null;
 
   const sortedPosts = allPosts.items
     .slice()
@@ -231,7 +226,6 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
       soundCloudOembed,
       youTubeOembed,
       tikTokOembed,
-      tikTokOembedDark,
       prevPost,
       nextPost,
     },

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -36,12 +36,13 @@ export interface BlogPostViewProps {
   soundCloudOembed?: SoundCloudOembed|null
   youTubeOembed?: YouTubeOembed|null
   tikTokOembed?: TikTokOembed|null
+  tikTokOembedDark?: TikTokOembed|null
   prevPost?: PostNavLink|null
   nextPost?: PostNavLink|null
 }
 
 
-export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, prevPost, nextPost }) => {
+export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, tikTokOembedDark, prevPost, nextPost }) => {
   const metaTitle = `${post.fields.title} | Audeos.com`;
   const metaImage = `https:${post.fields.image?.fields.file?.url}?w=${CONTENT_IMAGE_WIDTH}`;
   const metaImageDesc = post.fields.image?.fields.description || "";
@@ -143,7 +144,7 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloud
                 { post.fields.description }
               </p>
             </header>
-            { tikTokOembed && post.fields.tiktokUrl && <TikTokEmbed oembed={ tikTokOembed } url={ post.fields.tiktokUrl } /> }
+            { tikTokOembed && post.fields.tiktokUrl && <TikTokEmbed oembed={ tikTokOembed } oembedDark={ tikTokOembedDark } url={ post.fields.tiktokUrl } /> }
             <Markdown>{ post.fields.body || "" }</Markdown>
             <Gallery items={ resolveGalleryItems( post.fields.gallery ) } />
             { soundCloudOembed && post.fields.soundcloudUrl && <SoundCloudEmbed oembed={ soundCloudOembed } url={ post.fields.soundcloudUrl } /> }
@@ -197,8 +198,12 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
   const youTubeOembed = post.fields.youtubeUrl
     ? await getYouTubeOembed( post.fields.youtubeUrl ) : null;
 
-  const tikTokOembed = post.fields.tiktokUrl
-    ? await getTikTokOembed( post.fields.tiktokUrl ) : null;
+  const [ tikTokOembed, tikTokOembedDark ] = post.fields.tiktokUrl
+    ? await Promise.all( [
+      getTikTokOembed( post.fields.tiktokUrl ),
+      getTikTokOembed( post.fields.tiktokUrl, { darkMode: true }),
+    ] )
+    : [ null, null ];
 
   const sortedPosts = allPosts.items
     .slice()
@@ -226,6 +231,7 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
       soundCloudOembed,
       youTubeOembed,
       tikTokOembed,
+      tikTokOembedDark,
       prevPost,
       nextPost,
     },

--- a/src/styles/TikTokEmbed.module.scss
+++ b/src/styles/TikTokEmbed.module.scss
@@ -1,0 +1,13 @@
+section.tiktokEmbed {
+  margin-top: 2rem;
+  margin-bottom: 4rem;
+}
+
+.tiktokHeader {
+  margin-bottom: 1rem;
+}
+
+.embedContainer {
+  display: flex;
+  justify-content: center;
+}

--- a/src/types/contentful/TypeBlogPost.ts
+++ b/src/types/contentful/TypeBlogPost.ts
@@ -86,6 +86,12 @@ export interface TypeBlogPostFields {
      * @localized false
      */
     youtubeUrl?: EntryFieldTypes.Symbol;
+    /**
+     * Field type definition for field 'tiktokUrl' (TikTok URL)
+     * @name TikTok URL
+     * @localized false
+     */
+    tiktokUrl?: EntryFieldTypes.Symbol;
 }
 
 /**
@@ -94,7 +100,7 @@ export interface TypeBlogPostFields {
  * @type {TypeBlogPostSkeleton}
  * @author 5qtbtLdlsTzODfegrwA2Ez
  * @since 2023-04-01T06:07:22.846Z
- * @version 25
+ * @version 27
  */
 export type TypeBlogPostSkeleton = EntrySkeletonType<TypeBlogPostFields, "blogPost">;
 /**
@@ -103,7 +109,7 @@ export type TypeBlogPostSkeleton = EntrySkeletonType<TypeBlogPostFields, "blogPo
  * @type {TypeBlogPost}
  * @author 5qtbtLdlsTzODfegrwA2Ez
  * @since 2023-04-01T06:07:22.846Z
- * @version 25
+ * @version 27
  */
 export type TypeBlogPost<Modifiers extends ChainModifiers, Locales extends LocaleCode = LocaleCode> = Entry<TypeBlogPostSkeleton, Modifiers, Locales>;
 

--- a/src/utils/tiktok/getOembed.test.ts
+++ b/src/utils/tiktok/getOembed.test.ts
@@ -49,30 +49,4 @@ describe( "getOembed", () => {
 
     expect( result ).toBeNull();
   });
-
-  it( "appends dark_mode=1 when darkMode option is true", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve( MOCK_OEMBED_RESPONSE ),
-    });
-
-    await getOembed( TIKTOK_VIDEO_URL, { darkMode: true });
-
-    expect( mockFetch ).toHaveBeenCalledWith(
-      `https://www.tiktok.com/oembed?format=json&url=${encodeURIComponent( TIKTOK_VIDEO_URL )}&dark_mode=1`,
-    );
-  });
-
-  it( "does not append dark_mode when darkMode option is false", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve( MOCK_OEMBED_RESPONSE ),
-    });
-
-    await getOembed( TIKTOK_VIDEO_URL, { darkMode: false });
-
-    expect( mockFetch ).toHaveBeenCalledWith(
-      `https://www.tiktok.com/oembed?format=json&url=${encodeURIComponent( TIKTOK_VIDEO_URL )}`,
-    );
-  });
 });

--- a/src/utils/tiktok/getOembed.test.ts
+++ b/src/utils/tiktok/getOembed.test.ts
@@ -29,7 +29,7 @@ describe( "getOembed", () => {
     const result = await getOembed( TIKTOK_VIDEO_URL );
 
     expect( mockFetch ).toHaveBeenCalledWith(
-      `https://www.tiktok.com/oembed?format=json&url=${encodeURIComponent( TIKTOK_VIDEO_URL )}`,
+      `https://www.tiktok.com/oembed?format=json&dark_mode=1&url=${encodeURIComponent( TIKTOK_VIDEO_URL )}`,
     );
     expect( result ).toEqual( MOCK_OEMBED_RESPONSE );
   });

--- a/src/utils/tiktok/getOembed.test.ts
+++ b/src/utils/tiktok/getOembed.test.ts
@@ -49,4 +49,30 @@ describe( "getOembed", () => {
 
     expect( result ).toBeNull();
   });
+
+  it( "appends dark_mode=1 when darkMode option is true", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve( MOCK_OEMBED_RESPONSE ),
+    });
+
+    await getOembed( TIKTOK_VIDEO_URL, { darkMode: true });
+
+    expect( mockFetch ).toHaveBeenCalledWith(
+      `https://www.tiktok.com/oembed?format=json&url=${encodeURIComponent( TIKTOK_VIDEO_URL )}&dark_mode=1`,
+    );
+  });
+
+  it( "does not append dark_mode when darkMode option is false", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve( MOCK_OEMBED_RESPONSE ),
+    });
+
+    await getOembed( TIKTOK_VIDEO_URL, { darkMode: false });
+
+    expect( mockFetch ).toHaveBeenCalledWith(
+      `https://www.tiktok.com/oembed?format=json&url=${encodeURIComponent( TIKTOK_VIDEO_URL )}`,
+    );
+  });
 });

--- a/src/utils/tiktok/getOembed.test.ts
+++ b/src/utils/tiktok/getOembed.test.ts
@@ -3,11 +3,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockFetch = vi.fn();
 vi.stubGlobal( "fetch", mockFetch );
 
-import { getOembed, TikTokOembed } from "./getOembed";
+import { getOembed } from "./getOembed";
 
 const TIKTOK_VIDEO_URL = "https://www.tiktok.com/@testuser/video/1234567890";
 
-const MOCK_OEMBED_RESPONSE: TikTokOembed = {
+const MOCK_API_RESPONSE = {
   title: "Test TikTok Video",
   author_name: "testuser",
   author_url: "https://www.tiktok.com/@testuser",
@@ -23,7 +23,7 @@ describe( "getOembed", () => {
   it( "fetches oEmbed data for a valid TikTok URL", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve( MOCK_OEMBED_RESPONSE ),
+      json: () => Promise.resolve({ ...MOCK_API_RESPONSE }),
     });
 
     const result = await getOembed( TIKTOK_VIDEO_URL );
@@ -31,7 +31,22 @@ describe( "getOembed", () => {
     expect( mockFetch ).toHaveBeenCalledWith(
       `https://www.tiktok.com/oembed?format=json&dark_mode=1&url=${encodeURIComponent( TIKTOK_VIDEO_URL )}`,
     );
-    expect( result ).toEqual( MOCK_OEMBED_RESPONSE );
+    expect( result ).toEqual({
+      ...MOCK_API_RESPONSE,
+      html: '<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@testuser/video/1234567890"><section>Test content</section></blockquote>',
+    });
+  });
+
+  it( "strips script tags from the oEmbed HTML", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ...MOCK_API_RESPONSE }),
+    });
+
+    const result = await getOembed( TIKTOK_VIDEO_URL );
+
+    expect( result?.html ).not.toContain( "<script" );
+    expect( result?.html ).toContain( "tiktok-embed" );
   });
 
   it( "returns null when the fetch fails", async () => {

--- a/src/utils/tiktok/getOembed.test.ts
+++ b/src/utils/tiktok/getOembed.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal( "fetch", mockFetch );
+
+import { getOembed, TikTokOembed } from "./getOembed";
+
+const TIKTOK_VIDEO_URL = "https://www.tiktok.com/@testuser/video/1234567890";
+
+const MOCK_OEMBED_RESPONSE: TikTokOembed = {
+  title: "Test TikTok Video",
+  author_name: "testuser",
+  author_url: "https://www.tiktok.com/@testuser",
+  html: '<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@testuser/video/1234567890"><section>Test content</section></blockquote><script async src="https://www.tiktok.com/embed.js"></script>',
+  thumbnail_url: "https://p16-sign.tiktokcdn.com/obj/test-thumbnail.jpg",
+};
+
+describe( "getOembed", () => {
+  beforeEach( () => {
+    vi.resetAllMocks();
+  });
+
+  it( "fetches oEmbed data for a valid TikTok URL", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve( MOCK_OEMBED_RESPONSE ),
+    });
+
+    const result = await getOembed( TIKTOK_VIDEO_URL );
+
+    expect( mockFetch ).toHaveBeenCalledWith(
+      `https://www.tiktok.com/oembed?format=json&url=${encodeURIComponent( TIKTOK_VIDEO_URL )}`,
+    );
+    expect( result ).toEqual( MOCK_OEMBED_RESPONSE );
+  });
+
+  it( "returns null when the fetch fails", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const result = await getOembed( TIKTOK_VIDEO_URL );
+
+    expect( result ).toBeNull();
+  });
+
+  it( "returns null when fetch throws a network error", async () => {
+    mockFetch.mockRejectedValueOnce( new Error( "Network error" ) );
+
+    const result = await getOembed( TIKTOK_VIDEO_URL );
+
+    expect( result ).toBeNull();
+  });
+});

--- a/src/utils/tiktok/getOembed.ts
+++ b/src/utils/tiktok/getOembed.ts
@@ -1,3 +1,5 @@
+import { JSDOM } from "jsdom";
+
 export interface TikTokOembed {
   title: string;
   author_name: string;
@@ -7,6 +9,13 @@ export interface TikTokOembed {
 }
 
 const OEMBED_ENDPOINT = "https://www.tiktok.com/oembed";
+
+function stripScriptTags( html: string ): string {
+  const dom = new JSDOM( html );
+  const scripts = dom.window.document.querySelectorAll( "script" );
+  scripts.forEach( ( element: Element ) => element.remove() );
+  return dom.window.document.body.innerHTML;
+}
 
 export async function getOembed( tiktokUrl: string ): Promise<TikTokOembed | null> {
   const url = `${OEMBED_ENDPOINT}?format=json&dark_mode=1&url=${encodeURIComponent( tiktokUrl )}`;
@@ -19,6 +28,7 @@ export async function getOembed( tiktokUrl: string ): Promise<TikTokOembed | nul
     }
 
     const data: TikTokOembed = await response.json();
+    data.html = stripScriptTags( data.html );
     return data;
   } catch {
     return null;

--- a/src/utils/tiktok/getOembed.ts
+++ b/src/utils/tiktok/getOembed.ts
@@ -8,8 +8,13 @@ export interface TikTokOembed {
 
 const OEMBED_ENDPOINT = "https://www.tiktok.com/oembed";
 
-export async function getOembed( tiktokUrl: string ): Promise<TikTokOembed | null> {
-  const url = `${OEMBED_ENDPOINT}?format=json&url=${encodeURIComponent( tiktokUrl )}`;
+export interface TikTokOembedOptions {
+  darkMode?: boolean;
+}
+
+export async function getOembed( tiktokUrl: string, options?: TikTokOembedOptions ): Promise<TikTokOembed | null> {
+  const darkParam = options?.darkMode ? "&dark_mode=1" : "";
+  const url = `${OEMBED_ENDPOINT}?format=json&url=${encodeURIComponent( tiktokUrl )}${darkParam}`;
 
   try {
     const response = await fetch( url );

--- a/src/utils/tiktok/getOembed.ts
+++ b/src/utils/tiktok/getOembed.ts
@@ -8,13 +8,8 @@ export interface TikTokOembed {
 
 const OEMBED_ENDPOINT = "https://www.tiktok.com/oembed";
 
-export interface TikTokOembedOptions {
-  darkMode?: boolean;
-}
-
-export async function getOembed( tiktokUrl: string, options?: TikTokOembedOptions ): Promise<TikTokOembed | null> {
-  const darkParam = options?.darkMode ? "&dark_mode=1" : "";
-  const url = `${OEMBED_ENDPOINT}?format=json&url=${encodeURIComponent( tiktokUrl )}${darkParam}`;
+export async function getOembed( tiktokUrl: string ): Promise<TikTokOembed | null> {
+  const url = `${OEMBED_ENDPOINT}?format=json&url=${encodeURIComponent( tiktokUrl )}`;
 
   try {
     const response = await fetch( url );

--- a/src/utils/tiktok/getOembed.ts
+++ b/src/utils/tiktok/getOembed.ts
@@ -1,0 +1,26 @@
+export interface TikTokOembed {
+  title: string;
+  author_name: string;
+  author_url: string;
+  html: string;
+  thumbnail_url: string;
+}
+
+const OEMBED_ENDPOINT = "https://www.tiktok.com/oembed";
+
+export async function getOembed( tiktokUrl: string ): Promise<TikTokOembed | null> {
+  const url = `${OEMBED_ENDPOINT}?format=json&url=${encodeURIComponent( tiktokUrl )}`;
+
+  try {
+    const response = await fetch( url );
+
+    if( !response.ok ) {
+      return null;
+    }
+
+    const data: TikTokOembed = await response.json();
+    return data;
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/tiktok/getOembed.ts
+++ b/src/utils/tiktok/getOembed.ts
@@ -9,7 +9,7 @@ export interface TikTokOembed {
 const OEMBED_ENDPOINT = "https://www.tiktok.com/oembed";
 
 export async function getOembed( tiktokUrl: string ): Promise<TikTokOembed | null> {
-  const url = `${OEMBED_ENDPOINT}?format=json&url=${encodeURIComponent( tiktokUrl )}`;
+  const url = `${OEMBED_ENDPOINT}?format=json&dark_mode=1&url=${encodeURIComponent( tiktokUrl )}`;
 
   try {
     const response = await fetch( url );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,6 +1110,16 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/jsdom@^28.0.1":
+  version "28.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-28.0.1.tgz#2c014d8c0eca6135233519bff8c49f7aadfeda63"
+  integrity sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==
+  dependencies:
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    parse5 "^7.0.0"
+    undici-types "^7.21.0"
+
 "@types/json-schema@^7.0.15":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
@@ -1132,7 +1142,7 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
-"@types/node@^25.5.0":
+"@types/node@*", "@types/node@^25.5.0":
   version "25.6.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-25.6.0.tgz#4e09bad9b469871f2d0f68140198cbd714f4edca"
   integrity sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==
@@ -1150,6 +1160,11 @@
   integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==
   dependencies:
     csstype "^3.2.2"
+
+"@types/tough-cookie@*":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
+  integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
 "@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.3"
@@ -5583,6 +5598,13 @@ parse5@^6.0.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
+parse5@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
+
 parse5@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-8.0.0.tgz#aceb267f6b15f9b6e6ba9e35bfdd481fc2167b12"
@@ -6852,6 +6874,11 @@ unbox-primitive@^1.1.0:
     has-bigints "^1.0.2"
     has-symbols "^1.1.0"
     which-boxed-primitive "^1.1.1"
+
+undici-types@^7.21.0:
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.25.0.tgz#c5f8feb61c70d8954e05beb5f1c786c7ff95458a"
+  integrity sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==
 
 undici-types@~7.19.0:
   version "7.19.2"


### PR DESCRIPTION
## Summary

- Add TikTok video embedding to blog posts using TikTok's oEmbed API with client-side script hydration
- oEmbed data is fetched at build time; TikTok's `embed.js` loads client-side via `useEffect` to render the native player widget with likes, comments, and social metadata
- TikTok embed renders before the post body (not after, like YouTube/SoundCloud) since video is the primary content
- SEO header (`Watch "Title" on TikTok`) with crawlable links, matching the existing YouTube/SoundCloud pattern
- Script tags are stripped from oEmbed HTML to prevent double-loading embed.js

## Changes

- **Contentful**: New optional `tiktokUrl` field on BlogPost content type
- **New**: `src/utils/tiktok/getOembed.ts` — oEmbed fetch utility (3 tests)
- **New**: `src/components/TikTokEmbed.tsx` — embed component with `useEffect` script loader (6 tests)
- **New**: `src/styles/TikTokEmbed.module.scss` — embed styles
- **Modified**: `src/pages/post/[slug].tsx` — integration (2 tests)

## Test plan

- [x] 131 tests pass (`yarn test`)
- [x] Full build passes (`yarn build`)
- [x] TypeScript compiles cleanly (`yarn typecheck`)
- [x] Lint passes (`yarn format`)
- [x] TikTok oEmbed API verified with real URL (returns expected blockquote HTML)
- [x] Add `tiktokUrl` to a test post in Contentful and verify the embed renders in the browser