### PR TITLE
chore: remove 'records' tag config (records→releases rename complete)

### DIFF
--- a/data/tags.json
+++ b/data/tags.json
@@ -19,11 +19,6 @@
     "description": "Original music edits, remixes, and custom bootleg versions by DJ Audeos.",
     "ogImage": null
   },
-  "records": {
-    "title": "Records",
-    "description": "Music releases produced and written DJ Audeos.",
-    "ogImage": null
-  },
   "releases": {
     "title": "Releases",
     "description": "Music releases produced and written by DJ Audeos.",


### PR DESCRIPTION
## Summary
- Drops the now-unused `records` key from `data/tags.json`
- Final cleanup PR for the `records` → `releases` tag rename
- Contentful side is already migrated: the `records` tag has been deleted, all 3 affected entries (`Audeostrumentals 1`, `Eddypocalypse - Apocalypse Now Album`, `Audeos - Do U (Think About Us)`) have been re-tagged with `releases` and republished

## Why this is safe to merge
- `validateTagSeoConfig` (`src/utils/tagSeoConfig.ts`) checks that every Contentful tag id has a matching key in `data/tags.json`. Contentful no longer exposes `records`, so removing it from the config keeps the strict mapping intact.
- After this merges, `/tags/releases/` is the live URL for the rebranded category and `/tags/records/` will 404.

## Test plan
- [x] `yarn lint` passes
- [x] `yarn test` passes (140 tests)
- [ ] CI green
- [ ] After deploy, verify `/tags/releases/` lists all 3 posts