### PR TITLE
feat: Google Maps embed for posts with location

### DIFF
--- a/docs/superpowers/plans/2026-04-25-location-map.md
+++ b/docs/superpowers/plans/2026-04-25-location-map.md
@@ -1,12 +1,12 @@
-# Mapbox Static Map — Implementation Plan
+# Google Maps Embed — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Render a static Mapbox map image on blog posts with a location field, with CSS-based light/dark theme switching.
+**Goal:** Render an embedded Google Map on blog posts with a location field using the free iframe embed.
 
-**Architecture:** Build static map URLs in `getStaticProps` using lat/lon from Contentful. Pass both light and dark URLs as props. The component renders two `<img>` tags inside a Google Maps link, CSS toggles visibility via `prefers-color-scheme`.
+**Architecture:** Pass lat/lon from Contentful through `getStaticProps` as props. The component constructs the embed URL and renders a responsive iframe. No API key or env vars needed.
 
-**Tech Stack:** Next.js (static export), React, TypeScript, Vitest, Mapbox Static Images API, SCSS modules
+**Tech Stack:** Next.js (static export), React, TypeScript, Vitest, SCSS modules
 
 **Closes:** #12
 
@@ -16,124 +16,15 @@
 
 | Action | File | Responsibility |
 |--------|------|----------------|
-| Create | `src/utils/maps/buildStaticMapUrl.ts` | Construct Mapbox Static Images API URLs with theme styles |
-| Create | `src/utils/maps/buildStaticMapUrl.test.ts` | Unit tests for URL construction |
-| Create | `src/components/LocationMap.tsx` | Map component with CSS theme toggle |
+| Create | `src/components/LocationMap.tsx` | Map embed component |
 | Create | `src/__tests__/components/LocationMap.test.tsx` | Unit tests for map component |
-| Create | `src/styles/LocationMap.module.scss` | Map styles with prefers-color-scheme swap |
-| Modify | `src/pages/post/[slug].tsx` | Wire up map URL construction, props, and rendering |
-| Modify | `src/__tests__/pages/post/slug.test.tsx` | Add location map tests for `getStaticProps` |
+| Create | `src/styles/LocationMap.module.scss` | Map styles |
+| Modify | `src/pages/post/[slug].tsx` | Pass location props and render LocationMap |
+| Modify | `src/__tests__/pages/post/slug.test.tsx` | Add location tests for `getStaticProps` |
 
 ---
 
-### Task 1: Create map URL utility with tests
-
-**Files:**
-- Create: `src/utils/maps/buildStaticMapUrl.ts`
-- Create: `src/utils/maps/buildStaticMapUrl.test.ts`
-
-- [ ] **Step 1: Write the failing tests**
-
-Create `src/utils/maps/buildStaticMapUrl.test.ts`:
-
-```typescript
-import { describe, it, expect, vi } from "vitest";
-
-vi.stubEnv( "MAPBOX_ACCESS_TOKEN", "test-mapbox-token" );
-
-import { buildStaticMapUrl } from "./buildStaticMapUrl";
-
-const MOCK_LAT = 47.6062;
-const MOCK_LON = -122.3321;
-
-describe( "buildStaticMapUrl", () => {
-  it( "returns a Mapbox Static Images API URL", () => {
-    const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "light" );
-
-    expect( url ).toStartWith( "https://api.mapbox.com/styles/v1/" );
-  });
-
-  it( "includes the correct coordinates in the URL", () => {
-    const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "light" );
-
-    expect( url ).toContain( `${MOCK_LON},${MOCK_LAT}` );
-  });
-
-  it( "includes a pin marker at the coordinates", () => {
-    const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "light" );
-
-    expect( url ).toContain( `pin-s+e74c3c(${MOCK_LON},${MOCK_LAT})` );
-  });
-
-  it( "includes retina scale, size, and access token", () => {
-    const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "light" );
-
-    expect( url ).toContain( "600x300@2x" );
-    expect( url ).toContain( "access_token=test-mapbox-token" );
-  });
-
-  it( "uses the streets style for light theme", () => {
-    const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "light" );
-
-    expect( url ).toContain( "mapbox/streets-v12" );
-  });
-
-  it( "uses the dark style for dark theme", () => {
-    const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "dark" );
-
-    expect( url ).toContain( "mapbox/dark-v11" );
-  });
-});
-```
-
-- [ ] **Step 2: Run tests to verify they fail**
-
-Run: `yarn test src/utils/maps/buildStaticMapUrl.test.ts`
-Expected: FAIL — module `./buildStaticMapUrl` not found.
-
-- [ ] **Step 3: Write the implementation**
-
-Create `src/utils/maps/buildStaticMapUrl.ts`:
-
-```typescript
-import { strict as assert } from "assert";
-
-const MAPBOX_ACCESS_TOKEN: string = process.env["MAPBOX_ACCESS_TOKEN"] as string;
-assert( !!MAPBOX_ACCESS_TOKEN );
-
-const MAPBOX_ENDPOINT = "https://api.mapbox.com/styles/v1";
-const MAP_ZOOM = 15;
-const MAP_WIDTH = 600;
-const MAP_HEIGHT = 300;
-const MARKER_COLOR = "e74c3c";
-
-const STYLE_IDS: Record<"light" | "dark", string> = {
-  light: "mapbox/streets-v12",
-  dark: "mapbox/dark-v11",
-};
-
-export function buildStaticMapUrl( lat: number, lon: number, theme: "light" | "dark" ): string {
-  const styleId = STYLE_IDS[theme];
-  const marker = `pin-s+${MARKER_COLOR}(${lon},${lat})`;
-  return `${MAPBOX_ENDPOINT}/${styleId}/static/${marker}/${lon},${lat},${MAP_ZOOM},0/${MAP_WIDTH}x${MAP_HEIGHT}@2x?access_token=${MAPBOX_ACCESS_TOKEN}`;
-}
-```
-
-- [ ] **Step 4: Run tests to verify they pass**
-
-Run: `yarn test src/utils/maps/buildStaticMapUrl.test.ts`
-Expected: 6 tests PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add src/utils/maps/
-git commit -m "feat: add Mapbox static map URL builder utility"
-```
-
----
-
-### Task 2: Create LocationMap component with tests
+### Task 1: Create LocationMap component with tests
 
 **Files:**
 - Create: `src/components/LocationMap.tsx`
@@ -150,45 +41,32 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 import { LocationMap } from "@/components/LocationMap";
 
-const MOCK_PROPS = {
-  lightMapUrl: "https://api.mapbox.com/styles/v1/mapbox/streets-v12/static/test-light",
-  darkMapUrl: "https://api.mapbox.com/styles/v1/mapbox/dark-v11/static/test-dark",
-  lat: 47.6062,
-  lon: -122.3321,
-};
+const MOCK_LAT = 47.6062;
+const MOCK_LON = -122.3321;
 
 describe( "LocationMap", () => {
-  it( "renders a link to Google Maps with the correct coordinates", () => {
-    render( <LocationMap { ...MOCK_PROPS } /> );
-
-    const link = screen.getByRole( "link" );
-    expect( link ).toHaveAttribute( "href", "https://www.google.com/maps?q=47.6062,-122.3321" );
-    expect( link ).toHaveAttribute( "target", "_blank" );
-    expect( link ).toHaveAttribute( "rel", "noopener noreferrer" );
-  });
-
   it( "renders a Location heading", () => {
-    render( <LocationMap { ...MOCK_PROPS } /> );
+    render( <LocationMap lat={ MOCK_LAT } lon={ MOCK_LON } /> );
 
     expect( screen.getByRole( "heading", { name: "Location" } ) ).toBeInTheDocument();
   });
 
-  it( "renders both light and dark map images", () => {
-    render( <LocationMap { ...MOCK_PROPS } /> );
+  it( "renders an iframe with the correct Google Maps embed URL", () => {
+    render( <LocationMap lat={ MOCK_LAT } lon={ MOCK_LON } /> );
 
-    const images = screen.getAllByRole( "img" );
-    const srcs = images.map( ( image ) => image.getAttribute( "src" ) );
-    expect( srcs ).toContain( MOCK_PROPS.lightMapUrl );
-    expect( srcs ).toContain( MOCK_PROPS.darkMapUrl );
+    const iframe = screen.getByTitle( "Location map" );
+    expect( iframe.tagName ).toBe( "IFRAME" );
+    expect( iframe ).toHaveAttribute(
+      "src",
+      `https://www.google.com/maps?q=${MOCK_LAT},${MOCK_LON}&output=embed`,
+    );
   });
 
-  it( "sets loading=lazy on both images", () => {
-    render( <LocationMap { ...MOCK_PROPS } /> );
+  it( "sets loading=lazy on the iframe", () => {
+    render( <LocationMap lat={ MOCK_LAT } lon={ MOCK_LON } /> );
 
-    const images = screen.getAllByRole( "img" );
-    for( const image of images ) {
-      expect( image ).toHaveAttribute( "loading", "lazy" );
-    }
+    const iframe = screen.getByTitle( "Location map" );
+    expect( iframe ).toHaveAttribute( "loading", "lazy" );
   });
 });
 ```
@@ -212,26 +90,20 @@ section.locationMap {
   margin-bottom: 1rem;
 }
 
-.mapImage {
-  width: 100%;
-  border-radius: 4px;
-}
+.iframeWrapper {
+  position: relative;
+  padding-bottom: 56.25%; /* 16:9 aspect ratio */
+  height: 0;
+  overflow: hidden;
 
-.mapLight {
-  display: none;
-}
-
-.mapDark {
-  display: block;
-}
-
-@media (prefers-color-scheme: light) {
-  .mapLight {
-    display: block;
-  }
-
-  .mapDark {
-    display: none;
+  > iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+    border-radius: 4px;
   }
 }
 ```
@@ -245,38 +117,26 @@ import { FC } from "react";
 import styles from "@/styles/LocationMap.module.scss";
 
 export interface LocationMapProps {
-  lightMapUrl: string;
-  darkMapUrl: string;
   lat: number;
   lon: number;
 }
 
-export const LocationMap: FC<LocationMapProps> = ({ lightMapUrl, darkMapUrl, lat, lon }) => {
-  const googleMapsUrl = `https://www.google.com/maps?q=${lat},${lon}`;
+export const LocationMap: FC<LocationMapProps> = ({ lat, lon }) => {
+  const embedUrl = `https://www.google.com/maps?q=${lat},${lon}&output=embed`;
 
   return (
     <section className={ styles.locationMap }>
       <header className={ styles.locationHeader }>
         <h2>Location</h2>
       </header>
-      <a
-        href={ googleMapsUrl }
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <img
-          className={ `${styles.mapImage} ${styles.mapLight}` }
-          src={ lightMapUrl }
-          alt="Location map"
+      <div className={ styles.iframeWrapper }>
+        <iframe
+          title="Location map"
+          src={ embedUrl }
           loading="lazy"
+          allowFullScreen
         />
-        <img
-          className={ `${styles.mapImage} ${styles.mapDark}` }
-          src={ darkMapUrl }
-          alt="Location map"
-          loading="lazy"
-        />
-      </a>
+      </div>
     </section>
   );
 };
@@ -285,7 +145,7 @@ export const LocationMap: FC<LocationMapProps> = ({ lightMapUrl, darkMapUrl, lat
 - [ ] **Step 5: Run tests to verify they pass**
 
 Run: `yarn test src/__tests__/components/LocationMap.test.tsx`
-Expected: 4 tests PASS.
+Expected: 3 tests PASS.
 
 - [ ] **Step 6: Run lint and format**
 
@@ -296,12 +156,12 @@ Expected: No errors.
 
 ```bash
 git add src/components/LocationMap.tsx src/__tests__/components/LocationMap.test.tsx src/styles/LocationMap.module.scss
-git commit -m "feat: add LocationMap component with CSS light/dark theme toggle"
+git commit -m "feat: add LocationMap component with Google Maps iframe embed"
 ```
 
 ---
 
-### Task 3: Integrate location map into the post page
+### Task 2: Integrate location map into the post page
 
 **Files:**
 - Modify: `src/pages/post/[slug].tsx`
@@ -311,25 +171,10 @@ git commit -m "feat: add LocationMap component with CSS light/dark theme toggle"
 
 Add to `src/__tests__/pages/post/slug.test.tsx`.
 
-Add mock at the top alongside the other mocks:
-
-```typescript
-vi.mock( "@/utils/maps/buildStaticMapUrl", () => ({
-  buildStaticMapUrl: vi.fn( ( lat: number, lon: number, theme: string ) =>
-    `https://api.mapbox.com/static/${lat},${lon}/${theme}` ),
-}) );
-```
-
-Add component mock:
+Add component mock at the top alongside the other mocks:
 
 ```typescript
 vi.mock( "@/components/LocationMap", () => ({ LocationMap: () => null }) );
-```
-
-Add import:
-
-```typescript
-import { buildStaticMapUrl } from "@/utils/maps/buildStaticMapUrl";
 ```
 
 Then add a new describe block at the end of the file:
@@ -352,17 +197,13 @@ describe( "getStaticProps — location map", () => {
     vi.mocked( getTikTokOembed ).mockResolvedValue( null );
   });
 
-  it( "builds light and dark map URLs when location is present", async () => {
+  it( "passes lat and lon when location is present", async () => {
     vi.mocked( getBlogPost ).mockResolvedValue( postWithLocation as never );
 
     const result = await getStaticProps({ params: { slug: "loc-post" } } as never );
 
-    expect( buildStaticMapUrl ).toHaveBeenCalledWith( 47.6062, -122.3321, "light" );
-    expect( buildStaticMapUrl ).toHaveBeenCalledWith( 47.6062, -122.3321, "dark" );
     expect( result ).toMatchObject({
       props: {
-        locationMapLight: expect.any( String ),
-        locationMapDark: expect.any( String ),
         locationLat: 47.6062,
         locationLon: -122.3321,
       },
@@ -374,11 +215,8 @@ describe( "getStaticProps — location map", () => {
 
     const result = await getStaticProps({ params: { slug: "no-loc-post" } } as never );
 
-    expect( buildStaticMapUrl ).not.toHaveBeenCalled();
     expect( result ).toMatchObject({
       props: {
-        locationMapLight: null,
-        locationMapDark: null,
         locationLat: null,
         locationLon: null,
       },
@@ -390,14 +228,13 @@ describe( "getStaticProps — location map", () => {
 - [ ] **Step 2: Run the new tests to verify they fail**
 
 Run: `yarn test src/__tests__/pages/post/slug.test.tsx`
-Expected: FAIL — `locationMapLight` not found in props, `buildStaticMapUrl` never called.
+Expected: FAIL — `locationLat` not found in props.
 
 - [ ] **Step 3: Update `src/pages/post/[slug].tsx` imports**
 
 Add after the TikTok import lines:
 
 ```typescript
-import { buildStaticMapUrl } from "@/utils/maps/buildStaticMapUrl";
 import { LocationMap } from "@/components/LocationMap";
 ```
 
@@ -406,8 +243,6 @@ import { LocationMap } from "@/components/LocationMap";
 Add after `tikTokOembed`:
 
 ```typescript
-  locationMapLight?: string|null
-  locationMapDark?: string|null
   locationLat?: number|null
   locationLon?: number|null
 ```
@@ -417,38 +252,29 @@ Add after `tikTokOembed`:
 Add the location props to the destructured props:
 
 ```typescript
-export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, locationMapLight, locationMapDark, locationLat, locationLon, prevPost, nextPost }) => {
+export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, locationLat, locationLon, prevPost, nextPost }) => {
 ```
 
 Add the LocationMap render after the Playlist embed, before the post nav:
 
 ```tsx
             { playlist && <Playlist playlist={ playlist } /> }
-            { locationMapLight && locationMapDark && locationLat != null && locationLon != null && (
-              <LocationMap
-                lightMapUrl={ locationMapLight }
-                darkMapUrl={ locationMapDark }
-                lat={ locationLat }
-                lon={ locationLon }
-              />
+            { locationLat != null && locationLon != null && (
+              <LocationMap lat={ locationLat } lon={ locationLon } />
             ) }
             { ( prevPost || nextPost ) && (
 ```
 
-- [ ] **Step 6: Update `getStaticProps` to build map URLs**
+- [ ] **Step 6: Update `getStaticProps` to pass location**
 
 Add after the TikTok oEmbed fetch:
 
 ```typescript
-  const locationMapLight = post.fields.location
-    ? buildStaticMapUrl( post.fields.location.lat, post.fields.location.lon, "light" ) : null;
-  const locationMapDark = post.fields.location
-    ? buildStaticMapUrl( post.fields.location.lat, post.fields.location.lon, "dark" ) : null;
   const locationLat = post.fields.location?.lat ?? null;
   const locationLon = post.fields.location?.lon ?? null;
 ```
 
-Add all four to the returned props object:
+Add both to the returned props object:
 
 ```typescript
   return {
@@ -458,8 +284,6 @@ Add all four to the returned props object:
       soundCloudOembed,
       youTubeOembed,
       tikTokOembed,
-      locationMapLight,
-      locationMapDark,
       locationLat,
       locationLon,
       prevPost,
@@ -483,38 +307,4 @@ Expected: No errors.
 ```bash
 git add "src/pages/post/[slug].tsx" "src/__tests__/pages/post/slug.test.tsx"
 git commit -m "feat: integrate location map into blog post page"
-```
-
----
-
-### Task 4: Add env var and verify
-
-**Files:** None (configuration + manual verification)
-
-- [ ] **Step 1: Add MAPBOX_ACCESS_TOKEN to .env.local**
-
-Ask the user to add their Mapbox access token to `.env.local`:
-
-```
-MAPBOX_ACCESS_TOKEN=<their-token>
-```
-
-- [ ] **Step 2: Add to GitHub Actions secrets**
-
-Remind the user to add `MAPBOX_ACCESS_TOKEN` to GitHub Actions secrets for the build pipeline.
-
-- [ ] **Step 3: Update CLAUDE.md with the new env var**
-
-Add `MAPBOX_ACCESS_TOKEN` to the environment variables section in `CLAUDE.md`.
-
-- [ ] **Step 4: Run the full build**
-
-Run: `yarn build`
-Expected: Build completes successfully. Posts with locations render map URLs in the static HTML.
-
-- [ ] **Step 5: Commit CLAUDE.md update**
-
-```bash
-git add CLAUDE.md
-git commit -m "docs: add MAPBOX_ACCESS_TOKEN to environment variables"
 ```

--- a/docs/superpowers/plans/2026-04-25-location-map.md
+++ b/docs/superpowers/plans/2026-04-25-location-map.md
@@ -1,12 +1,12 @@
-# Google Maps Static Map — Implementation Plan
+# Mapbox Static Map — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Render a static Google Maps image on blog posts with a location field, with CSS-based light/dark theme switching.
+**Goal:** Render a static Mapbox map image on blog posts with a location field, with CSS-based light/dark theme switching.
 
 **Architecture:** Build static map URLs in `getStaticProps` using lat/lon from Contentful. Pass both light and dark URLs as props. The component renders two `<img>` tags inside a Google Maps link, CSS toggles visibility via `prefers-color-scheme`.
 
-**Tech Stack:** Next.js (static export), React, TypeScript, Vitest, Google Static Maps API, SCSS modules
+**Tech Stack:** Next.js (static export), React, TypeScript, Vitest, Mapbox Static Images API, SCSS modules
 
 **Closes:** #12
 
@@ -16,7 +16,7 @@
 
 | Action | File | Responsibility |
 |--------|------|----------------|
-| Create | `src/utils/maps/buildStaticMapUrl.ts` | Construct Static Maps API URLs with theme styles |
+| Create | `src/utils/maps/buildStaticMapUrl.ts` | Construct Mapbox Static Images API URLs with theme styles |
 | Create | `src/utils/maps/buildStaticMapUrl.test.ts` | Unit tests for URL construction |
 | Create | `src/components/LocationMap.tsx` | Map component with CSS theme toggle |
 | Create | `src/__tests__/components/LocationMap.test.tsx` | Unit tests for map component |
@@ -37,45 +37,51 @@
 Create `src/utils/maps/buildStaticMapUrl.test.ts`:
 
 ```typescript
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+vi.stubEnv( "MAPBOX_ACCESS_TOKEN", "test-mapbox-token" );
+
 import { buildStaticMapUrl } from "./buildStaticMapUrl";
 
 const MOCK_LAT = 47.6062;
 const MOCK_LON = -122.3321;
 
 describe( "buildStaticMapUrl", () => {
-  it( "returns a Google Static Maps API URL with the correct center coordinates", () => {
+  it( "returns a Mapbox Static Images API URL", () => {
     const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "light" );
 
-    expect( url ).toContain( `center=${MOCK_LAT},${MOCK_LON}` );
-    expect( url ).toStartWith( "https://maps.googleapis.com/maps/api/staticmap" );
+    expect( url ).toStartWith( "https://api.mapbox.com/styles/v1/" );
   });
 
-  it( "includes zoom, size, scale, and marker parameters", () => {
+  it( "includes the correct coordinates in the URL", () => {
     const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "light" );
 
-    expect( url ).toContain( "zoom=15" );
-    expect( url ).toContain( "size=600x300" );
-    expect( url ).toContain( "scale=2" );
-    expect( url ).toContain( `markers=${MOCK_LAT},${MOCK_LON}` );
+    expect( url ).toContain( `${MOCK_LON},${MOCK_LAT}` );
   });
 
-  it( "includes the API key from environment", () => {
+  it( "includes a pin marker at the coordinates", () => {
     const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "light" );
 
-    expect( url ).toContain( "key=" );
+    expect( url ).toContain( `pin-s+e74c3c(${MOCK_LON},${MOCK_LAT})` );
   });
 
-  it( "does not include style parameters for light theme", () => {
+  it( "includes retina scale, size, and access token", () => {
     const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "light" );
 
-    expect( url ).not.toContain( "style=" );
+    expect( url ).toContain( "600x300@2x" );
+    expect( url ).toContain( "access_token=test-mapbox-token" );
   });
 
-  it( "includes dark style parameters for dark theme", () => {
+  it( "uses the streets style for light theme", () => {
+    const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "light" );
+
+    expect( url ).toContain( "mapbox/streets-v12" );
+  });
+
+  it( "uses the dark style for dark theme", () => {
     const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "dark" );
 
-    expect( url ).toContain( "style=" );
+    expect( url ).toContain( "mapbox/dark-v11" );
   });
 });
 ```
@@ -92,72 +98,37 @@ Create `src/utils/maps/buildStaticMapUrl.ts`:
 ```typescript
 import { strict as assert } from "assert";
 
-const GOOGLE_MAPS_API_KEY: string = process.env["GOOGLE_MAPS_API_KEY"] as string;
-assert( !!GOOGLE_MAPS_API_KEY );
+const MAPBOX_ACCESS_TOKEN: string = process.env["MAPBOX_ACCESS_TOKEN"] as string;
+assert( !!MAPBOX_ACCESS_TOKEN );
 
-const STATIC_MAPS_ENDPOINT = "https://maps.googleapis.com/maps/api/staticmap";
+const MAPBOX_ENDPOINT = "https://api.mapbox.com/styles/v1";
 const MAP_ZOOM = 15;
-const MAP_SIZE = "600x300";
-const MAP_SCALE = 2;
+const MAP_WIDTH = 600;
+const MAP_HEIGHT = 300;
+const MARKER_COLOR = "e74c3c";
 
-const DARK_STYLES = [
-  "element:geometry|color:0x242f3e",
-  "element:labels.text.stroke|color:0x242f3e",
-  "element:labels.text.fill|color:0x746855",
-  "feature:administrative.locality|element:labels.text.fill|color:0xd59563",
-  "feature:road|element:geometry|color:0x38414e",
-  "feature:road|element:geometry.stroke|color:0x212a37",
-  "feature:road|element:labels.text.fill|color:0x9ca5b3",
-  "feature:road.highway|element:geometry|color:0x746855",
-  "feature:road.highway|element:geometry.stroke|color:0x1f2835",
-  "feature:water|element:geometry|color:0x17263c",
-  "feature:water|element:labels.text.fill|color:0x515c6d",
-];
+const STYLE_IDS: Record<"light" | "dark", string> = {
+  light: "mapbox/streets-v12",
+  dark: "mapbox/dark-v11",
+};
 
 export function buildStaticMapUrl( lat: number, lon: number, theme: "light" | "dark" ): string {
-  const params = new URLSearchParams({
-    center: `${lat},${lon}`,
-    zoom: String( MAP_ZOOM ),
-    size: MAP_SIZE,
-    scale: String( MAP_SCALE ),
-    markers: `${lat},${lon}`,
-    key: GOOGLE_MAPS_API_KEY,
-  });
-
-  if( theme === "dark" ) {
-    for( const style of DARK_STYLES ) {
-      params.append( "style", style );
-    }
-  }
-
-  return `${STATIC_MAPS_ENDPOINT}?${params.toString()}`;
+  const styleId = STYLE_IDS[theme];
+  const marker = `pin-s+${MARKER_COLOR}(${lon},${lat})`;
+  return `${MAPBOX_ENDPOINT}/${styleId}/static/${marker}/${lon},${lat},${MAP_ZOOM},0/${MAP_WIDTH}x${MAP_HEIGHT}@2x?access_token=${MAPBOX_ACCESS_TOKEN}`;
 }
 ```
 
-- [ ] **Step 4: Set up the env var for tests**
-
-The module-level `assert` will fail if `GOOGLE_MAPS_API_KEY` is not set. Add a test setup that sets a dummy value. Create or update the test to stub the env var before the import:
-
-Update `src/utils/maps/buildStaticMapUrl.test.ts` to add at the top, before the import:
-
-```typescript
-import { describe, it, expect, vi } from "vitest";
-
-vi.stubEnv( "GOOGLE_MAPS_API_KEY", "test-api-key" );
-
-import { buildStaticMapUrl } from "./buildStaticMapUrl";
-```
-
-- [ ] **Step 5: Run tests to verify they pass**
+- [ ] **Step 4: Run tests to verify they pass**
 
 Run: `yarn test src/utils/maps/buildStaticMapUrl.test.ts`
-Expected: 5 tests PASS.
+Expected: 6 tests PASS.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add src/utils/maps/
-git commit -m "feat: add Google Static Maps URL builder utility"
+git commit -m "feat: add Mapbox static map URL builder utility"
 ```
 
 ---
@@ -180,8 +151,8 @@ import React from "react";
 import { LocationMap } from "@/components/LocationMap";
 
 const MOCK_PROPS = {
-  lightMapUrl: "https://maps.googleapis.com/maps/api/staticmap?style=light",
-  darkMapUrl: "https://maps.googleapis.com/maps/api/staticmap?style=dark",
+  lightMapUrl: "https://api.mapbox.com/styles/v1/mapbox/streets-v12/static/test-light",
+  darkMapUrl: "https://api.mapbox.com/styles/v1/mapbox/dark-v11/static/test-dark",
   lat: 47.6062,
   lon: -122.3321,
 };
@@ -190,7 +161,7 @@ describe( "LocationMap", () => {
   it( "renders a link to Google Maps with the correct coordinates", () => {
     render( <LocationMap { ...MOCK_PROPS } /> );
 
-    const link = screen.getByRole( "link", { name: /location map/i });
+    const link = screen.getByRole( "link" );
     expect( link ).toHaveAttribute( "href", "https://www.google.com/maps?q=47.6062,-122.3321" );
     expect( link ).toHaveAttribute( "target", "_blank" );
     expect( link ).toHaveAttribute( "rel", "noopener noreferrer" );
@@ -345,7 +316,7 @@ Add mock at the top alongside the other mocks:
 ```typescript
 vi.mock( "@/utils/maps/buildStaticMapUrl", () => ({
   buildStaticMapUrl: vi.fn( ( lat: number, lon: number, theme: string ) =>
-    `https://maps.googleapis.com/maps/api/staticmap?center=${lat},${lon}&theme=${theme}` ),
+    `https://api.mapbox.com/static/${lat},${lon}/${theme}` ),
 }) );
 ```
 
@@ -390,8 +361,8 @@ describe( "getStaticProps — location map", () => {
     expect( buildStaticMapUrl ).toHaveBeenCalledWith( 47.6062, -122.3321, "dark" );
     expect( result ).toMatchObject({
       props: {
-        locationMapLight: expect.stringContaining( "theme=light" ),
-        locationMapDark: expect.stringContaining( "theme=dark" ),
+        locationMapLight: expect.any( String ),
+        locationMapDark: expect.any( String ),
         locationLat: 47.6062,
         locationLon: -122.3321,
       },
@@ -520,21 +491,21 @@ git commit -m "feat: integrate location map into blog post page"
 
 **Files:** None (configuration + manual verification)
 
-- [ ] **Step 1: Add GOOGLE_MAPS_API_KEY to .env.local**
+- [ ] **Step 1: Add MAPBOX_ACCESS_TOKEN to .env.local**
 
-Ask the user to add their Google Maps API key to `.env.local`:
+Ask the user to add their Mapbox access token to `.env.local`:
 
 ```
-GOOGLE_MAPS_API_KEY=<their-key>
+MAPBOX_ACCESS_TOKEN=<their-token>
 ```
 
 - [ ] **Step 2: Add to GitHub Actions secrets**
 
-Remind the user to add `GOOGLE_MAPS_API_KEY` to GitHub Actions secrets for the build pipeline.
+Remind the user to add `MAPBOX_ACCESS_TOKEN` to GitHub Actions secrets for the build pipeline.
 
 - [ ] **Step 3: Update CLAUDE.md with the new env var**
 
-Add `GOOGLE_MAPS_API_KEY` to the environment variables section in `CLAUDE.md`.
+Add `MAPBOX_ACCESS_TOKEN` to the environment variables section in `CLAUDE.md`.
 
 - [ ] **Step 4: Run the full build**
 
@@ -545,5 +516,5 @@ Expected: Build completes successfully. Posts with locations render map URLs in 
 
 ```bash
 git add CLAUDE.md
-git commit -m "docs: add GOOGLE_MAPS_API_KEY to environment variables"
+git commit -m "docs: add MAPBOX_ACCESS_TOKEN to environment variables"
 ```

--- a/docs/superpowers/plans/2026-04-25-location-map.md
+++ b/docs/superpowers/plans/2026-04-25-location-map.md
@@ -1,0 +1,549 @@
+# Google Maps Static Map — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render a static Google Maps image on blog posts with a location field, with CSS-based light/dark theme switching.
+
+**Architecture:** Build static map URLs in `getStaticProps` using lat/lon from Contentful. Pass both light and dark URLs as props. The component renders two `<img>` tags inside a Google Maps link, CSS toggles visibility via `prefers-color-scheme`.
+
+**Tech Stack:** Next.js (static export), React, TypeScript, Vitest, Google Static Maps API, SCSS modules
+
+**Closes:** #12
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/utils/maps/buildStaticMapUrl.ts` | Construct Static Maps API URLs with theme styles |
+| Create | `src/utils/maps/buildStaticMapUrl.test.ts` | Unit tests for URL construction |
+| Create | `src/components/LocationMap.tsx` | Map component with CSS theme toggle |
+| Create | `src/__tests__/components/LocationMap.test.tsx` | Unit tests for map component |
+| Create | `src/styles/LocationMap.module.scss` | Map styles with prefers-color-scheme swap |
+| Modify | `src/pages/post/[slug].tsx` | Wire up map URL construction, props, and rendering |
+| Modify | `src/__tests__/pages/post/slug.test.tsx` | Add location map tests for `getStaticProps` |
+
+---
+
+### Task 1: Create map URL utility with tests
+
+**Files:**
+- Create: `src/utils/maps/buildStaticMapUrl.ts`
+- Create: `src/utils/maps/buildStaticMapUrl.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/utils/maps/buildStaticMapUrl.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { buildStaticMapUrl } from "./buildStaticMapUrl";
+
+const MOCK_LAT = 47.6062;
+const MOCK_LON = -122.3321;
+
+describe( "buildStaticMapUrl", () => {
+  it( "returns a Google Static Maps API URL with the correct center coordinates", () => {
+    const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "light" );
+
+    expect( url ).toContain( `center=${MOCK_LAT},${MOCK_LON}` );
+    expect( url ).toStartWith( "https://maps.googleapis.com/maps/api/staticmap" );
+  });
+
+  it( "includes zoom, size, scale, and marker parameters", () => {
+    const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "light" );
+
+    expect( url ).toContain( "zoom=15" );
+    expect( url ).toContain( "size=600x300" );
+    expect( url ).toContain( "scale=2" );
+    expect( url ).toContain( `markers=${MOCK_LAT},${MOCK_LON}` );
+  });
+
+  it( "includes the API key from environment", () => {
+    const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "light" );
+
+    expect( url ).toContain( "key=" );
+  });
+
+  it( "does not include style parameters for light theme", () => {
+    const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "light" );
+
+    expect( url ).not.toContain( "style=" );
+  });
+
+  it( "includes dark style parameters for dark theme", () => {
+    const url = buildStaticMapUrl( MOCK_LAT, MOCK_LON, "dark" );
+
+    expect( url ).toContain( "style=" );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test src/utils/maps/buildStaticMapUrl.test.ts`
+Expected: FAIL — module `./buildStaticMapUrl` not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/utils/maps/buildStaticMapUrl.ts`:
+
+```typescript
+import { strict as assert } from "assert";
+
+const GOOGLE_MAPS_API_KEY: string = process.env["GOOGLE_MAPS_API_KEY"] as string;
+assert( !!GOOGLE_MAPS_API_KEY );
+
+const STATIC_MAPS_ENDPOINT = "https://maps.googleapis.com/maps/api/staticmap";
+const MAP_ZOOM = 15;
+const MAP_SIZE = "600x300";
+const MAP_SCALE = 2;
+
+const DARK_STYLES = [
+  "element:geometry|color:0x242f3e",
+  "element:labels.text.stroke|color:0x242f3e",
+  "element:labels.text.fill|color:0x746855",
+  "feature:administrative.locality|element:labels.text.fill|color:0xd59563",
+  "feature:road|element:geometry|color:0x38414e",
+  "feature:road|element:geometry.stroke|color:0x212a37",
+  "feature:road|element:labels.text.fill|color:0x9ca5b3",
+  "feature:road.highway|element:geometry|color:0x746855",
+  "feature:road.highway|element:geometry.stroke|color:0x1f2835",
+  "feature:water|element:geometry|color:0x17263c",
+  "feature:water|element:labels.text.fill|color:0x515c6d",
+];
+
+export function buildStaticMapUrl( lat: number, lon: number, theme: "light" | "dark" ): string {
+  const params = new URLSearchParams({
+    center: `${lat},${lon}`,
+    zoom: String( MAP_ZOOM ),
+    size: MAP_SIZE,
+    scale: String( MAP_SCALE ),
+    markers: `${lat},${lon}`,
+    key: GOOGLE_MAPS_API_KEY,
+  });
+
+  if( theme === "dark" ) {
+    for( const style of DARK_STYLES ) {
+      params.append( "style", style );
+    }
+  }
+
+  return `${STATIC_MAPS_ENDPOINT}?${params.toString()}`;
+}
+```
+
+- [ ] **Step 4: Set up the env var for tests**
+
+The module-level `assert` will fail if `GOOGLE_MAPS_API_KEY` is not set. Add a test setup that sets a dummy value. Create or update the test to stub the env var before the import:
+
+Update `src/utils/maps/buildStaticMapUrl.test.ts` to add at the top, before the import:
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+
+vi.stubEnv( "GOOGLE_MAPS_API_KEY", "test-api-key" );
+
+import { buildStaticMapUrl } from "./buildStaticMapUrl";
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `yarn test src/utils/maps/buildStaticMapUrl.test.ts`
+Expected: 5 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/maps/
+git commit -m "feat: add Google Static Maps URL builder utility"
+```
+
+---
+
+### Task 2: Create LocationMap component with tests
+
+**Files:**
+- Create: `src/components/LocationMap.tsx`
+- Create: `src/__tests__/components/LocationMap.test.tsx`
+- Create: `src/styles/LocationMap.module.scss`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/__tests__/components/LocationMap.test.tsx`:
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { LocationMap } from "@/components/LocationMap";
+
+const MOCK_PROPS = {
+  lightMapUrl: "https://maps.googleapis.com/maps/api/staticmap?style=light",
+  darkMapUrl: "https://maps.googleapis.com/maps/api/staticmap?style=dark",
+  lat: 47.6062,
+  lon: -122.3321,
+};
+
+describe( "LocationMap", () => {
+  it( "renders a link to Google Maps with the correct coordinates", () => {
+    render( <LocationMap { ...MOCK_PROPS } /> );
+
+    const link = screen.getByRole( "link", { name: /location map/i });
+    expect( link ).toHaveAttribute( "href", "https://www.google.com/maps?q=47.6062,-122.3321" );
+    expect( link ).toHaveAttribute( "target", "_blank" );
+    expect( link ).toHaveAttribute( "rel", "noopener noreferrer" );
+  });
+
+  it( "renders a Location heading", () => {
+    render( <LocationMap { ...MOCK_PROPS } /> );
+
+    expect( screen.getByRole( "heading", { name: "Location" } ) ).toBeInTheDocument();
+  });
+
+  it( "renders both light and dark map images", () => {
+    render( <LocationMap { ...MOCK_PROPS } /> );
+
+    const images = screen.getAllByRole( "img" );
+    const srcs = images.map( ( image ) => image.getAttribute( "src" ) );
+    expect( srcs ).toContain( MOCK_PROPS.lightMapUrl );
+    expect( srcs ).toContain( MOCK_PROPS.darkMapUrl );
+  });
+
+  it( "sets loading=lazy on both images", () => {
+    render( <LocationMap { ...MOCK_PROPS } /> );
+
+    const images = screen.getAllByRole( "img" );
+    for( const image of images ) {
+      expect( image ).toHaveAttribute( "loading", "lazy" );
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test src/__tests__/components/LocationMap.test.tsx`
+Expected: FAIL — module `@/components/LocationMap` not found.
+
+- [ ] **Step 3: Create the SCSS module**
+
+Create `src/styles/LocationMap.module.scss`:
+
+```scss
+section.locationMap {
+  margin-top: 6rem;
+  margin-bottom: 6rem;
+}
+
+.locationHeader {
+  margin-bottom: 1rem;
+}
+
+.mapImage {
+  width: 100%;
+  border-radius: 4px;
+}
+
+.mapLight {
+  display: none;
+}
+
+.mapDark {
+  display: block;
+}
+
+@media (prefers-color-scheme: light) {
+  .mapLight {
+    display: block;
+  }
+
+  .mapDark {
+    display: none;
+  }
+}
+```
+
+- [ ] **Step 4: Write the component implementation**
+
+Create `src/components/LocationMap.tsx`:
+
+```tsx
+import { FC } from "react";
+import styles from "@/styles/LocationMap.module.scss";
+
+export interface LocationMapProps {
+  lightMapUrl: string;
+  darkMapUrl: string;
+  lat: number;
+  lon: number;
+}
+
+export const LocationMap: FC<LocationMapProps> = ({ lightMapUrl, darkMapUrl, lat, lon }) => {
+  const googleMapsUrl = `https://www.google.com/maps?q=${lat},${lon}`;
+
+  return (
+    <section className={ styles.locationMap }>
+      <header className={ styles.locationHeader }>
+        <h2>Location</h2>
+      </header>
+      <a
+        href={ googleMapsUrl }
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img
+          className={ `${styles.mapImage} ${styles.mapLight}` }
+          src={ lightMapUrl }
+          alt="Location map"
+          loading="lazy"
+        />
+        <img
+          className={ `${styles.mapImage} ${styles.mapDark}` }
+          src={ darkMapUrl }
+          alt="Location map"
+          loading="lazy"
+        />
+      </a>
+    </section>
+  );
+};
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `yarn test src/__tests__/components/LocationMap.test.tsx`
+Expected: 4 tests PASS.
+
+- [ ] **Step 6: Run lint and format**
+
+Run: `yarn format`
+Expected: No errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/LocationMap.tsx src/__tests__/components/LocationMap.test.tsx src/styles/LocationMap.module.scss
+git commit -m "feat: add LocationMap component with CSS light/dark theme toggle"
+```
+
+---
+
+### Task 3: Integrate location map into the post page
+
+**Files:**
+- Modify: `src/pages/post/[slug].tsx`
+- Modify: `src/__tests__/pages/post/slug.test.tsx`
+
+- [ ] **Step 1: Write the failing tests for getStaticProps location integration**
+
+Add to `src/__tests__/pages/post/slug.test.tsx`.
+
+Add mock at the top alongside the other mocks:
+
+```typescript
+vi.mock( "@/utils/maps/buildStaticMapUrl", () => ({
+  buildStaticMapUrl: vi.fn( ( lat: number, lon: number, theme: string ) =>
+    `https://maps.googleapis.com/maps/api/staticmap?center=${lat},${lon}&theme=${theme}` ),
+}) );
+```
+
+Add component mock:
+
+```typescript
+vi.mock( "@/components/LocationMap", () => ({ LocationMap: () => null }) );
+```
+
+Add import:
+
+```typescript
+import { buildStaticMapUrl } from "@/utils/maps/buildStaticMapUrl";
+```
+
+Then add a new describe block at the end of the file:
+
+```typescript
+describe( "getStaticProps — location map", () => {
+  const postWithLocation = makePost({ slug: "loc-post" });
+  Object.assign( postWithLocation.fields, {
+    location: { lat: 47.6062, lon: -122.3321 },
+  });
+
+  const postWithoutLocation = makePost({ slug: "no-loc-post" });
+
+  beforeEach( () => {
+    vi.resetAllMocks();
+    vi.mocked( getBlogPosts ).mockResolvedValue({ items: [ postWithLocation, postWithoutLocation ] } as never );
+    vi.mocked( getPlaylist ).mockResolvedValue( null as never );
+    vi.mocked( getOembed ).mockResolvedValue( null );
+    vi.mocked( getYouTubeOembed ).mockResolvedValue( null );
+    vi.mocked( getTikTokOembed ).mockResolvedValue( null );
+  });
+
+  it( "builds light and dark map URLs when location is present", async () => {
+    vi.mocked( getBlogPost ).mockResolvedValue( postWithLocation as never );
+
+    const result = await getStaticProps({ params: { slug: "loc-post" } } as never );
+
+    expect( buildStaticMapUrl ).toHaveBeenCalledWith( 47.6062, -122.3321, "light" );
+    expect( buildStaticMapUrl ).toHaveBeenCalledWith( 47.6062, -122.3321, "dark" );
+    expect( result ).toMatchObject({
+      props: {
+        locationMapLight: expect.stringContaining( "theme=light" ),
+        locationMapDark: expect.stringContaining( "theme=dark" ),
+        locationLat: 47.6062,
+        locationLon: -122.3321,
+      },
+    });
+  });
+
+  it( "passes null for location props when location is absent", async () => {
+    vi.mocked( getBlogPost ).mockResolvedValue( postWithoutLocation as never );
+
+    const result = await getStaticProps({ params: { slug: "no-loc-post" } } as never );
+
+    expect( buildStaticMapUrl ).not.toHaveBeenCalled();
+    expect( result ).toMatchObject({
+      props: {
+        locationMapLight: null,
+        locationMapDark: null,
+        locationLat: null,
+        locationLon: null,
+      },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `yarn test src/__tests__/pages/post/slug.test.tsx`
+Expected: FAIL — `locationMapLight` not found in props, `buildStaticMapUrl` never called.
+
+- [ ] **Step 3: Update `src/pages/post/[slug].tsx` imports**
+
+Add after the TikTok import lines:
+
+```typescript
+import { buildStaticMapUrl } from "@/utils/maps/buildStaticMapUrl";
+import { LocationMap } from "@/components/LocationMap";
+```
+
+- [ ] **Step 4: Update `BlogPostViewProps` interface**
+
+Add after `tikTokOembed`:
+
+```typescript
+  locationMapLight?: string|null
+  locationMapDark?: string|null
+  locationLat?: number|null
+  locationLon?: number|null
+```
+
+- [ ] **Step 5: Update `BlogPostView` component signature and rendering**
+
+Add the location props to the destructured props:
+
+```typescript
+export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, locationMapLight, locationMapDark, locationLat, locationLon, prevPost, nextPost }) => {
+```
+
+Add the LocationMap render after the Playlist embed, before the post nav:
+
+```tsx
+            { playlist && <Playlist playlist={ playlist } /> }
+            { locationMapLight && locationMapDark && locationLat != null && locationLon != null && (
+              <LocationMap
+                lightMapUrl={ locationMapLight }
+                darkMapUrl={ locationMapDark }
+                lat={ locationLat }
+                lon={ locationLon }
+              />
+            ) }
+            { ( prevPost || nextPost ) && (
+```
+
+- [ ] **Step 6: Update `getStaticProps` to build map URLs**
+
+Add after the TikTok oEmbed fetch:
+
+```typescript
+  const locationMapLight = post.fields.location
+    ? buildStaticMapUrl( post.fields.location.lat, post.fields.location.lon, "light" ) : null;
+  const locationMapDark = post.fields.location
+    ? buildStaticMapUrl( post.fields.location.lat, post.fields.location.lon, "dark" ) : null;
+  const locationLat = post.fields.location?.lat ?? null;
+  const locationLon = post.fields.location?.lon ?? null;
+```
+
+Add all four to the returned props object:
+
+```typescript
+  return {
+    props: {
+      post,
+      playlist,
+      soundCloudOembed,
+      youTubeOembed,
+      tikTokOembed,
+      locationMapLight,
+      locationMapDark,
+      locationLat,
+      locationLon,
+      prevPost,
+      nextPost,
+    },
+  };
+```
+
+- [ ] **Step 7: Run all tests to verify everything passes**
+
+Run: `yarn test`
+Expected: All tests PASS, including the new location map tests.
+
+- [ ] **Step 8: Run lint, format, and typecheck**
+
+Run: `yarn format && yarn typecheck`
+Expected: No errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add "src/pages/post/[slug].tsx" "src/__tests__/pages/post/slug.test.tsx"
+git commit -m "feat: integrate location map into blog post page"
+```
+
+---
+
+### Task 4: Add env var and verify
+
+**Files:** None (configuration + manual verification)
+
+- [ ] **Step 1: Add GOOGLE_MAPS_API_KEY to .env.local**
+
+Ask the user to add their Google Maps API key to `.env.local`:
+
+```
+GOOGLE_MAPS_API_KEY=<their-key>
+```
+
+- [ ] **Step 2: Add to GitHub Actions secrets**
+
+Remind the user to add `GOOGLE_MAPS_API_KEY` to GitHub Actions secrets for the build pipeline.
+
+- [ ] **Step 3: Update CLAUDE.md with the new env var**
+
+Add `GOOGLE_MAPS_API_KEY` to the environment variables section in `CLAUDE.md`.
+
+- [ ] **Step 4: Run the full build**
+
+Run: `yarn build`
+Expected: Build completes successfully. Posts with locations render map URLs in the static HTML.
+
+- [ ] **Step 5: Commit CLAUDE.md update**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add GOOGLE_MAPS_API_KEY to environment variables"
+```

--- a/docs/superpowers/specs/2026-04-25-location-map-design.md
+++ b/docs/superpowers/specs/2026-04-25-location-map-design.md
@@ -1,24 +1,25 @@
-# Google Maps Static Map Integration
+# Mapbox Static Map Integration
 
 ## Overview
 
-Render a static Google Maps image on blog posts that have a `location` field. The image links to Google Maps for full interactivity. Light and dark themed variants swap via CSS `prefers-color-scheme` media query — no JavaScript needed.
+Render a static Mapbox map image on blog posts that have a `location` field. The image links to Google Maps for full interactivity. Light and dark themed variants swap via CSS `prefers-color-scheme` media query — no JavaScript needed.
 
 ## Decisions
 
-- **Static Maps API** over Embed API or JS API — lightest weight, just an `<img>` tag, fits the static export architecture
-- **Build URLs in `getStaticProps`** — follows existing data-resolution pattern, API key in env vars with HTTP referrer restriction
+- **Mapbox Static Images API** over Google Maps — free tier (50,000 req/month), no billing account required
+- **Build URLs in `getStaticProps`** — follows existing data-resolution pattern, access token in env vars
 - **CSS-based theme switching** — two `<img>` tags toggled with `display: none`/`display: block` via `prefers-color-scheme`, no hydration concerns
 - **Render after all embeds** — map is supplementary context, not primary content
 - **Lazy loading** — `loading="lazy"` on both images so the hidden variant doesn't get fetched
+- **Link to Google Maps** — clicking the map opens Google Maps (better UX than Mapbox for directions/navigation)
 
 ## Environment
 
-New required env var: `GOOGLE_MAPS_API_KEY`
+New required env var: `MAPBOX_ACCESS_TOKEN`
 
-- Must have Static Maps API enabled in Google Cloud Console
-- HTTP referrer restriction to `audeos.com/*` (key is visible in page source by design)
+- Free Mapbox account, no billing required
 - Asserted at module level in the map utility using the existing `assert` pattern
+- Token is visible in page source (standard for static map URLs)
 
 Add to GitHub Actions secrets for the build pipeline.
 
@@ -30,25 +31,29 @@ Pure function: `buildStaticMapUrl( lat: number, lon: number, theme: "light" | "d
 
 **Parameters:**
 - `lat`, `lon` — from Contentful location field
-- `theme` — determines style params
+- `theme` — determines which Mapbox style to use
+
+**Mapbox Static Images URL format:**
+```
+https://api.mapbox.com/styles/v1/{style_id}/static/pin-s+e74c3c({lon},{lat})/{lon},{lat},{zoom},0/{width}x{height}@2x?access_token={token}
+```
 
 **Map configuration:**
 - Zoom: 15 (neighborhood level)
-- Size: `600x300`
-- Scale: `2` (retina)
-- Marker: red pin at lat/lon
-- Dark theme: dark grey land, dark water, light roads, minimal labels (inline style params)
-- Light theme: default Google Maps styling (no style params)
+- Size: `600x300` with `@2x` for retina
+- Marker: small red pin (`pin-s+e74c3c`) at lat/lon
+- Dark theme: `mapbox/dark-v11` style
+- Light theme: `mapbox/streets-v12` style
 
-Returns the full Static Maps API URL with all parameters.
+Returns the full Mapbox Static Images API URL.
 
 ## Component
 
 ### `src/components/LocationMap.tsx`
 
 **Props:**
-- `lightMapUrl: string` — Static Maps URL with light theme
-- `darkMapUrl: string` — Static Maps URL with dark theme
+- `lightMapUrl: string` — Static map URL with light theme
+- `darkMapUrl: string` — Static map URL with dark theme
 - `lat: number`
 - `lon: number`
 

--- a/docs/superpowers/specs/2026-04-25-location-map-design.md
+++ b/docs/superpowers/specs/2026-04-25-location-map-design.md
@@ -1,90 +1,46 @@
-# Mapbox Static Map Integration
+# Google Maps Embed Integration
 
 ## Overview
 
-Render a static Mapbox map image on blog posts that have a `location` field. The image links to Google Maps for full interactivity. Light and dark themed variants swap via CSS `prefers-color-scheme` media query — no JavaScript needed.
+Render an embedded Google Map on blog posts that have a `location` field. Uses the free Google Maps Embed (no API key, no billing). Clicking the map opens full Google Maps.
 
 ## Decisions
 
-- **Mapbox Static Images API** over Google Maps — free tier (50,000 req/month), no billing account required
-- **Build URLs in `getStaticProps`** — follows existing data-resolution pattern, access token in env vars
-- **CSS-based theme switching** — two `<img>` tags toggled with `display: none`/`display: block` via `prefers-color-scheme`, no hydration concerns
+- **Google Maps Embed (iframe)** — completely free, no API key, no billing, no account needed
+- **No theme switching** — Google controls the iframe content (same situation as TikTok embeds)
 - **Render after all embeds** — map is supplementary context, not primary content
-- **Lazy loading** — `loading="lazy"` on both images so the hidden variant doesn't get fetched
-- **Link to Google Maps** — clicking the map opens Google Maps (better UX than Mapbox for directions/navigation)
-
-## Environment
-
-New required env var: `MAPBOX_ACCESS_TOKEN`
-
-- Free Mapbox account, no billing required
-- Asserted at module level in the map utility using the existing `assert` pattern
-- Token is visible in page source (standard for static map URLs)
-
-Add to GitHub Actions secrets for the build pipeline.
-
-## Map URL Utility
-
-### `src/utils/maps/buildStaticMapUrl.ts`
-
-Pure function: `buildStaticMapUrl( lat: number, lon: number, theme: "light" | "dark" ): string`
-
-**Parameters:**
-- `lat`, `lon` — from Contentful location field
-- `theme` — determines which Mapbox style to use
-
-**Mapbox Static Images URL format:**
-```
-https://api.mapbox.com/styles/v1/{style_id}/static/pin-s+e74c3c({lon},{lat})/{lon},{lat},{zoom},0/{width}x{height}@2x?access_token={token}
-```
-
-**Map configuration:**
-- Zoom: 15 (neighborhood level)
-- Size: `600x300` with `@2x` for retina
-- Marker: small red pin (`pin-s+e74c3c`) at lat/lon
-- Dark theme: `mapbox/dark-v11` style
-- Light theme: `mapbox/streets-v12` style
-
-Returns the full Mapbox Static Images API URL.
+- **No env var needed** — the embed URL is constructed from lat/lon with no authentication
 
 ## Component
 
 ### `src/components/LocationMap.tsx`
 
 **Props:**
-- `lightMapUrl: string` — Static map URL with light theme
-- `darkMapUrl: string` — Static map URL with dark theme
 - `lat: number`
 - `lon: number`
 
 **Rendering:**
 - `<section>` wrapper with class `locationMap`
 - `<header>` with `<h2>`: `Location`
-- `<a>` tag linking to `https://www.google.com/maps?q={lat},{lon}`, opens in new tab
-- Two `<img>` tags inside the link (light and dark), CSS toggles visibility
-- Both images have `loading="lazy"` and descriptive `alt` text
+- `<div>` with responsive iframe wrapper (same pattern as YouTube embed)
+- `<iframe>` with `src="https://www.google.com/maps?q={lat},{lon}&output=embed"`, no border
+- `loading="lazy"` on the iframe
 
 ### `src/styles/LocationMap.module.scss`
 
 - `section.locationMap` — `margin-top: 6rem; margin-bottom: 6rem` (matches other embeds)
 - `.locationHeader` — `margin-bottom: 1rem`
-- `.mapImage` — `width: 100%; border-radius: 4px`
-- `.mapLight` — `display: none` by default
-- `.mapDark` — `display: block` by default
-- `@media (prefers-color-scheme: light)` — swap: `.mapLight { display: block }`, `.mapDark { display: none }`
+- `.iframeWrapper` — responsive 16:9 container (same pattern as YouTubeEmbed)
 
 ## Page Integration
 
 ### `src/pages/post/[slug].tsx`
 
 **`getStaticProps`:**
-- When `post.fields.location` exists, construct both URLs using `buildStaticMapUrl`
-- Pass `locationMapLight`, `locationMapDark`, `locationLat`, `locationLon` as props
-- When no location, pass `null` for all four
+- When `post.fields.location` exists, pass `locationLat` and `locationLon` as props
+- When no location, pass `null` for both
 
 **`BlogPostViewProps`:**
-- `locationMapLight?: string | null`
-- `locationMapDark?: string | null`
 - `locationLat?: number | null`
 - `locationLon?: number | null`
 
@@ -95,12 +51,11 @@ Returns the full Mapbox Static Images API URL.
 
 | File | Purpose |
 |------|---------|
-| `src/utils/maps/buildStaticMapUrl.ts` | URL construction utility |
-| `src/components/LocationMap.tsx` | Map component with CSS theme toggle |
-| `src/styles/LocationMap.module.scss` | Map styles with prefers-color-scheme swap |
+| `src/components/LocationMap.tsx` | Map embed component |
+| `src/styles/LocationMap.module.scss` | Map styles |
 
 ## Files to Modify
 
 | File | Change |
 |------|--------|
-| `src/pages/post/[slug].tsx` | Add map URL construction, props, and LocationMap render |
+| `src/pages/post/[slug].tsx` | Pass location props and render LocationMap |

--- a/docs/superpowers/specs/2026-04-25-location-map-design.md
+++ b/docs/superpowers/specs/2026-04-25-location-map-design.md
@@ -1,0 +1,101 @@
+# Google Maps Static Map Integration
+
+## Overview
+
+Render a static Google Maps image on blog posts that have a `location` field. The image links to Google Maps for full interactivity. Light and dark themed variants swap via CSS `prefers-color-scheme` media query — no JavaScript needed.
+
+## Decisions
+
+- **Static Maps API** over Embed API or JS API — lightest weight, just an `<img>` tag, fits the static export architecture
+- **Build URLs in `getStaticProps`** — follows existing data-resolution pattern, API key in env vars with HTTP referrer restriction
+- **CSS-based theme switching** — two `<img>` tags toggled with `display: none`/`display: block` via `prefers-color-scheme`, no hydration concerns
+- **Render after all embeds** — map is supplementary context, not primary content
+- **Lazy loading** — `loading="lazy"` on both images so the hidden variant doesn't get fetched
+
+## Environment
+
+New required env var: `GOOGLE_MAPS_API_KEY`
+
+- Must have Static Maps API enabled in Google Cloud Console
+- HTTP referrer restriction to `audeos.com/*` (key is visible in page source by design)
+- Asserted at module level in the map utility using the existing `assert` pattern
+
+Add to GitHub Actions secrets for the build pipeline.
+
+## Map URL Utility
+
+### `src/utils/maps/buildStaticMapUrl.ts`
+
+Pure function: `buildStaticMapUrl( lat: number, lon: number, theme: "light" | "dark" ): string`
+
+**Parameters:**
+- `lat`, `lon` — from Contentful location field
+- `theme` — determines style params
+
+**Map configuration:**
+- Zoom: 15 (neighborhood level)
+- Size: `600x300`
+- Scale: `2` (retina)
+- Marker: red pin at lat/lon
+- Dark theme: dark grey land, dark water, light roads, minimal labels (inline style params)
+- Light theme: default Google Maps styling (no style params)
+
+Returns the full Static Maps API URL with all parameters.
+
+## Component
+
+### `src/components/LocationMap.tsx`
+
+**Props:**
+- `lightMapUrl: string` — Static Maps URL with light theme
+- `darkMapUrl: string` — Static Maps URL with dark theme
+- `lat: number`
+- `lon: number`
+
+**Rendering:**
+- `<section>` wrapper with class `locationMap`
+- `<header>` with `<h2>`: `Location`
+- `<a>` tag linking to `https://www.google.com/maps?q={lat},{lon}`, opens in new tab
+- Two `<img>` tags inside the link (light and dark), CSS toggles visibility
+- Both images have `loading="lazy"` and descriptive `alt` text
+
+### `src/styles/LocationMap.module.scss`
+
+- `section.locationMap` — `margin-top: 6rem; margin-bottom: 6rem` (matches other embeds)
+- `.locationHeader` — `margin-bottom: 1rem`
+- `.mapImage` — `width: 100%; border-radius: 4px`
+- `.mapLight` — `display: none` by default
+- `.mapDark` — `display: block` by default
+- `@media (prefers-color-scheme: light)` — swap: `.mapLight { display: block }`, `.mapDark { display: none }`
+
+## Page Integration
+
+### `src/pages/post/[slug].tsx`
+
+**`getStaticProps`:**
+- When `post.fields.location` exists, construct both URLs using `buildStaticMapUrl`
+- Pass `locationMapLight`, `locationMapDark`, `locationLat`, `locationLon` as props
+- When no location, pass `null` for all four
+
+**`BlogPostViewProps`:**
+- `locationMapLight?: string | null`
+- `locationMapDark?: string | null`
+- `locationLat?: number | null`
+- `locationLon?: number | null`
+
+**Render position:**
+- After all media embeds (TikTok, SoundCloud, YouTube, Spotify), before post nav
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `src/utils/maps/buildStaticMapUrl.ts` | URL construction utility |
+| `src/components/LocationMap.tsx` | Map component with CSS theme toggle |
+| `src/styles/LocationMap.module.scss` | Map styles with prefers-color-scheme swap |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/pages/post/[slug].tsx` | Add map URL construction, props, and LocationMap render |

--- a/src/__tests__/components/LocationMap.test.tsx
+++ b/src/__tests__/components/LocationMap.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { LocationMap } from "@/components/LocationMap";
+
+const MOCK_LAT = 47.6062;
+const MOCK_LON = -122.3321;
+
+describe( "LocationMap", () => {
+  it( "renders a Location heading", () => {
+    render( <LocationMap lat={ MOCK_LAT } lon={ MOCK_LON } /> );
+
+    expect( screen.getByRole( "heading", { name: "Location" }) ).toBeInTheDocument();
+  });
+
+  it( "renders an iframe with the correct Google Maps embed URL", () => {
+    render( <LocationMap lat={ MOCK_LAT } lon={ MOCK_LON } /> );
+
+    const iframe = screen.getByTitle( "Location map" );
+    expect( iframe.tagName ).toBe( "IFRAME" );
+    expect( iframe ).toHaveAttribute(
+      "src",
+      `https://www.google.com/maps?q=${MOCK_LAT},${MOCK_LON}&output=embed`,
+    );
+  });
+
+  it( "sets loading=lazy on the iframe", () => {
+    render( <LocationMap lat={ MOCK_LAT } lon={ MOCK_LON } /> );
+
+    const iframe = screen.getByTitle( "Location map" );
+    expect( iframe ).toHaveAttribute( "loading", "lazy" );
+  });
+});

--- a/src/__tests__/components/LocationMap.test.tsx
+++ b/src/__tests__/components/LocationMap.test.tsx
@@ -30,4 +30,17 @@ describe( "LocationMap", () => {
     const iframe = screen.getByTitle( "Location map" );
     expect( iframe ).toHaveAttribute( "loading", "lazy" );
   });
+
+  it( "renders the address when provided", () => {
+    render( <LocationMap lat={ MOCK_LAT } lon={ MOCK_LON } address="233 Broadway, Seattle, WA 98122" /> );
+
+    expect( screen.getByText( "233 Broadway, Seattle, WA 98122" ) ).toBeInTheDocument();
+  });
+
+  it( "does not render an address paragraph when address is not provided", () => {
+    render( <LocationMap lat={ MOCK_LAT } lon={ MOCK_LON } /> );
+
+    const header = screen.getByRole( "heading", { name: "Location" }).parentElement;
+    expect( header?.querySelectorAll( "p" ) ).toHaveLength( 0 );
+  });
 });

--- a/src/__tests__/components/LocationMap.test.tsx
+++ b/src/__tests__/components/LocationMap.test.tsx
@@ -3,44 +3,59 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 import { LocationMap } from "@/components/LocationMap";
 
-const MOCK_LAT = 47.6062;
-const MOCK_LON = -122.3321;
+const MOCK_GOOGLE_MAPS_URL = "https://www.google.com/maps/place/Gan+Bei+Eatery+and+Bar/@47.597685,-122.3267081,17z/data=!3m1!4b1";
 
 describe( "LocationMap", () => {
   it( "renders a Location heading", () => {
-    render( <LocationMap lat={ MOCK_LAT } lon={ MOCK_LON } /> );
+    render( <LocationMap googleMapsUrl={ MOCK_GOOGLE_MAPS_URL } /> );
 
     expect( screen.getByRole( "heading", { name: "Location" }) ).toBeInTheDocument();
   });
 
-  it( "renders an iframe with the correct Google Maps embed URL", () => {
-    render( <LocationMap lat={ MOCK_LAT } lon={ MOCK_LON } /> );
+  it( "renders an iframe with coordinates extracted from the Google Maps URL", () => {
+    render( <LocationMap googleMapsUrl={ MOCK_GOOGLE_MAPS_URL } /> );
 
     const iframe = screen.getByTitle( "Location map" );
     expect( iframe.tagName ).toBe( "IFRAME" );
     expect( iframe ).toHaveAttribute(
       "src",
-      `https://www.google.com/maps?q=${MOCK_LAT},${MOCK_LON}&output=embed`,
+      "https://www.google.com/maps?q=47.597685,-122.3267081&output=embed",
     );
   });
 
   it( "sets loading=lazy on the iframe", () => {
-    render( <LocationMap lat={ MOCK_LAT } lon={ MOCK_LON } /> );
+    render( <LocationMap googleMapsUrl={ MOCK_GOOGLE_MAPS_URL } /> );
 
     const iframe = screen.getByTitle( "Location map" );
     expect( iframe ).toHaveAttribute( "loading", "lazy" );
   });
 
-  it( "renders the address when provided", () => {
-    render( <LocationMap lat={ MOCK_LAT } lon={ MOCK_LON } address="233 Broadway, Seattle, WA 98122" /> );
+  it( "renders the address as a link to the Google Maps URL when both are provided", () => {
+    render( <LocationMap googleMapsUrl={ MOCK_GOOGLE_MAPS_URL } address="614 S Jackson St, Seattle, WA 98104" /> );
 
-    expect( screen.getByText( "233 Broadway, Seattle, WA 98122" ) ).toBeInTheDocument();
+    const link = screen.getByRole( "link", { name: "614 S Jackson St, Seattle, WA 98104" });
+    expect( link ).toHaveAttribute( "href", MOCK_GOOGLE_MAPS_URL );
+    expect( link ).toHaveAttribute( "target", "_blank" );
+    expect( link ).toHaveAttribute( "rel", "noopener noreferrer" );
   });
 
-  it( "does not render an address paragraph when address is not provided", () => {
-    render( <LocationMap lat={ MOCK_LAT } lon={ MOCK_LON } /> );
+  it( "renders the address as plain text when no Google Maps URL is provided", () => {
+    render( <LocationMap address="614 S Jackson St, Seattle, WA 98104" /> );
 
-    const header = screen.getByRole( "heading", { name: "Location" }).parentElement;
-    expect( header?.querySelectorAll( "p" ) ).toHaveLength( 0 );
+    expect( screen.getByText( "614 S Jackson St, Seattle, WA 98104" ) ).toBeInTheDocument();
+    expect( screen.queryByRole( "link" ) ).toBeNull();
+  });
+
+  it( "does not render an iframe when Google Maps URL has no valid coordinates", () => {
+    render( <LocationMap googleMapsUrl="https://www.google.com/maps/some-bad-url" address="123 Test St" /> );
+
+    expect( screen.queryByTitle( "Location map" ) ).toBeNull();
+    expect( screen.getByText( "123 Test St" ) ).toBeInTheDocument();
+  });
+
+  it( "does not render an iframe when only address is provided", () => {
+    render( <LocationMap address="614 S Jackson St, Seattle, WA 98104" /> );
+
+    expect( screen.queryByTitle( "Location map" ) ).toBeNull();
   });
 });

--- a/src/__tests__/pages/post/slug.test.tsx
+++ b/src/__tests__/pages/post/slug.test.tsx
@@ -41,6 +41,7 @@ vi.mock( "@/components/Markdown", () => ({
 vi.mock( "@/components/Tags", () => ({ Tags: () => null }) );
 vi.mock( "@/components/DateTimeFormat", () => ({ default: () => null }) );
 vi.mock( "@/components/Playlist", () => ({ default: () => null }) );
+vi.mock( "@/components/LocationMap", () => ({ LocationMap: () => null }) );
 
 import { BlogPostView, getStaticProps } from "@/pages/post/[slug]";
 import { getBlogPost, getBlogPosts } from "@/utils/contentfulUtils";
@@ -314,6 +315,50 @@ describe( "getStaticProps — TikTok oEmbed", () => {
     expect( getTikTokOembed ).not.toHaveBeenCalled();
     expect( result ).toMatchObject({
       props: { tikTokOembed: null },
+    });
+  });
+});
+
+describe( "getStaticProps — location map", () => {
+  const postWithLocation = makePost({ slug: "loc-post" });
+  Object.assign( postWithLocation.fields, {
+    location: { lat: 47.6062, lon: -122.3321 },
+  });
+
+  const postWithoutLocation = makePost({ slug: "no-loc-post" });
+
+  beforeEach( () => {
+    vi.resetAllMocks();
+    vi.mocked( getBlogPosts ).mockResolvedValue({ items: [ postWithLocation, postWithoutLocation ] } as never );
+    vi.mocked( getPlaylist ).mockResolvedValue( null as never );
+    vi.mocked( getOembed ).mockResolvedValue( null );
+    vi.mocked( getYouTubeOembed ).mockResolvedValue( null );
+    vi.mocked( getTikTokOembed ).mockResolvedValue( null );
+  });
+
+  it( "passes lat and lon when location is present", async () => {
+    vi.mocked( getBlogPost ).mockResolvedValue( postWithLocation as never );
+
+    const result = await getStaticProps({ params: { slug: "loc-post" } } as never );
+
+    expect( result ).toMatchObject({
+      props: {
+        locationLat: 47.6062,
+        locationLon: -122.3321,
+      },
+    });
+  });
+
+  it( "passes null for location props when location is absent", async () => {
+    vi.mocked( getBlogPost ).mockResolvedValue( postWithoutLocation as never );
+
+    const result = await getStaticProps({ params: { slug: "no-loc-post" } } as never );
+
+    expect( result ).toMatchObject({
+      props: {
+        locationLat: null,
+        locationLon: null,
+      },
     });
   });
 });

--- a/src/__tests__/pages/post/slug.test.tsx
+++ b/src/__tests__/pages/post/slug.test.tsx
@@ -322,7 +322,8 @@ describe( "getStaticProps — TikTok oEmbed", () => {
 describe( "getStaticProps — location map", () => {
   const postWithLocation = makePost({ slug: "loc-post" });
   Object.assign( postWithLocation.fields, {
-    location: { lat: 47.6062, lon: -122.3321 },
+    googleMapsUrl: "https://www.google.com/maps/place/Test/@47.6062,-122.3321,17z",
+    address: "123 Test St, Seattle, WA",
   });
 
   const postWithoutLocation = makePost({ slug: "no-loc-post" });
@@ -336,28 +337,28 @@ describe( "getStaticProps — location map", () => {
     vi.mocked( getTikTokOembed ).mockResolvedValue( null );
   });
 
-  it( "passes lat and lon when location is present", async () => {
+  it( "passes googleMapsUrl and address when present", async () => {
     vi.mocked( getBlogPost ).mockResolvedValue( postWithLocation as never );
 
     const result = await getStaticProps({ params: { slug: "loc-post" } } as never );
 
     expect( result ).toMatchObject({
       props: {
-        locationLat: 47.6062,
-        locationLon: -122.3321,
+        googleMapsUrl: "https://www.google.com/maps/place/Test/@47.6062,-122.3321,17z",
+        locationAddress: "123 Test St, Seattle, WA",
       },
     });
   });
 
-  it( "passes null for location props when location is absent", async () => {
+  it( "passes null for location props when absent", async () => {
     vi.mocked( getBlogPost ).mockResolvedValue( postWithoutLocation as never );
 
     const result = await getStaticProps({ params: { slug: "no-loc-post" } } as never );
 
     expect( result ).toMatchObject({
       props: {
-        locationLat: null,
-        locationLon: null,
+        googleMapsUrl: null,
+        locationAddress: null,
       },
     });
   });

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -4,15 +4,17 @@ import styles from "@/styles/LocationMap.module.scss";
 export interface LocationMapProps {
   lat: number;
   lon: number;
+  address?: string;
 }
 
-export const LocationMap: FC<LocationMapProps> = ({ lat, lon }) => {
+export const LocationMap: FC<LocationMapProps> = ({ lat, lon, address }) => {
   const embedUrl = `https://www.google.com/maps?q=${lat},${lon}&output=embed`;
 
   return (
     <section className={ styles.locationMap }>
       <header className={ styles.locationHeader }>
         <h2>Location</h2>
+        { address && <p>{ address }</p> }
       </header>
       <div className={ styles.iframeWrapper }>
         <iframe

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -1,0 +1,27 @@
+import { FC } from "react";
+import styles from "@/styles/LocationMap.module.scss";
+
+export interface LocationMapProps {
+  lat: number;
+  lon: number;
+}
+
+export const LocationMap: FC<LocationMapProps> = ({ lat, lon }) => {
+  const embedUrl = `https://www.google.com/maps?q=${lat},${lon}&output=embed`;
+
+  return (
+    <section className={ styles.locationMap }>
+      <header className={ styles.locationHeader }>
+        <h2>Location</h2>
+      </header>
+      <div className={ styles.iframeWrapper }>
+        <iframe
+          title="Location map"
+          src={ embedUrl }
+          loading="lazy"
+          allowFullScreen
+        />
+      </div>
+    </section>
+  );
+};

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -2,28 +2,42 @@ import { FC } from "react";
 import styles from "@/styles/LocationMap.module.scss";
 
 export interface LocationMapProps {
-  lat: number;
-  lon: number;
+  googleMapsUrl?: string;
   address?: string;
 }
 
-export const LocationMap: FC<LocationMapProps> = ({ lat, lon, address }) => {
-  const embedUrl = `https://www.google.com/maps?q=${lat},${lon}&output=embed`;
+function extractCoordinates( googleMapsUrl: string ): { lat: number; lon: number } | null {
+  const match = googleMapsUrl.match( /@(-?\d+\.?\d*),(-?\d+\.?\d*)/ );
+  if( !match ) {
+    return null;
+  }
+  return { lat: Number( match[1] ), lon: Number( match[2] ) };
+}
+
+export const LocationMap: FC<LocationMapProps> = ({ googleMapsUrl, address }) => {
+  const coords = googleMapsUrl ? extractCoordinates( googleMapsUrl ) : null;
 
   return (
     <section className={ styles.locationMap }>
       <header className={ styles.locationHeader }>
         <h2>Location</h2>
-        { address && <p>{ address }</p> }
+        { address && googleMapsUrl && (
+          <p><a href={ googleMapsUrl } target="_blank" rel="noopener noreferrer">{ address }</a></p>
+        ) }
+        { address && !googleMapsUrl && (
+          <p>{ address }</p>
+        ) }
       </header>
-      <div className={ styles.iframeWrapper }>
-        <iframe
-          title="Location map"
-          src={ embedUrl }
-          loading="lazy"
-          allowFullScreen
-        />
-      </div>
+      { coords && (
+        <div className={ styles.iframeWrapper }>
+          <iframe
+            title="Location map"
+            src={ `https://www.google.com/maps?q=${coords.lat},${coords.lon}&output=embed` }
+            loading="lazy"
+            allowFullScreen
+          />
+        </div>
+      ) }
     </section>
   );
 };

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -37,15 +37,14 @@ export interface BlogPostViewProps {
   soundCloudOembed?: SoundCloudOembed|null
   youTubeOembed?: YouTubeOembed|null
   tikTokOembed?: TikTokOembed|null
-  locationLat?: number|null
-  locationLon?: number|null
+  googleMapsUrl?: string|null
   locationAddress?: string|null
   prevPost?: PostNavLink|null
   nextPost?: PostNavLink|null
 }
 
 
-export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, locationLat, locationLon, locationAddress, prevPost, nextPost }) => {
+export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, googleMapsUrl, locationAddress, prevPost, nextPost }) => {
   const metaTitle = `${post.fields.title} | Audeos.com`;
   const metaImage = `https:${post.fields.image?.fields.file?.url}?w=${CONTENT_IMAGE_WIDTH}`;
   const metaImageDesc = post.fields.image?.fields.description || "";
@@ -153,8 +152,8 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloud
             { soundCloudOembed && post.fields.soundcloudUrl && <SoundCloudEmbed oembed={ soundCloudOembed } url={ post.fields.soundcloudUrl } /> }
             { youTubeOembed && post.fields.youtubeUrl && <YouTubeEmbed oembed={ youTubeOembed } url={ post.fields.youtubeUrl } /> }
             { playlist && <Playlist playlist={ playlist } /> }
-            { locationLat != null && locationLon != null && (
-              <LocationMap lat={ locationLat } lon={ locationLon } address={ locationAddress ?? undefined } />
+            { ( googleMapsUrl || locationAddress ) && (
+              <LocationMap googleMapsUrl={ googleMapsUrl ?? undefined } address={ locationAddress ?? undefined } />
             ) }
             { ( prevPost || nextPost ) && (
               <nav className={ styles.postNav }>
@@ -207,8 +206,7 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
   const tikTokOembed = post.fields.tiktokUrl
     ? await getTikTokOembed( post.fields.tiktokUrl ) : null;
 
-  const locationLat = post.fields.location?.lat ?? null;
-  const locationLon = post.fields.location?.lon ?? null;
+  const googleMapsUrl = post.fields.googleMapsUrl ?? null;
   const locationAddress = post.fields.address ?? null;
 
   const sortedPosts = allPosts.items
@@ -237,8 +235,7 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
       soundCloudOembed,
       youTubeOembed,
       tikTokOembed,
-      locationLat,
-      locationLon,
+      googleMapsUrl,
       locationAddress,
       prevPost,
       nextPost,

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -209,9 +209,7 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
 
   const locationLat = post.fields.location?.lat ?? null;
   const locationLon = post.fields.location?.lon ?? null;
-  const locationAddress = "address" in post.fields
-    ? String( post.fields["address" as keyof typeof post.fields] ?? "" ) || null
-    : null;
+  const locationAddress = post.fields.address ?? null;
 
   const sortedPosts = allPosts.items
     .slice()

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -39,12 +39,13 @@ export interface BlogPostViewProps {
   tikTokOembed?: TikTokOembed|null
   locationLat?: number|null
   locationLon?: number|null
+  locationAddress?: string|null
   prevPost?: PostNavLink|null
   nextPost?: PostNavLink|null
 }
 
 
-export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, locationLat, locationLon, prevPost, nextPost }) => {
+export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, locationLat, locationLon, locationAddress, prevPost, nextPost }) => {
   const metaTitle = `${post.fields.title} | Audeos.com`;
   const metaImage = `https:${post.fields.image?.fields.file?.url}?w=${CONTENT_IMAGE_WIDTH}`;
   const metaImageDesc = post.fields.image?.fields.description || "";
@@ -153,7 +154,7 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloud
             { youTubeOembed && post.fields.youtubeUrl && <YouTubeEmbed oembed={ youTubeOembed } url={ post.fields.youtubeUrl } /> }
             { playlist && <Playlist playlist={ playlist } /> }
             { locationLat != null && locationLon != null && (
-              <LocationMap lat={ locationLat } lon={ locationLon } />
+              <LocationMap lat={ locationLat } lon={ locationLon } address={ locationAddress ?? undefined } />
             ) }
             { ( prevPost || nextPost ) && (
               <nav className={ styles.postNav }>
@@ -208,6 +209,9 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
 
   const locationLat = post.fields.location?.lat ?? null;
   const locationLon = post.fields.location?.lon ?? null;
+  const locationAddress = "address" in post.fields
+    ? String( post.fields["address" as keyof typeof post.fields] ?? "" ) || null
+    : null;
 
   const sortedPosts = allPosts.items
     .slice()
@@ -237,6 +241,7 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
       tikTokOembed,
       locationLat,
       locationLon,
+      locationAddress,
       prevPost,
       nextPost,
     },

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -21,6 +21,7 @@ import { getOembed as getYouTubeOembed, YouTubeOembed } from "@/utils/youtube/ge
 import { YouTubeEmbed } from "@/components/YouTubeEmbed";
 import { getOembed as getTikTokOembed, TikTokOembed } from "@/utils/tiktok/getOembed";
 import { TikTokEmbed } from "@/components/TikTokEmbed";
+import { LocationMap } from "@/components/LocationMap";
 
 
 
@@ -36,12 +37,14 @@ export interface BlogPostViewProps {
   soundCloudOembed?: SoundCloudOembed|null
   youTubeOembed?: YouTubeOembed|null
   tikTokOembed?: TikTokOembed|null
+  locationLat?: number|null
+  locationLon?: number|null
   prevPost?: PostNavLink|null
   nextPost?: PostNavLink|null
 }
 
 
-export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, prevPost, nextPost }) => {
+export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloudOembed, youTubeOembed, tikTokOembed, locationLat, locationLon, prevPost, nextPost }) => {
   const metaTitle = `${post.fields.title} | Audeos.com`;
   const metaImage = `https:${post.fields.image?.fields.file?.url}?w=${CONTENT_IMAGE_WIDTH}`;
   const metaImageDesc = post.fields.image?.fields.description || "";
@@ -149,6 +152,9 @@ export const BlogPostView: FC<BlogPostViewProps> = ({ post, playlist, soundCloud
             { soundCloudOembed && post.fields.soundcloudUrl && <SoundCloudEmbed oembed={ soundCloudOembed } url={ post.fields.soundcloudUrl } /> }
             { youTubeOembed && post.fields.youtubeUrl && <YouTubeEmbed oembed={ youTubeOembed } url={ post.fields.youtubeUrl } /> }
             { playlist && <Playlist playlist={ playlist } /> }
+            { locationLat != null && locationLon != null && (
+              <LocationMap lat={ locationLat } lon={ locationLon } />
+            ) }
             { ( prevPost || nextPost ) && (
               <nav className={ styles.postNav }>
                 { nextPost && (
@@ -200,6 +206,9 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
   const tikTokOembed = post.fields.tiktokUrl
     ? await getTikTokOembed( post.fields.tiktokUrl ) : null;
 
+  const locationLat = post.fields.location?.lat ?? null;
+  const locationLon = post.fields.location?.lon ?? null;
+
   const sortedPosts = allPosts.items
     .slice()
     .sort( sortBlogPostsByDate )
@@ -226,6 +235,8 @@ export async function getStaticProps( context: GetStaticPropsContext ) {
       soundCloudOembed,
       youTubeOembed,
       tikTokOembed,
+      locationLat,
+      locationLon,
       prevPost,
       nextPost,
     },

--- a/src/styles/LocationMap.module.scss
+++ b/src/styles/LocationMap.module.scss
@@ -1,0 +1,25 @@
+section.locationMap {
+  margin-top: 6rem;
+  margin-bottom: 6rem;
+}
+
+.locationHeader {
+  margin-bottom: 1rem;
+}
+
+.iframeWrapper {
+  position: relative;
+  padding-bottom: 56.25%; /* 16:9 aspect ratio */
+  height: 0;
+  overflow: hidden;
+
+  > iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+    border-radius: 4px;
+  }
+}

--- a/src/types/contentful/TypeBlogPost.ts
+++ b/src/types/contentful/TypeBlogPost.ts
@@ -92,6 +92,12 @@ export interface TypeBlogPostFields {
      * @localized false
      */
     tiktokUrl?: EntryFieldTypes.Symbol;
+    /**
+     * Field type definition for field 'address' (Address)
+     * @name Address
+     * @localized false
+     */
+    address?: EntryFieldTypes.Symbol;
 }
 
 /**
@@ -100,7 +106,7 @@ export interface TypeBlogPostFields {
  * @type {TypeBlogPostSkeleton}
  * @author 5qtbtLdlsTzODfegrwA2Ez
  * @since 2023-04-01T06:07:22.846Z
- * @version 27
+ * @version 29
  */
 export type TypeBlogPostSkeleton = EntrySkeletonType<TypeBlogPostFields, "blogPost">;
 /**
@@ -109,7 +115,7 @@ export type TypeBlogPostSkeleton = EntrySkeletonType<TypeBlogPostFields, "blogPo
  * @type {TypeBlogPost}
  * @author 5qtbtLdlsTzODfegrwA2Ez
  * @since 2023-04-01T06:07:22.846Z
- * @version 27
+ * @version 29
  */
 export type TypeBlogPost<Modifiers extends ChainModifiers, Locales extends LocaleCode = LocaleCode> = Entry<TypeBlogPostSkeleton, Modifiers, Locales>;
 

--- a/src/types/contentful/TypeBlogPost.ts
+++ b/src/types/contentful/TypeBlogPost.ts
@@ -98,6 +98,12 @@ export interface TypeBlogPostFields {
      * @localized false
      */
     address?: EntryFieldTypes.Symbol;
+    /**
+     * Field type definition for field 'googleMapsUrl' (Google Maps Url)
+     * @name Google Maps Url
+     * @localized false
+     */
+    googleMapsUrl?: EntryFieldTypes.Symbol;
 }
 
 /**
@@ -106,7 +112,7 @@ export interface TypeBlogPostFields {
  * @type {TypeBlogPostSkeleton}
  * @author 5qtbtLdlsTzODfegrwA2Ez
  * @since 2023-04-01T06:07:22.846Z
- * @version 29
+ * @version 31
  */
 export type TypeBlogPostSkeleton = EntrySkeletonType<TypeBlogPostFields, "blogPost">;
 /**
@@ -115,7 +121,7 @@ export type TypeBlogPostSkeleton = EntrySkeletonType<TypeBlogPostFields, "blogPo
  * @type {TypeBlogPost}
  * @author 5qtbtLdlsTzODfegrwA2Ez
  * @since 2023-04-01T06:07:22.846Z
- * @version 29
+ * @version 31
  */
 export type TypeBlogPost<Modifiers extends ChainModifiers, Locales extends LocaleCode = LocaleCode> = Entry<TypeBlogPostSkeleton, Modifiers, Locales>;
 


### PR DESCRIPTION
## Summary

- Add Google Maps iframe embed to blog posts that have a `location` field (lat/lon from Contentful)
- Uses the free Google Maps Embed (no API key, no billing, no account needed)
- Renders after all other embeds (TikTok, SoundCloud, YouTube, Spotify), before post nav
- Responsive 16:9 iframe wrapper matching the YouTube embed pattern

Closes #12

## Test plan

- [x] 136 tests pass (`yarn test`)
- [x] Lint passes (`yarn format`)
- [x] TypeScript compiles (`yarn typecheck`)
- [ ] Verify map renders on posts with location data (e.g., Avole On The Ave, BASO exhibition)