### PR TITLE
fix: move viewport meta from _document to _app

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import "@/styles/globals.css";
 import type { AppProps } from "next/app";
 import { useEffect } from "react";
 import { useRouter } from "next/router";
+import Head from "next/head";
 import * as gtag from "../lib/google-analytics";
 import { GoogleAnalytics } from "@/lib/GoogleAnalytics";
 import CookieConsent from "@/components/CookieConsent";
@@ -24,6 +25,10 @@ export default function App({ Component, pageProps }: AppProps ) {
 
   return (
     <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="view-transition" content="same-origin" />
+      </Head>
       <CookieConsent />
       <GoogleAnalytics />
       <div className={ fontMona_Sans.className }>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,8 +4,6 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="view-transition" content="same-origin" />
         <link rel="icon" type="image/x-icon" href="/favicon.ico" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />


### PR DESCRIPTION
## Summary

Resolves the Next.js dev-console warning:

> Warning: viewport meta tags should not be used in _document.js's \`<Head>\`.
> https://nextjs.org/docs/messages/no-document-viewport-meta

Moved viewport and view-transition meta out of \`src/pages/_document.tsx\` (which renders once on the server) into \`src/pages/_app.tsx\` via \`next/head\`, where page-level meta belongs on the Pages Router.

## Test plan

- [x] \`yarn lint\` — typecheck + ESLint clean
- [x] \`yarn build\` — full build with no \`no-document-viewport-meta\` warning
- [ ] Confirm \`yarn dev\` console no longer shows the warning