### PR TITLE
chore: delete location field, document address + googleMapsUrl

### DIFF
--- a/.claude/skills/new-post/SKILL.md
+++ b/.claude/skills/new-post/SKILL.md
@@ -66,7 +66,8 @@ Collect or derive all required fields. Show each to the user for approval:
 | **soundcloudUrl** | Ask if they want to embed a SoundCloud track or playlist (yes/no). If yes, collect the full SoundCloud URL. Skip if no. |
 | **youtubeUrl** | Ask if they want to embed a YouTube video (yes/no). If yes, collect the full YouTube URL. Skip if no. |
 | **tiktokUrl** | Ask if they want to embed a TikTok video (yes/no). If yes, collect the full TikTok URL. Fetch oEmbed data via `curl -s "https://www.tiktok.com/oembed?format=json&url=<encoded-url>"` to get the title and thumbnail. Offer to use the TikTok thumbnail as the featured image — download it with `curl -o`, rename to a descriptive filename, and upload via `make upload-images`. |
-| **location** | Ask if they want to add a location (yes/no). Skip if no. |
+| **address** | Ask if they want to add a location (yes/no). If yes, collect a human-readable address (e.g. `Cultiva Law, 2510 Western Ave Suite 500, Seattle, WA 98121`). Renders inside the post's "Location" section header. Skip if no. |
+| **googleMapsUrl** | Only ask if `address` was provided. Collect a Google Maps URL containing an `@lat,lon` segment (the format from the Google Maps "Share → Copy link" button on a pinned place — e.g. `https://www.google.com/maps/place/.../@47.6144758,-122.3524581,...`). The `LocationMap` component (`src/components/LocationMap.tsx`) regex-extracts the coordinates from this URL to render the embedded map iframe. Without this URL the address shows as plain text — no map embed, even if `address` is set. Skip if the user only wants the address text. |
 
 ## SEO Check
 
@@ -149,7 +150,9 @@ Use `mcp__contentful__create_entry` with:
     "spotifyPlaylistId": { "en-US": "<playlistId>" },
     "soundcloudUrl": { "en-US": "<soundcloudUrl>" },
     "youtubeUrl": { "en-US": "<youtubeUrl>" },
-    "tiktokUrl": { "en-US": "<tiktokUrl>" }
+    "tiktokUrl": { "en-US": "<tiktokUrl>" },
+    "address": { "en-US": "<address>" },
+    "googleMapsUrl": { "en-US": "<googleMapsUrl>" }
   },
   "metadata": {
     "tags": [{ "sys": { "type": "Link", "linkType": "Tag", "id": "<tagId>" } }]
@@ -157,7 +160,7 @@ Use `mcp__contentful__create_entry` with:
 }
 ```
 
-Omit optional fields that were not provided (gallery, spotifyPlaylistId, soundcloudUrl, youtubeUrl, tiktokUrl, location). Tags go in `metadata`, not `fields`.
+Omit optional fields that were not provided (gallery, spotifyPlaylistId, soundcloudUrl, youtubeUrl, tiktokUrl, address, googleMapsUrl). Tags go in `metadata`, not `fields`.
 
 If the user chose **publish immediately**, follow up with `mcp__contentful__publish_entry`.
 

--- a/src/types/contentful/TypeBlogPost.ts
+++ b/src/types/contentful/TypeBlogPost.ts
@@ -57,12 +57,6 @@ export interface TypeBlogPostFields {
      */
     spotifyPlaylistId?: EntryFieldTypes.Symbol;
     /**
-     * Field type definition for field 'location' (Location)
-     * @name Location
-     * @localized true
-     */
-    location?: EntryFieldTypes.Location;
-    /**
      * Field type definition for field 'author' (Author)
      * @name Author
      * @localized false
@@ -112,7 +106,7 @@ export interface TypeBlogPostFields {
  * @type {TypeBlogPostSkeleton}
  * @author 5qtbtLdlsTzODfegrwA2Ez
  * @since 2023-04-01T06:07:22.846Z
- * @version 31
+ * @version 35
  */
 export type TypeBlogPostSkeleton = EntrySkeletonType<TypeBlogPostFields, "blogPost">;
 /**
@@ -121,7 +115,7 @@ export type TypeBlogPostSkeleton = EntrySkeletonType<TypeBlogPostFields, "blogPo
  * @type {TypeBlogPost}
  * @author 5qtbtLdlsTzODfegrwA2Ez
  * @since 2023-04-01T06:07:22.846Z
- * @version 31
+ * @version 35
  */
 export type TypeBlogPost<Modifiers extends ChainModifiers, Locales extends LocaleCode = LocaleCode> = Entry<TypeBlogPostSkeleton, Modifiers, Locales>;
 


### PR DESCRIPTION
## Summary

- Removed the `location` (Location/lat-lng) field from the `blogPost` content type in Contentful. It was orphaned at render-time — `LocationMap` reads only from `address` + `googleMapsUrl` (added in #78), not `location`. The 12 posts that had `location` populated without an `address` were predominantly design pieces, mixes, and playlists where geo data was incidental.
- Regenerated `src/types/contentful/TypeBlogPost.ts` via `make types` to reflect the schema change. No site code referenced `location`, so no source changes beyond the type file.
- Updated `.claude/skills/new-post/SKILL.md`: removed the obsolete `location` row from the Field Assembly table, added `address` + `googleMapsUrl` rows with guidance on the `@lat,lon` URL format the `LocationMap` regex expects, and updated the entry-creation JSON example.

## Test plan

- [x] `yarn lint` (typecheck + ESLint) clean
- [x] `yarn test` — 140/140 pass
- [ ] Confirm an existing post with `address` + `googleMapsUrl` still renders the embedded map after deploy
- [ ] Confirm the next `/new-post` invocation surfaces `address`/`googleMapsUrl` fields correctly