### PR TITLE
docs: add prerequisites and getting-started to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,43 @@ This site is automatically deployed to **GitHub Pages** using GitHub Actions.
 ![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js&logoColor=white)
 ![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)
 ![Node](https://img.shields.io/badge/Node-v25.8.1-339933?logo=node.js&logoColor=white)
+![Yarn](https://img.shields.io/badge/Yarn-4-2C8EBB?logo=yarn&logoColor=white)
 ![Tested with Vitest](https://img.shields.io/badge/tested%20with-vitest-6E9F18?logo=vitest&logoColor=white)
 
 ![Last Commit](https://img.shields.io/github/last-commit/aud-eos/aud-eos.github.io/main)
 ![Repo Size](https://img.shields.io/github/repo-size/aud-eos/aud-eos.github.io)
+
+## Getting Started
+
+### Prerequisites
+
+- **Node.js ≥25.8.1** (see `.nvmrc`)
+- **Corepack** — manages the project's pinned Yarn 4 version via the `packageManager` field in `package.json`
+
+On macOS, Homebrew's Node formula excludes Corepack, so install it separately:
+
+```bash
+brew install corepack   # removes Homebrew yarn/pnpm if installed (Corepack provides shims)
+corepack enable
+```
+
+On other platforms, Corepack ships with Node ≥16.10 and only needs to be enabled:
+
+```bash
+corepack enable
+```
+
+### Install and run
+
+```bash
+yarn install      # Corepack auto-downloads Yarn 4.x on first invocation
+yarn dev          # Start the development server
+yarn build        # Build the static export to ./dist
+yarn test         # Run the Vitest suite
+yarn lint         # ESLint + TypeScript typecheck
+```
+
+For dependency upgrades and Contentful tooling, see the targets in `Makefile` (`make upgrade`, `make types`, `make upload-images`).
 
 ### .env
 


### PR DESCRIPTION
## Summary

After #83 migrated this repo from Yarn 1 to Yarn 4, the \`packageManager\` field in \`package.json\` correctly signals tooling — but the README had nothing for human contributors. Anyone cloning fresh would hit Yarn 1's "use Corepack" error before knowing it was a requirement.

This PR fills the gap with proactive documentation.

### Changes

- **Added a "Getting Started" section** with:
  - Prerequisites (Node ≥25.8.1, Corepack)
  - macOS-specific \`brew install corepack\` step (since Homebrew's Node formula excludes it)
  - Generic \`corepack enable\` instruction for other platforms
  - Core commands (\`yarn install\`, \`dev\`, \`build\`, \`test\`, \`lint\`)
  - Pointer to \`Makefile\` for upgrade and Contentful tooling targets
- **Added a Yarn 4 badge** alongside the existing Next.js / TypeScript / Node / Vitest badges so the dependency is visible at a glance.

## Test plan

- [x] README renders correctly on GitHub (preview confirmed)
- [x] Prerequisites match what's actually needed (\`packageManager: yarn@4.14.1\` in \`package.json\`, \`.nvmrc\` pinning Node 25.8.1)