### PR TITLE
fix: move TikTok embed below post body

### DIFF
--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -143,9 +143,9 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloud
                 { post.fields.description }
               </p>
             </header>
-            { tikTokOembed && post.fields.tiktokUrl && <TikTokEmbed oembed={ tikTokOembed } url={ post.fields.tiktokUrl } /> }
             <Markdown>{ post.fields.body || "" }</Markdown>
             <Gallery items={ resolveGalleryItems( post.fields.gallery ) } />
+            { tikTokOembed && post.fields.tiktokUrl && <TikTokEmbed oembed={ tikTokOembed } url={ post.fields.tiktokUrl } /> }
             { soundCloudOembed && post.fields.soundcloudUrl && <SoundCloudEmbed oembed={ soundCloudOembed } url={ post.fields.soundcloudUrl } /> }
             { youTubeOembed && post.fields.youtubeUrl && <YouTubeEmbed oembed={ youTubeOembed } url={ post.fields.youtubeUrl } /> }
             { playlist && <Playlist playlist={ playlist } /> }

--- a/src/styles/TikTokEmbed.module.scss
+++ b/src/styles/TikTokEmbed.module.scss
@@ -1,6 +1,6 @@
 section.tiktokEmbed {
-  margin-top: 2rem;
-  margin-bottom: 4rem;
+  margin-top: 6rem;
+  margin-bottom: 6rem;
 }
 
 .tiktokHeader {


### PR DESCRIPTION
## Summary

- Move TikTok embed from before the body to after body and gallery, consistent with YouTube/SoundCloud positioning
- Update TikTok embed margins from 2rem/4rem to 6rem/6rem to match other media embeds

## Test plan

- [x] 131 tests pass
- [ ] Verify embed renders after body content on posts with TikTok URLs