### PR TITLE
chore: add 'releases' tag config (prep for records→releases rename)

### DIFF
--- a/data/tags.json
+++ b/data/tags.json
@@ -24,6 +24,11 @@
     "description": "Music releases produced and written DJ Audeos.",
     "ogImage": null
   },
+  "releases": {
+    "title": "Releases",
+    "description": "Music releases produced and written by DJ Audeos.",
+    "ogImage": null
+  },
   "radio": {
     "title": "Radio",
     "description": "DJ mix shows and broadcasts from DJ Audeos.",


### PR DESCRIPTION
## Summary
- Adds a `releases` entry to `data/tags.json` alongside the existing `records` entry
- Bridge state for renaming the Contentful `records` tag id to `releases` (Contentful tag ids are immutable, so the rename is a create-new + remigrate + delete-old operation)
- Builds remain safe because `validateTagSeoConfig` (`src/utils/tagSeoConfig.ts`) only fails on Contentful tag ids missing from the config — extra config keys are tolerated

## Sequence
1. **This PR** — add `releases` to tags.json (keep `records`)
2. **Contentful migration** — create `releases` tag, re-tag the 3 affected entries, delete `records` tag
3. **Follow-up PR** — remove `records` from tags.json

## Test plan
- [x] `yarn lint` passes
- [x] `yarn test` passes (140 tests)
- [ ] CI green