### PR TITLE
feat: convert home page to tag-section layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ The build output goes to `dist/` (not `.next/`). Feeds (RSS/Atom/JSON) are gener
 
 | Route | File | Notes |
 |---|---|---|
-| `/` | `pages/index.tsx` | Paginated post list, tag filter, search form |
+| `/` | `pages/index.tsx` | Tag-sectioned overview (3 most recent posts per tag) with JSON-LD |
 | `/search` | `pages/search.tsx` | Client-side Fuse.js search |
 | `/post/[slug]` | `pages/post/[slug].tsx` | Individual blog post |
 | `/page/[page]` | `pages/page/[page].tsx` | Pagination |

--- a/docs/superpowers/plans/2026-04-27-tag-sections-index.md
+++ b/docs/superpowers/plans/2026-04-27-tag-sections-index.md
@@ -1,0 +1,1464 @@
+# Tag Sections Index — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the home page (`/`) into a sectioned overview where each Contentful tag gets a section showing its 3 most recent posts. The flat paginated archive remains at `/page/[page]`, linked from a footer link on the home.
+
+**Architecture:** The existing `Home` component (which serves four routes via re-export) is split. `pages/index.tsx` becomes a new sectioned `Home` with its own `getStaticProps` and a `TaggedPostSections` component. The three archive routes (`/page/[page]`, `/tags/[tagId]`, `/tags/[tagId]/page/[page]`) re-export a renamed `BlogArchive` component preserving today's flat-list behavior. A `<JsonLd>` component renders `CollectionPage` structured data, and a `priority` flag is threaded through `Picture` to control LCP behavior in a 30-image layout.
+
+**Tech Stack:** Next.js (`output: "export"`), TypeScript, SCSS modules, Vitest, Contentful CMS.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-tag-sections-index-design.md`
+
+---
+
+### Task 1: Add `POSTS_PER_TAG_SECTION` constant
+
+**Files:**
+- Modify: `src/constants.ts`
+
+- [ ] **Step 1: Add the constant**
+
+Append to `src/constants.ts`:
+
+```typescript
+export const POSTS_PER_TAG_SECTION = 3;
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `yarn typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/constants.ts
+git commit -m "feat: add POSTS_PER_TAG_SECTION constant"
+```
+
+---
+
+### Task 2: Add `priority` prop to `Picture`
+
+**Files:**
+- Modify: `src/components/Picture.tsx`
+- Create: `src/__tests__/components/Picture.test.tsx`
+
+The `Picture` component currently emits `<img>` with no `loading` attribute, which the browser treats as eager. The new sectioned home will render up to 30 cards — most of them off-screen — so we want lazy loading by default with an opt-in priority flag for the LCP image.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/components/Picture.test.tsx`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import Picture from "@/components/Picture";
+
+describe( "Picture", () => {
+  it( "lazy-loads the image by default", () => {
+    const { container } = render(
+      <Picture url="//img.test/photo.jpg" alt="alt" />,
+    );
+    const img = container.querySelector( "img" );
+    expect( img?.getAttribute( "loading" ) ).toBe( "lazy" );
+    expect( img?.getAttribute( "fetchpriority" ) ).toBeNull();
+  });
+
+  it( "marks the image as priority when priority is true", () => {
+    const { container } = render(
+      <Picture url="//img.test/photo.jpg" alt="alt" priority />,
+    );
+    const img = container.querySelector( "img" );
+    expect( img?.getAttribute( "loading" ) ).toBe( "eager" );
+    expect( img?.getAttribute( "fetchpriority" ) ).toBe( "high" );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `yarn test src/__tests__/components/Picture.test.tsx`
+Expected: FAIL — both assertions fail because `loading` and `fetchpriority` are not set.
+
+- [ ] **Step 3: Implement the priority prop**
+
+Modify `src/components/Picture.tsx`:
+
+```typescript
+import { CONTENT_IMAGE_WIDTH } from "@/constants";
+
+export interface PictureProps {
+  url: string;
+  alt: string;
+  maxWidth?: number;
+  breakpoints?: number[],
+  priority?: boolean;
+}
+
+export default function Picture({
+  url,
+  maxWidth = CONTENT_IMAGE_WIDTH,
+  alt,
+  breakpoints = [ 749, 600, 350 ],
+  priority = false,
+}: PictureProps ) {
+  return (
+    <picture>
+      {
+        breakpoints
+          .filter( breakpoint => breakpoint < maxWidth )
+          .map( breakpoint =>
+            <source
+              key={ breakpoint }
+              media={ `(max-width: ${ breakpoint }px)` }
+              srcSet={ getImgSrc( url, { width: breakpoint, format: "webp" }) }
+              type={ "image/webp" }
+            />,
+          )
+      }
+      <source
+        srcSet={ getImgSrc( url, { width: maxWidth, format: "webp" }) }
+        type="image/webp"
+      />
+      <img
+        src={ getImgSrc( url, { width: maxWidth }) }
+        alt={ alt }
+        loading={ priority ? "eager" : "lazy" }
+        { ...( priority ? { fetchPriority: "high" } : {}) }
+      />
+    </picture>
+  );
+}
+```
+
+(Leave the `ImageSourceOptions` type and `getImgSrc` function below it untouched.)
+
+Note: React 19 / Next.js 15 supports `fetchPriority` (camelCase) as a JSX prop that emits `fetchpriority` (lowercase) on the DOM. If the project's React version is older, use a spread approach with the lowercase `fetchpriority` to satisfy TypeScript.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `yarn test src/__tests__/components/Picture.test.tsx`
+Expected: PASS — both tests green.
+
+- [ ] **Step 5: Run the full test suite for regressions**
+
+Run: `yarn test`
+Expected: PASS — `BlogPostList.test.tsx` mocks `Picture`, so changes to the real component don't affect it.
+
+- [ ] **Step 6: Run lint + typecheck**
+
+Run: `yarn lint`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/Picture.tsx src/__tests__/components/Picture.test.tsx
+git commit -m "feat: add priority prop to Picture for LCP control"
+```
+
+---
+
+### Task 3: Add `firstCardPriority` prop to `BlogPostList`
+
+**Files:**
+- Modify: `src/components/Home/BlogPostList.tsx`
+- Modify: `src/__tests__/components/BlogPostList.test.tsx`
+
+`BlogPostList` is reused by both the new sectioned home and the existing archive routes. We want a flag that marks the first rendered card as priority — but only when the consumer opts in. Default behavior stays lazy across the board (matching today's effective behavior after Task 2 lands).
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `src/__tests__/components/BlogPostList.test.tsx` inside the `describe( "BlogPostList", ... )` block. Adjust the `Picture` mock at the top of the file to forward the `priority` prop so the test can observe it:
+
+Replace the existing mock:
+
+```typescript
+vi.mock( "@/components/Picture", () => ({
+  default: ({ alt }: { alt: string }) => <img alt={ alt } />,
+}) );
+```
+
+with:
+
+```typescript
+vi.mock( "@/components/Picture", () => ({
+  default: ({ alt, priority }: { alt: string; priority?: boolean }) => (
+    <img alt={ alt } data-priority={ priority ? "true" : "false" } />
+  ),
+}) );
+```
+
+Then add the new test:
+
+```typescript
+it( "passes priority to the first card image only when firstCardPriority is true", () => {
+  const { container } = render(
+    <BlogPostList
+      posts={ makePosts( 3 ) as never[] }
+      page={ 1 }
+      firstCardPriority
+    />,
+  );
+  const images = container.querySelectorAll( "img" );
+  expect( images[0].getAttribute( "data-priority" ) ).toBe( "true" );
+  expect( images[1].getAttribute( "data-priority" ) ).toBe( "false" );
+  expect( images[2].getAttribute( "data-priority" ) ).toBe( "false" );
+});
+
+it( "does not mark any image priority when firstCardPriority is false (default)", () => {
+  const { container } = render(
+    <BlogPostList posts={ makePosts( 3 ) as never[] } page={ 1 } />,
+  );
+  const images = container.querySelectorAll( "img" );
+  images.forEach( image => {
+    expect( image.getAttribute( "data-priority" ) ).toBe( "false" );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `yarn test src/__tests__/components/BlogPostList.test.tsx`
+Expected: FAIL — `firstCardPriority` is not yet a prop.
+
+- [ ] **Step 3: Implement the prop**
+
+Modify `src/components/Home/BlogPostList.tsx`:
+
+Update the `BlogPostListProps` interface:
+
+```typescript
+export interface BlogPostListProps {
+  posts: BlogPost[]
+  page: number
+  tagId?: string
+  firstCardPriority?: boolean
+}
+```
+
+Update the function signature:
+
+```typescript
+export default function BlogPostList({ posts, page, tagId, firstCardPriority = false }: BlogPostListProps ) {
+```
+
+The map callback already produces cards in render order. Track the index (already provided by the existing structure — re-derive via `.map` with two args) and pass `priority` to `Picture` only on the first card. Replace the `.map( post => {` line with:
+
+```typescript
+.map( ( post, cardIndex ) => {
+```
+
+And replace the `<Picture` JSX block with:
+
+```typescript
+<Picture
+  url={ pictureUrl }
+  maxWidth={ IMAGE_WIDTH }
+  alt={ altText }
+  priority={ firstCardPriority && cardIndex === 0 }
+/>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `yarn test src/__tests__/components/BlogPostList.test.tsx`
+Expected: PASS — all existing tests plus the two new ones green.
+
+- [ ] **Step 5: Run lint + typecheck**
+
+Run: `yarn lint`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Home/BlogPostList.tsx src/__tests__/components/BlogPostList.test.tsx
+git commit -m "feat: add firstCardPriority prop to BlogPostList"
+```
+
+---
+
+### Task 4: Create `JsonLd` component
+
+**Files:**
+- Create: `src/components/JsonLd.tsx`
+- Create: `src/__tests__/components/JsonLd.test.tsx`
+
+Encapsulates JSON-LD script injection with a `<` → `\u003c` escape so a malicious post title containing `</script>` cannot break out of the script tag. This is the **only** allowed call site for raw JSON-LD injection in the codebase.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/components/JsonLd.test.tsx`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { JsonLd } from "@/components/JsonLd";
+
+describe( "JsonLd", () => {
+  it( "renders a script tag with type application/ld+json", () => {
+    const { container } = render( <JsonLd schema={ { "@type": "WebSite" } } /> );
+    const script = container.querySelector( "script" );
+    expect( script?.getAttribute( "type" ) ).toBe( "application/ld+json" );
+  });
+
+  it( "stringifies the schema as the script body", () => {
+    const { container } = render(
+      <JsonLd schema={ { "@type": "WebSite", "name": "Audeos" } } />,
+    );
+    const script = container.querySelector( "script" );
+    expect( script?.textContent ).toContain( "\"@type\":\"WebSite\"" );
+    expect( script?.textContent ).toContain( "\"name\":\"Audeos\"" );
+  });
+
+  it( "escapes < to \\u003c so </script> in strings cannot break out", () => {
+    const malicious = { "@type": "WebSite", "headline": "Hi </script><script>alert(1)</script>" };
+    const { container } = render( <JsonLd schema={ malicious } /> );
+    const script = container.querySelector( "script" );
+    expect( script?.textContent ).not.toContain( "</script>" );
+    expect( script?.textContent ).toContain( "\\u003c/script\\u003e" );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `yarn test src/__tests__/components/JsonLd.test.tsx`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+Create `src/components/JsonLd.tsx`:
+
+```typescript
+export interface JsonLdProps {
+  schema: object;
+}
+
+export function JsonLd({ schema }: JsonLdProps ) {
+  const json = JSON.stringify( schema ).replace( /</g, "\\u003c" );
+  return <script type="application/ld+json">{ json }</script>;
+}
+```
+
+React renders text children with HTML-escaping, so the `<script>` body itself is safe; the `<` substitution defends against `</script>` sequences inside Contentful-sourced strings.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `yarn test src/__tests__/components/JsonLd.test.tsx`
+Expected: PASS — all three tests green.
+
+- [ ] **Step 5: Run lint + typecheck**
+
+Run: `yarn lint`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/JsonLd.tsx src/__tests__/components/JsonLd.test.tsx
+git commit -m "feat: add JsonLd component with script-breakout escape"
+```
+
+---
+
+### Task 5: Create `homepageSchema` builder
+
+**Files:**
+- Create: `src/lib/homepageSchema.ts`
+- Create: `src/__tests__/lib/homepageSchema.test.ts`
+
+Builds a `CollectionPage` JSON-LD object referencing every post shown on the home page (deduped by slug). Called from `pages/index.tsx`'s `getStaticProps`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/lib/homepageSchema.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { buildHomepageSchema } from "@/lib/homepageSchema";
+
+const makePost = ({
+  id,
+  slug,
+  title,
+  date,
+  imageUrl,
+}: {
+  id: string;
+  slug: string;
+  title: string;
+  date: string;
+  imageUrl?: string;
+}) => ({
+  sys: { id, createdAt: date },
+  fields: {
+    slug,
+    title,
+    date,
+    image: imageUrl
+      ? { fields: { file: { url: imageUrl }, description: "" } }
+      : undefined,
+  },
+  metadata: { tags: [] },
+});
+
+describe( "buildHomepageSchema", () => {
+  it( "returns a CollectionPage with site-level metadata", () => {
+    const schema = buildHomepageSchema({
+      items: [ makePost({ id: "1", slug: "post-1", title: "Post 1", date: "2026-04-01" }) ],
+    } as never );
+    expect( schema[ "@context" ] ).toBe( "https://schema.org" );
+    expect( schema[ "@type" ] ).toBe( "CollectionPage" );
+    expect( schema.name ).toBeDefined();
+    expect( schema.description ).toBeDefined();
+    expect( schema.url ).toBeDefined();
+    expect( schema.isPartOf ).toEqual({
+      "@type": "WebSite",
+      "name": "Audeos.com",
+      "url": "https://www.audeos.com",
+    });
+  });
+
+  it( "includes one BlogPosting per post in hasPart", () => {
+    const schema = buildHomepageSchema({
+      items: [
+        makePost({ id: "1", slug: "post-1", title: "Post 1", date: "2026-04-01", imageUrl: "//img/1.jpg" }),
+        makePost({ id: "2", slug: "post-2", title: "Post 2", date: "2026-04-02" }),
+      ],
+    } as never );
+    expect( schema.hasPart ).toHaveLength( 2 );
+    expect( schema.hasPart[0] ).toMatchObject({
+      "@type": "BlogPosting",
+      "headline": "Post 1",
+      "url": "https://www.audeos.com/post/post-1",
+      "datePublished": "2026-04-01",
+      "image": "https://img/1.jpg",
+    });
+    expect( schema.hasPart[1] ).toMatchObject({
+      "@type": "BlogPosting",
+      "headline": "Post 2",
+      "url": "https://www.audeos.com/post/post-2",
+      "datePublished": "2026-04-02",
+    });
+    expect( schema.hasPart[1].image ).toBeUndefined();
+  });
+
+  it( "deduplicates posts by slug", () => {
+    const post = makePost({ id: "1", slug: "post-1", title: "Post 1", date: "2026-04-01" });
+    const schema = buildHomepageSchema({
+      items: [ post, post, post ],
+    } as never );
+    expect( schema.hasPart ).toHaveLength( 1 );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `yarn test src/__tests__/lib/homepageSchema.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the builder**
+
+Create `src/lib/homepageSchema.ts`:
+
+```typescript
+import { BlogPost, BlogPosts } from "@/utils/contentfulUtils";
+import { resolvePostDate } from "@/utils/blogPostUtils";
+import { META_DESCRIPTION, META_TITLE, SITE_URL } from "@/constants";
+
+function dedupeBySlug( posts: BlogPost[] ): BlogPost[] {
+  const seen = new Set<string>();
+  const unique: BlogPost[] = [];
+  posts.forEach( post => {
+    const slug = post.fields.slug;
+    if( !seen.has( slug ) ) {
+      seen.add( slug );
+      unique.push( post );
+    }
+  });
+  return unique;
+}
+
+export function buildHomepageSchema( posts: BlogPosts ) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": META_TITLE,
+    "description": META_DESCRIPTION,
+    "url": SITE_URL,
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "Audeos.com",
+      "url": SITE_URL,
+    },
+    "hasPart": dedupeBySlug( posts.items ).map( post => {
+      const imageUrl = post.fields.image?.fields.file?.url;
+      return {
+        "@type": "BlogPosting",
+        "headline": post.fields.title,
+        "url": `${SITE_URL}/post/${post.fields.slug}`,
+        "datePublished": resolvePostDate( post ),
+        "image": imageUrl ? `https:${imageUrl}` : undefined,
+      };
+    }),
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `yarn test src/__tests__/lib/homepageSchema.test.ts`
+Expected: PASS — all three tests green.
+
+- [ ] **Step 5: Run lint + typecheck**
+
+Run: `yarn lint`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/homepageSchema.ts src/__tests__/lib/homepageSchema.test.ts
+git commit -m "feat: add homepageSchema builder for CollectionPage JSON-LD"
+```
+
+---
+
+### Task 6: Extract `BlogArchive` component
+
+**Files:**
+- Create: `src/components/BlogArchive/BlogArchive.tsx`
+- Create: `src/components/BlogArchive/getStaticProps.ts`
+
+Move today's `Home` component out of `pages/index.tsx` and into a reusable `BlogArchive` component. The three archive routes will re-export it. `pages/index.tsx` is left untouched in this task — Task 9 replaces it.
+
+- [ ] **Step 1: Create `BlogArchive.tsx`**
+
+Create `src/components/BlogArchive/BlogArchive.tsx` with the contents of today's `Home` component (the JSX render in `src/pages/index.tsx`), renamed:
+
+```typescript
+import Link from "next/link";
+import styles from "@/styles/Home.module.scss";
+import { BlogPosts } from "@/utils/contentfulUtils";
+import BlogPostList from "@/components/Home/BlogPostList";
+import { Layout } from "@/components/Layout/Layout";
+import { TagCollection } from "contentful";
+import { sortTagsById } from "@/utils/blogPostUtils";
+import Pagination from "@/components/Home/Pagination";
+import { META_DESCRIPTION, META_IMAGE, META_TITLE, SITE_URL } from "@/constants";
+import { SeoHead } from "@/components/SeoHead";
+import { TagSeoConfig } from "@/types/tagConfig";
+
+export interface BlogArchiveProps {
+  posts: BlogPosts
+  tags: TagCollection
+  page: number
+  tagId?: string
+  tagSeoConfig?: TagSeoConfig
+}
+
+export default function BlogArchive({ posts, page, tags, tagId, tagSeoConfig }: BlogArchiveProps ) {
+  const filteredBlogPosts = posts.items
+    .filter( post => tagId === null || post.metadata.tags
+      .find( tag => tag.sys.id === tagId ) );
+
+  const isTagPage = Boolean( tagId );
+  const isPaginated = page > 1;
+
+  const tagLabel = tagSeoConfig?.title ?? "";
+
+  const pageTitle = isTagPage && isPaginated
+    ? `${tagLabel} — Page ${page} | Audeos.com`
+    : isTagPage
+      ? `${tagLabel} | Audeos.com`
+      : isPaginated
+        ? `Blog — Page ${page} | ${META_TITLE}`
+        : META_TITLE;
+
+  const pageDescription = isTagPage && tagSeoConfig
+    ? tagSeoConfig.description
+    : META_DESCRIPTION;
+
+  const ogImage = isTagPage && tagSeoConfig?.ogImage
+    ? tagSeoConfig.ogImage
+    : META_IMAGE;
+
+  const canonicalUrl = isTagPage && isPaginated
+    ? `${SITE_URL}/tags/${tagId}/page/${page}`
+    : isTagPage
+      ? `${SITE_URL}/tags/${tagId}`
+      : isPaginated
+        ? `${SITE_URL}/page/${page}`
+        : SITE_URL;
+
+  return (
+    <>
+      <SeoHead
+        title={ pageTitle }
+        canonicalUrl={ canonicalUrl }
+        description={ pageDescription }
+        ogImage={ ogImage }
+      >
+        <link rel="alternate" type="application/rss+xml" href="/rss.xml" />
+        <link rel="alternate" type="application/atom+xml" href="/atom.xml" />
+        <link rel="alternate" type="application/feed+json" href="/feed.json" />
+      </SeoHead>
+      <Layout isFullwidth>
+        <main className={ styles.main }>
+          <nav className={ styles.tagNav }>
+            {
+              tags.items
+                .sort( sortTagsById )
+                .map( tag => {
+                  const isActive = tag.sys.id === tagId;
+                  const href = isActive ? "/" : `/tags/${tag.sys.id}`;
+                  return (
+                    <Link
+                      key={ tag.sys.id }
+                      href={ href }
+                      className={ isActive ? styles.tagActive : styles.tag }
+                    >
+                      { tag.sys.id }
+                    </Link>
+                  );
+                })
+            }
+          </nav>
+          <BlogPostList
+            posts={ filteredBlogPosts }
+            tagId={ tagId }
+            page={ page }
+          />
+          <Pagination
+            posts={ filteredBlogPosts }
+            page={ page }
+            tagId={ tagId }
+          />
+        </main>
+      </Layout>
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Create `getStaticProps.ts`**
+
+Create `src/components/BlogArchive/getStaticProps.ts` with today's `getStaticProps` minus the `generateFeeds` call (which never fires from archive routes):
+
+```typescript
+import { GetStaticPropsContext } from "next";
+import { getBlogPosts, getTags } from "@/utils/contentfulUtils";
+import { TagSeoConfigMap } from "@/types/tagConfig";
+import tagSeoConfigData from "../../../data/tags.json";
+import { validateTagSeoConfig } from "@/utils/tagSeoConfig";
+
+export async function getArchiveStaticProps( context: GetStaticPropsContext ) {
+  const tagId = context.params?.tagId || null;
+  const page: number = Number( context.params?.page ) || 1;
+  const tags = await getTags();
+  const posts = await getBlogPosts();
+
+  const tagConfig: TagSeoConfigMap = tagSeoConfigData satisfies TagSeoConfigMap;
+  const contentfulTagIds = tags.items.map( tag => tag.sys.id );
+  validateTagSeoConfig( tagConfig, contentfulTagIds );
+
+  const resolvedTagId = Array.isArray( tagId ) ? tagId[0] : tagId;
+  const tagSeoConfig = resolvedTagId ? tagConfig[resolvedTagId] : null;
+
+  return {
+    props: {
+      tagId,
+      posts,
+      tags,
+      page,
+      tagSeoConfig,
+    },
+  };
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `yarn typecheck`
+Expected: PASS — both new files compile, no callers yet.
+
+- [ ] **Step 4: Run lint**
+
+Run: `yarn lint`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/BlogArchive/BlogArchive.tsx src/components/BlogArchive/getStaticProps.ts
+git commit -m "feat: extract BlogArchive component from Home"
+```
+
+---
+
+### Task 7: Repoint archive route shells at `BlogArchive`
+
+**Files:**
+- Modify: `src/pages/page/[page].tsx`
+- Modify: `src/pages/tags/[tagId].tsx`
+- Modify: `src/pages/tags/[tagId]/page/[page].tsx`
+
+The three archive routes currently re-export `Home` and `getStaticProps` from `@/pages`. After this task, they re-export `BlogArchive` and `getArchiveStaticProps` from the new location. `pages/index.tsx` is still untouched — that's Task 9.
+
+- [ ] **Step 1: Update `pages/page/[page].tsx`**
+
+Replace the file with:
+
+```typescript
+import { getBlogPosts } from "@/utils/contentfulUtils";
+import BlogArchive from "@/components/BlogArchive/BlogArchive";
+import { getArchiveStaticProps } from "@/components/BlogArchive/getStaticProps";
+import { PAGE_SIZE } from "@/constants";
+
+
+export const getStaticProps = getArchiveStaticProps;
+
+export async function getStaticPaths() {
+  const posts = await getBlogPosts();
+  const numPages = Math.ceil( posts.items.length / PAGE_SIZE );
+  const paths: { params: { page: string } }[] = [];
+
+  for( let page = 2; page <= numPages; page++ ) {
+    paths.push({ params: { page: page.toString() } });
+  }
+
+  return {
+    paths,
+    fallback: false,
+  };
+}
+
+export default BlogArchive;
+```
+
+- [ ] **Step 2: Update `pages/tags/[tagId].tsx`**
+
+Replace the file with:
+
+```typescript
+import { getTags } from "@/utils/contentfulUtils";
+import BlogArchive from "@/components/BlogArchive/BlogArchive";
+import { getArchiveStaticProps } from "@/components/BlogArchive/getStaticProps";
+
+
+export const getStaticProps = getArchiveStaticProps;
+
+
+export async function getStaticPaths() {
+  const tags = await getTags();
+  const paths = tags.items.map( tag => {
+    const tagId = tag.sys.id;
+    return { params: { tagId } };
+  });
+
+  return {
+    paths,
+    fallback: false,
+  };
+}
+
+export default BlogArchive;
+```
+
+- [ ] **Step 3: Update `pages/tags/[tagId]/page/[page].tsx`**
+
+Replace the file with:
+
+```typescript
+import { getBlogPosts, getTags } from "@/utils/contentfulUtils";
+import BlogArchive from "@/components/BlogArchive/BlogArchive";
+import { getArchiveStaticProps } from "@/components/BlogArchive/getStaticProps";
+import { PAGE_SIZE } from "@/constants";
+
+
+export const getStaticProps = getArchiveStaticProps;
+
+
+export async function getStaticPaths() {
+  const tags = await getTags();
+  const posts = await getBlogPosts();
+  const paths: { params: { tagId: string, page: string }}[] = [];
+
+  tags.items.forEach( tag => {
+    const tagId = tag.sys.id;
+    const filteredPosts = posts.items
+      .filter( post => post.metadata.tags
+        .find( postTag => postTag.sys.id === tagId ) );
+    const numPages = Math.ceil( filteredPosts.length / PAGE_SIZE );
+    for( let page = 2; page <= numPages; page++ ) {
+      paths.push({
+        params: {
+          tagId,
+          page: page.toString(),
+        },
+      });
+    }
+  });
+
+  return {
+    paths,
+    fallback: false,
+  };
+}
+
+export default BlogArchive;
+```
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `yarn typecheck`
+Expected: PASS — `pages/index.tsx` still exports today's `Home` + `getStaticProps`, which the three shells no longer reference.
+
+- [ ] **Step 5: Run lint**
+
+Run: `yarn lint`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/page/[page].tsx src/pages/tags/[tagId].tsx src/pages/tags/[tagId]/page/[page].tsx
+git commit -m "refactor: route archive pages through BlogArchive"
+```
+
+---
+
+### Task 8: Create `TaggedPostSections` component
+
+**Files:**
+- Create: `src/components/Home/TaggedPostSections.tsx`
+- Create: `src/__tests__/components/TaggedPostSections.test.tsx`
+
+Renders one `<section>` per tag with at least one post, in `sortTagsById` order. Each section has a header (linked to `/tags/[tagId]`) and a `BlogPostList` rendering up to `POSTS_PER_TAG_SECTION` (3) most recent posts. Only the first rendered section receives `firstCardPriority`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/components/TaggedPostSections.test.tsx`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+
+vi.mock( "@/constants", async importOriginal => ({
+  ...( await importOriginal<typeof import( "@/constants" )>() ),
+  POSTS_PER_TAG_SECTION: 3,
+}) );
+vi.mock( "@/utils/contentfulUtils", () => ({}) );
+vi.mock( "next/link", () => ({
+  default: ({ children, href, ...props }: React.ComponentProps<"a"> ) => (
+    <a href={ href } { ...props }>{ children }</a>
+  ),
+}) );
+vi.mock( "@/components/Home/BlogPostList", () => ({
+  default: ({
+    posts,
+    firstCardPriority,
+    tagId,
+  }: {
+    posts: { fields: { slug: string } }[];
+    firstCardPriority?: boolean;
+    tagId?: string;
+  }) => (
+    <ul
+      data-testid={ `bpl-${tagId}` }
+      data-priority={ firstCardPriority ? "true" : "false" }
+      data-count={ posts.length }
+    >
+      { posts.map( post => <li key={ post.fields.slug }>{ post.fields.slug }</li> ) }
+    </ul>
+  ),
+}) );
+
+import TaggedPostSections from "@/components/Home/TaggedPostSections";
+
+const tagAlpha = { sys: { id: "alpha" } };
+const tagBeta = { sys: { id: "beta" } };
+const tagEmpty = { sys: { id: "empty" } };
+
+const tagSeoConfig = {
+  alpha: { title: "Alpha Title", description: "", ogImage: null },
+  beta: { title: "Beta Title", description: "", ogImage: null },
+  empty: { title: "Empty Title", description: "", ogImage: null },
+};
+
+const makePost = ({
+  slug,
+  date,
+  tagIds,
+}: {
+  slug: string;
+  date: string;
+  tagIds: string[];
+}) => ({
+  sys: { id: slug, createdAt: date },
+  fields: { slug, title: slug, date, image: undefined },
+  metadata: { tags: tagIds.map( id => ({ sys: { id, type: "Link", linkType: "Tag" } }) ) },
+});
+
+beforeEach( () => {
+  vi.stubGlobal( "matchMedia", ( query: string ) => ({
+    matches: false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }) );
+});
+
+describe( "TaggedPostSections", () => {
+  it( "renders one section per tag that has at least one post", () => {
+    const posts = {
+      items: [
+        makePost({ slug: "a1", date: "2026-04-01", tagIds: [ "alpha" ] }),
+        makePost({ slug: "b1", date: "2026-04-02", tagIds: [ "beta" ] }),
+      ],
+    };
+    const { container } = render(
+      <TaggedPostSections
+        posts={ posts as never }
+        tags={ { items: [ tagAlpha, tagBeta, tagEmpty ] } as never }
+        tagSeoConfig={ tagSeoConfig as never }
+      />,
+    );
+    const sections = container.querySelectorAll( "section" );
+    expect( sections ).toHaveLength( 2 );
+    expect( sections[0].id ).toBe( "tag-alpha" );
+    expect( sections[1].id ).toBe( "tag-beta" );
+  });
+
+  it( "iterates tags alphabetically by id", () => {
+    const posts = {
+      items: [
+        makePost({ slug: "b1", date: "2026-04-01", tagIds: [ "beta" ] }),
+        makePost({ slug: "a1", date: "2026-04-01", tagIds: [ "alpha" ] }),
+      ],
+    };
+    const { container } = render(
+      <TaggedPostSections
+        posts={ posts as never }
+        tags={ { items: [ tagBeta, tagAlpha ] } as never }
+        tagSeoConfig={ tagSeoConfig as never }
+      />,
+    );
+    const sections = container.querySelectorAll( "section" );
+    expect( sections[0].id ).toBe( "tag-alpha" );
+    expect( sections[1].id ).toBe( "tag-beta" );
+  });
+
+  it( "caps each section at POSTS_PER_TAG_SECTION (3) most recent posts", () => {
+    const posts = {
+      items: [
+        makePost({ slug: "a1", date: "2026-04-01", tagIds: [ "alpha" ] }),
+        makePost({ slug: "a2", date: "2026-04-02", tagIds: [ "alpha" ] }),
+        makePost({ slug: "a3", date: "2026-04-03", tagIds: [ "alpha" ] }),
+        makePost({ slug: "a4", date: "2026-04-04", tagIds: [ "alpha" ] }),
+        makePost({ slug: "a5", date: "2026-04-05", tagIds: [ "alpha" ] }),
+      ],
+    };
+    const { getByTestId } = render(
+      <TaggedPostSections
+        posts={ posts as never }
+        tags={ { items: [ tagAlpha ] } as never }
+        tagSeoConfig={ tagSeoConfig as never }
+      />,
+    );
+    const list = getByTestId( "bpl-alpha" );
+    expect( list.getAttribute( "data-count" ) ).toBe( "3" );
+    const slugs = Array.from( list.querySelectorAll( "li" ) ).map( item => item.textContent );
+    expect( slugs ).toEqual([ "a5", "a4", "a3" ]);
+  });
+
+  it( "shows a post tagged with two tags in both sections", () => {
+    const posts = {
+      items: [ makePost({ slug: "shared", date: "2026-04-01", tagIds: [ "alpha", "beta" ] }) ],
+    };
+    const { getByTestId } = render(
+      <TaggedPostSections
+        posts={ posts as never }
+        tags={ { items: [ tagAlpha, tagBeta ] } as never }
+        tagSeoConfig={ tagSeoConfig as never }
+      />,
+    );
+    expect( getByTestId( "bpl-alpha" ).getAttribute( "data-count" ) ).toBe( "1" );
+    expect( getByTestId( "bpl-beta" ).getAttribute( "data-count" ) ).toBe( "1" );
+  });
+
+  it( "links the section header to /tags/[tagId] using tagSeoConfig.title", () => {
+    const posts = {
+      items: [ makePost({ slug: "a1", date: "2026-04-01", tagIds: [ "alpha" ] }) ],
+    };
+    const { container } = render(
+      <TaggedPostSections
+        posts={ posts as never }
+        tags={ { items: [ tagAlpha ] } as never }
+        tagSeoConfig={ tagSeoConfig as never }
+      />,
+    );
+    const heading = container.querySelector( "h2 a" );
+    expect( heading?.getAttribute( "href" ) ).toBe( "/tags/alpha" );
+    expect( heading?.textContent ).toBe( "Alpha Title" );
+  });
+
+  it( "passes firstCardPriority only to the first rendered section", () => {
+    const posts = {
+      items: [
+        makePost({ slug: "a1", date: "2026-04-01", tagIds: [ "alpha" ] }),
+        makePost({ slug: "b1", date: "2026-04-01", tagIds: [ "beta" ] }),
+      ],
+    };
+    const { getByTestId } = render(
+      <TaggedPostSections
+        posts={ posts as never }
+        tags={ { items: [ tagAlpha, tagBeta ] } as never }
+        tagSeoConfig={ tagSeoConfig as never }
+      />,
+    );
+    expect( getByTestId( "bpl-alpha" ).getAttribute( "data-priority" ) ).toBe( "true" );
+    expect( getByTestId( "bpl-beta" ).getAttribute( "data-priority" ) ).toBe( "false" );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `yarn test src/__tests__/components/TaggedPostSections.test.tsx`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+Create `src/components/Home/TaggedPostSections.tsx`:
+
+```typescript
+import Link from "next/link";
+import { TagCollection } from "contentful";
+import { BlogPosts } from "@/utils/contentfulUtils";
+import BlogPostList from "@/components/Home/BlogPostList";
+import { POSTS_PER_TAG_SECTION } from "@/constants";
+import { sortBlogPostsByDate, sortTagsById } from "@/utils/blogPostUtils";
+import { TagSeoConfigMap } from "@/types/tagConfig";
+import styles from "@/styles/Home.module.scss";
+
+export interface TaggedPostSectionsProps {
+  posts: BlogPosts;
+  tags: TagCollection;
+  tagSeoConfig: TagSeoConfigMap;
+}
+
+export default function TaggedPostSections({ posts, tags, tagSeoConfig }: TaggedPostSectionsProps ) {
+  const sections = [ ...tags.items ]
+    .sort( sortTagsById )
+    .map( tag => {
+      const tagId = tag.sys.id;
+      const tagPosts = posts.items
+        .filter( post => post.metadata.tags.some( postTag => postTag.sys.id === tagId ) )
+        .sort( sortBlogPostsByDate )
+        .slice( 0, POSTS_PER_TAG_SECTION );
+      return { tagId, tagPosts };
+    })
+    .filter( section => section.tagPosts.length > 0 );
+
+  return (
+    <>
+      { sections.map( ( section, sectionIndex ) => {
+        const config = tagSeoConfig[section.tagId];
+        return (
+          <section
+            key={ section.tagId }
+            id={ `tag-${section.tagId}` }
+            className={ styles.tagSection }
+          >
+            <header className={ styles.tagSectionHeader }>
+              <h2>
+                <Link href={ `/tags/${section.tagId}` }>{ config.title }</Link>
+              </h2>
+              <Link href={ `/tags/${section.tagId}` } className={ styles.seeAll }>
+                See all →
+              </Link>
+            </header>
+            <BlogPostList
+              posts={ section.tagPosts }
+              page={ 1 }
+              tagId={ section.tagId }
+              firstCardPriority={ sectionIndex === 0 }
+            />
+          </section>
+        );
+      })}
+    </>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `yarn test src/__tests__/components/TaggedPostSections.test.tsx`
+Expected: PASS — all six tests green.
+
+- [ ] **Step 5: Run lint + typecheck**
+
+Run: `yarn lint`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Home/TaggedPostSections.tsx src/__tests__/components/TaggedPostSections.test.tsx
+git commit -m "feat: add TaggedPostSections component"
+```
+
+---
+
+### Task 9: Replace `pages/index.tsx` with sectioned `Home`
+
+**Files:**
+- Modify: `src/pages/index.tsx` (full replacement)
+
+Wires `TaggedPostSections`, `JsonLd`, and `homepageSchema` together. Owns its own `getStaticProps` that calls `generateFeeds` unconditionally (this code path only fires from `/`).
+
+- [ ] **Step 1: Replace `pages/index.tsx`**
+
+Replace the entire file with:
+
+```typescript
+import Link from "next/link";
+import styles from "@/styles/Home.module.scss";
+import { BlogPosts, getBlogPosts, getTags } from "@/utils/contentfulUtils";
+import { Layout } from "@/components/Layout/Layout";
+import { TagCollection } from "contentful";
+import TaggedPostSections from "@/components/Home/TaggedPostSections";
+import { generateFeeds } from "@/lib/generateFeeds";
+import { buildHomepageSchema } from "@/lib/homepageSchema";
+import { JsonLd } from "@/components/JsonLd";
+import { META_DESCRIPTION, META_IMAGE, META_TITLE, SITE_URL } from "@/constants";
+import { SeoHead } from "@/components/SeoHead";
+import { TagSeoConfigMap } from "@/types/tagConfig";
+import tagSeoConfigData from "../../data/tags.json";
+import { validateTagSeoConfig } from "@/utils/tagSeoConfig";
+
+export interface HomeProps {
+  posts: BlogPosts;
+  tags: TagCollection;
+  tagSeoConfig: TagSeoConfigMap;
+  schema: ReturnType<typeof buildHomepageSchema>;
+}
+
+export default function Home({ posts, tags, tagSeoConfig, schema }: HomeProps ) {
+  return (
+    <>
+      <SeoHead
+        title={ META_TITLE }
+        canonicalUrl={ SITE_URL }
+        description={ META_DESCRIPTION }
+        ogImage={ META_IMAGE }
+      >
+        <link rel="alternate" type="application/rss+xml" href="/rss.xml" />
+        <link rel="alternate" type="application/atom+xml" href="/atom.xml" />
+        <link rel="alternate" type="application/feed+json" href="/feed.json" />
+        <JsonLd schema={ schema } />
+      </SeoHead>
+      <Layout isFullwidth>
+        <main className={ styles.main }>
+          <TaggedPostSections
+            posts={ posts }
+            tags={ tags }
+            tagSeoConfig={ tagSeoConfig }
+          />
+          <Link href="/page/2" className={ styles.allPostsLink }>
+            Browse all posts →
+          </Link>
+        </main>
+      </Layout>
+    </>
+  );
+}
+
+export async function getStaticProps() {
+  const posts = await getBlogPosts();
+  const tags = await getTags();
+
+  const tagSeoConfig: TagSeoConfigMap = tagSeoConfigData satisfies TagSeoConfigMap;
+  const contentfulTagIds = tags.items.map( tag => tag.sys.id );
+  validateTagSeoConfig( tagSeoConfig, contentfulTagIds );
+
+  generateFeeds( posts.items );
+  const schema = buildHomepageSchema( posts );
+
+  return {
+    props: {
+      posts,
+      tags,
+      tagSeoConfig,
+      schema,
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `yarn typecheck`
+Expected: PASS — every consumer of `Home` now imports from a different path; the three archive shells import `BlogArchive` instead.
+
+- [ ] **Step 3: Run lint**
+
+Run: `yarn lint`
+Expected: PASS
+
+- [ ] **Step 4: Run the test suite**
+
+Run: `yarn test`
+Expected: PASS — no Home/index test exists; TaggedPostSections, BlogPostList, Picture, JsonLd, homepageSchema tests all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/index.tsx
+git commit -m "feat: convert home page to tag-section layout"
+```
+
+---
+
+### Task 10: Add SCSS for the new section styles
+
+**Files:**
+- Modify: `src/styles/Home.module.scss`
+
+Add styling for `.tagSection`, `.tagSectionHeader`, `.seeAll`, `.allPostsLink`. Existing classes (`.tagNav`, `.tag`, `.tagActive`, `.imageGallery`, `.pagination`) stay — they're still used by `BlogArchive`.
+
+- [ ] **Step 1: Append the new styles**
+
+Append to `src/styles/Home.module.scss` (after the existing rules):
+
+```scss
+.tagSection {
+  width: 100%;
+  margin-bottom: 4rem;
+
+  &:last-of-type {
+    margin-bottom: 2rem;
+  }
+}
+
+.tagSectionHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  width: 100%;
+  padding: 0 0.75rem;
+  margin-bottom: 1.5rem;
+
+  @media (min-width: 800px) {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+
+  @media (min-width: 872px) {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
+  }
+
+  @media (min-width: 1100px) {
+    padding-left: 3.5rem;
+    padding-right: 3.5rem;
+  }
+
+  @media (min-width: 1600px) {
+    padding-left: 4.5rem;
+    padding-right: 4.5rem;
+  }
+
+  > h2 {
+    margin: 0;
+    font-size: 1.75rem;
+    font-weight: 700;
+
+    > a {
+      text-decoration: none;
+      color: inherit;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}
+
+.seeAll {
+  font-size: 0.95rem;
+  font-weight: 500;
+  text-decoration: none;
+  opacity: 0.7;
+  transition: opacity 0.2s ease;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+.allPostsLink {
+  display: inline-block;
+  margin: 3rem auto 4rem;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 500;
+  text-decoration: none;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 8px;
+  transition: background 0.2s ease, border-color 0.2s ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.4);
+  }
+
+  @media (prefers-color-scheme: light) {
+    border-color: rgba(0, 0, 0, 0.25);
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.05);
+      border-color: rgba(0, 0, 0, 0.4);
+    }
+  }
+}
+```
+
+The padding values on `.tagSectionHeader` mirror the breakpoint progression already used by `.imageGallery` so the section heading aligns with the cards below it.
+
+- [ ] **Step 2: Run lint**
+
+Run: `yarn lint`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/styles/Home.module.scss
+git commit -m "feat: style tag sections and Browse all posts link"
+```
+
+---
+
+### Task 11: Final verification
+
+**Files:**
+- (No file changes — verification only.)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `yarn test`
+Expected: PASS — every existing test (BlogPostList, Pagination, generateFeeds, etc.) plus the four new tests (Picture, JsonLd, homepageSchema, TaggedPostSections) green.
+
+- [ ] **Step 2: Run lint**
+
+Run: `yarn lint`
+Expected: PASS — ESLint + TypeScript typecheck.
+
+- [ ] **Step 3: Run the production build**
+
+Run: `yarn build`
+Expected: PASS — Next.js export succeeds. All four route patterns (`/`, `/page/[page]`, `/tags/[tagId]`, `/tags/[tagId]/page/[page]`) generate without error. `public/rss.xml`, `public/atom.xml`, `public/feed.json`, and `public/sitemap*.xml` exist.
+
+- [ ] **Step 4: Spot-check the generated home HTML**
+
+Run: `head -200 dist/index.html | grep -E '(application/ld\+json|tag-section|loading=|fetchpriority=|Browse all posts)' || true`
+
+Expected output contains:
+- `<script type="application/ld+json">` line with the schema body.
+- One `<img>` with `loading="eager"` and `fetchpriority="high"` (the first card of the first section).
+- Multiple `<img>` with `loading="lazy"` (every other card).
+- `Browse all posts →` link text.
+
+If any expectation is missing, fix the underlying issue before proceeding.
+
+- [ ] **Step 5: Verify the JSON-LD parses as valid JSON**
+
+Extract the `application/ld+json` block from `dist/index.html` and pipe through `python3 -c "import json,sys;json.loads(sys.stdin.read())"` (or any JSON validator). The fact that no parsing error occurs confirms the `<` escape did not corrupt the JSON.
+
+- [ ] **Step 6: Confirm CLAUDE.md is still accurate**
+
+Skim `CLAUDE.md`'s Architecture → Routing table. The four route patterns and their files haven't changed at the URL level, so the table needs no update. Confirm this; if anything is now stale, fix it in this same task.
+
+- [ ] **Step 7: Push the branch and open the PR**
+
+```bash
+git push -u origin tag-sections-index
+gh pr create --title "feat: convert home page to tag-section layout" --body "$(cat <<'EOF'
+## Summary
+- Home page (`/`) now renders one section per Contentful tag with the 3 most recent posts in each, instead of a flat paginated list.
+- The flat paginated archive remains at `/page/[page]`, reachable via a "Browse all posts →" link at the bottom of the home page.
+- Tag pages (`/tags/[tagId]` and `/tags/[tagId]/page/[page]`) render unchanged via a new shared `BlogArchive` component.
+- Adds `CollectionPage` JSON-LD on the home page and threads a `priority` flag through `Picture` so only the LCP image loads eagerly.
+
+## Test plan
+- [ ] `yarn test` — all suites pass (Picture, JsonLd, homepageSchema, TaggedPostSections, BlogPostList, etc.)
+- [ ] `yarn lint` — clean
+- [ ] `yarn build` — succeeds; `dist/index.html` contains JSON-LD, exactly one eager image, and lazy attributes on the rest.
+- [ ] Visit `/` — see 10 tag sections (or fewer if some tags are empty), each with up to 3 cards.
+- [ ] Visit `/page/2` — flat archive view unchanged.
+- [ ] Visit `/tags/dj` — tag page unchanged.
+- [ ] Verify JSON-LD parses (Google's Rich Results Test, or `python3 -c "json.loads(...)"`).
+
+Spec: `docs/superpowers/specs/2026-04-27-tag-sections-index-design.md`
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+**Spec coverage** — every decision row in the spec maps to a task:
+
+| Spec decision | Task |
+|---|---|
+| Index → sectioned, `/page/[page]` stays flat | 6, 7, 9 |
+| All tags get a section (lazy below the fold) | 2, 3, 8 |
+| Alphabetical section ordering | 8 |
+| Most recent 3 posts per section | 8 |
+| Cross-tag duplicates allowed | 8 |
+| Tags with <3 posts render with what exists | 8 |
+| Tags with 0 posts omitted | 8 |
+| No tag nav on home | 9 |
+| "Browse all posts" footer link | 9, 10 |
+| LCP / CLS handling | 2, 3 |
+| `CollectionPage` JSON-LD | 4, 5, 9 |
+| `JsonLd` component centralises raw injection | 4 |
+| `BlogArchive` extraction | 6, 7 |
+| `getArchiveStaticProps` shared by archive routes | 6, 7 |
+| `POSTS_PER_TAG_SECTION` constant | 1 |
+| New SCSS classes | 10 |
+
+**Files mentioned in the spec, mapped to tasks:**
+- `src/components/Home/TaggedPostSections.tsx` → Task 8
+- `src/components/BlogArchive/BlogArchive.tsx` → Task 6
+- `src/components/BlogArchive/getStaticProps.ts` → Task 6
+- `src/lib/homepageSchema.ts` → Task 5
+- `src/components/JsonLd.tsx` → Task 4
+- `src/pages/index.tsx` → Task 9
+- `src/pages/page/[page].tsx`, `src/pages/tags/[tagId].tsx`, `src/pages/tags/[tagId]/page/[page].tsx` → Task 7
+- `src/components/Picture.tsx` → Task 2
+- `src/components/Home/BlogPostList.tsx` → Task 3
+- `src/styles/Home.module.scss` → Task 10
+- `src/constants.ts` → Task 1
+
+**`Picture` audit note** — the spec calls for an audit of every `Picture` call site outside the home. Survey result: `Picture` is imported in exactly two places — `src/components/Home/BlogPostList.tsx` (handled by Task 3's `firstCardPriority` flag) and `src/components/MediaFigure.tsx` (used inside `Markdown` rendering for in-content post body images, which are correctly served lazy). The post detail page (`src/pages/post/[slug].tsx`) uses `next/image` directly, not the local `Picture` component — its LCP is unaffected. No additional audit changes needed; the spec's audit obligation is discharged by this survey.
+
+**CLS** — `src/styles/Home.module.scss:175` already sets `aspect-ratio: 4/3` on `.imageGallery li figure picture > img`, so the multi-image layout is CLS-stable without further work.
+
+**Type consistency** — `BlogPostList`'s new `firstCardPriority` prop is named identically across Tasks 3 and 8. `Picture`'s new `priority` prop is named identically across Tasks 2 and 3. `JsonLd`'s `schema` prop matches across Tasks 4 and 9. `buildHomepageSchema` matches across Tasks 5 and 9.
+
+**Placeholders** — none. Every code step contains the actual code.
+
+**Scope** — single-feature change. Fits one plan.

--- a/docs/superpowers/specs/2026-04-27-tag-sections-index-design.md
+++ b/docs/superpowers/specs/2026-04-27-tag-sections-index-design.md
@@ -1,0 +1,280 @@
+# Tag Sections Index — Design Spec
+
+## Problem
+
+The home page (`/`) currently renders a single chronological list of the most recent posts (PAGE_SIZE per page) with a tag filter nav at the top. Readers can't see what categories the site covers without scanning post tags one card at a time, and tag pages get little promotion from the homepage. The home page should act as a hub: surface every tag, show what's recent in each, and route deeper drill-downs to the existing tag pages.
+
+## Solution
+
+Convert the home page into a sectioned overview. Each Contentful tag becomes a `<section>` containing the 3 most recent posts in that tag, with a header linking to the full tag page (`/tags/[tagId]`). The flat paginated archive remains reachable at `/page/[page]`, linked from a "Browse all posts →" footer link on the home.
+
+The existing `Home` component (which serves four routes today) is split: the index gets its own component, and the three archive routes (`/page/[page]`, `/tags/[tagId]`, `/tags/[tagId]/page/[page]`) share a renamed `BlogArchive` component with today's flat layout intact.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Scope of layout change | Index `/` only; `/page/[page]` stays as flat archive, linked from index footer | Preserves a chronological reader path while making the index a hub |
+| Which tags get a section | All 10 tags, render every section with images lazy-loaded below the fold | Every category visible at a glance; image-level laziness keeps initial paint cheap |
+| Section ordering | Alphabetical (matches existing tag nav `sortTagsById`) | Predictable, no new ordering logic |
+| Posts per section | Most recent 3 (sorted by `resolvePostDate`) | Honest "latest in this tag" snapshot |
+| Cross-tag duplicates | Allowed | A cross-tag post legitimately belongs in both categories; dedup logic gets gnarly |
+| Tags with <3 posts | Render with whatever exists (1, 2, or 3 cards) | Empty sections look broken; partial sections still useful |
+| Tags with 0 posts | Section omitted entirely | Avoids empty-state UI |
+| Top tag nav on home | Removed (sections themselves are the navigation) | Avoids redundancy on the index; nav stays on archive routes |
+| Archive entry point | "Browse all posts →" footer link to `/page/2` | One predictable link, single destination |
+| LCP / CLS | First section's first card image gets `priority`; all other Picture renders use `loading="lazy"` | 30 images vs. today's 10 demands explicit priority |
+| Structured data | `CollectionPage` JSON-LD with deduped `BlogPosting` entries in `hasPart` | Helps crawlers see the page-as-hub structure |
+
+## Architecture
+
+### Route → component → static-props mapping
+
+| Route | Page file | Component | Static props |
+|---|---|---|---|
+| `/` | `src/pages/index.tsx` | `Home` (new, sectioned) | Inline in `pages/index.tsx` |
+| `/page/[page]` | `src/pages/page/[page].tsx` | `BlogArchive` | `getArchiveStaticProps` |
+| `/tags/[tagId]` | `src/pages/tags/[tagId].tsx` | `BlogArchive` | `getArchiveStaticProps` |
+| `/tags/[tagId]/page/[page]` | `src/pages/tags/[tagId]/page/[page].tsx` | `BlogArchive` | `getArchiveStaticProps` |
+
+### Component layout
+
+```
+pages/index.tsx
+└── Home
+    ├── SeoHead (with feed <link>s + JsonLd schema)
+    └── Layout
+        └── main
+            ├── TaggedPostSections
+            │   └── For each tag with posts:
+            │       └── <section id="tag-{tagId}">
+            │           ├── <header>
+            │           │   ├── <h2><Link to /tags/[tagId]>{tagSeoConfig.title}</Link></h2>
+            │           │   └── <Link to /tags/[tagId]>See all →</Link>
+            │           └── BlogPostList (3 posts, firstCardPriority on first section)
+            └── <Link to /page/2>Browse all posts →</Link>
+
+pages/page/[page].tsx, pages/tags/[tagId].tsx, pages/tags/[tagId]/page/[page].tsx
+└── BlogArchive (today's Home, renamed)
+    ├── SeoHead
+    └── Layout
+        └── main
+            ├── tag nav (alphabetical Links to /tags/[tagId])
+            ├── BlogPostList (paginated)
+            └── Pagination
+```
+
+## Files
+
+### New
+
+**`src/components/Home/TaggedPostSections.tsx`**
+
+Renders one `<section>` per tag with posts. Filters and slices internally:
+
+```tsx
+posts.items
+  .filter( post => post.metadata.tags.some( postTag => postTag.sys.id === tagId ) )
+  .sort( sortBlogPostsByDate )
+  .slice( 0, POSTS_PER_TAG_SECTION )
+```
+
+Tags are iterated in `sortTagsById` order. Sections with zero matching posts are skipped. The component receives `posts`, `tags`, and `tagSeoConfig` as props. Passes `firstCardPriority={true}` to the first rendered section's `BlogPostList`.
+
+**`src/components/BlogArchive/BlogArchive.tsx`**
+
+Verbatim today's `Home` component renamed. Same props (`posts`, `tags`, `page`, `tagId`, `tagSeoConfig`), same SEO branching, same tag nav + `BlogPostList` + `Pagination` layout.
+
+**`src/components/BlogArchive/getStaticProps.ts`**
+
+Verbatim today's `getStaticProps` minus the `generateFeeds( posts.items )` call. Exported as `getArchiveStaticProps`. Re-exported by all three archive route shells.
+
+**`src/lib/homepageSchema.ts`**
+
+```ts
+export function buildHomepageSchema( posts: BlogPosts ) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": META_TITLE,
+    "description": META_DESCRIPTION,
+    "url": SITE_URL,
+    "isPartOf": { "@type": "WebSite", "name": "Audeos.com", "url": SITE_URL },
+    "hasPart": dedupeBySlug( posts.items ).map( post => ({
+      "@type": "BlogPosting",
+      "headline": post.fields.title,
+      "url": `${SITE_URL}/post/${post.fields.slug}`,
+      "datePublished": resolvePostDate( post ),
+      "image": post.fields.image?.fields.file?.url
+        ? `https:${post.fields.image.fields.file.url}`
+        : undefined,
+    }))
+  };
+}
+```
+
+The `hasPart` array contains the union of posts shown across all sections, deduplicated by slug. (Even though the rendered DOM allows duplicates per Q4b-i, schema dedup is data hygiene — one canonical entry per post.)
+
+**`src/components/JsonLd.tsx`**
+
+Encapsulates the unsafe-by-default React injection API behind an escaped helper. Centralises the `<` → `\u003c` substitution so a malicious title like `</script><script>` cannot break out of the JSON-LD script tag. Single allowed call site for raw JSON-LD injection — every other surface that needs structured data uses this component.
+
+```tsx
+export interface JsonLdProps { schema: object }
+
+export function JsonLd({ schema }: JsonLdProps ) {
+  const json = JSON.stringify( schema ).replace( /</g, "\\u003c" );
+  return <script type="application/ld+json">{ json }</script>;
+}
+```
+
+(React renders text children with HTML-escaping, so the `<script>` body is safe; the `<` escape inside the JSON string defends against `</script>` sequences inside post titles.)
+
+### Replaced
+
+**`src/pages/index.tsx`** — replaced with the new sectioned `Home`:
+
+```tsx
+export default function Home({ posts, tags, tagSeoConfig, schema }: HomeProps ) {
+  return (
+    <>
+      <SeoHead
+        title={ META_TITLE }
+        canonicalUrl={ SITE_URL }
+        description={ META_DESCRIPTION }
+        ogImage={ META_IMAGE }
+      >
+        <link rel="alternate" type="application/rss+xml" href="/rss.xml" />
+        <link rel="alternate" type="application/atom+xml" href="/atom.xml" />
+        <link rel="alternate" type="application/feed+json" href="/feed.json" />
+        <JsonLd schema={ schema } />
+      </SeoHead>
+      <Layout isFullwidth>
+        <main className={ styles.main }>
+          <TaggedPostSections
+            posts={ posts }
+            tags={ tags }
+            tagSeoConfig={ tagSeoConfig }
+          />
+          <Link href="/page/2" className={ styles.allPostsLink }>
+            Browse all posts →
+          </Link>
+        </main>
+      </Layout>
+    </>
+  );
+}
+
+export async function getStaticProps() {
+  const posts = await getBlogPosts();
+  const tags = await getTags();
+  const tagSeoConfig: TagSeoConfigMap = tagSeoConfigData satisfies TagSeoConfigMap;
+  validateTagSeoConfig( tagSeoConfig, tags.items.map( tag => tag.sys.id ) );
+  generateFeeds( posts.items );
+  const schema = buildHomepageSchema( posts );
+  return { props: { posts, tags, tagSeoConfig, schema } };
+}
+```
+
+No `tagId`, no `page`, no SEO branching. The `generateFeeds` gate is dropped — this code path only fires from `/`.
+
+### Modified
+
+**`src/pages/page/[page].tsx`**, **`src/pages/tags/[tagId].tsx`**, **`src/pages/tags/[tagId]/page/[page].tsx`** — each updates its imports to point at `BlogArchive` and `getArchiveStaticProps` instead of `Home` and `getStaticProps` from `@/pages`. `getStaticPaths` definitions stay intact.
+
+**`src/components/Picture.tsx`** — gains a `priority?: boolean` prop:
+
+- `priority=true` → `<img>` gets `loading="eager"` and `fetchpriority="high"`.
+- `priority=false` (default) → `<img>` gets `loading="lazy"`.
+
+**`src/components/Home/BlogPostList.tsx`** — gains a `firstCardPriority?: boolean` prop (default `false`). When `true`, the first rendered card's `Picture` receives `priority={true}`. All other cards' `Picture` calls receive no `priority` prop (defaulting to lazy).
+
+**`src/styles/Home.module.scss`** — adds `.tagSection`, `.tagSectionHeader`, `.seeAll`, `.allPostsLink`. Existing `.tagNav`/`.tagActive`/`.tag`/`.imageGallery` classes stay (still used by `BlogArchive`).
+
+**`src/constants.ts`** — adds `export const POSTS_PER_TAG_SECTION = 3;`.
+
+### Audited
+
+Every other call site of `Picture` outside the home (post detail page hero, author profile avatar, embedded image components, etc.) needs an explicit `priority={true}` for that page's LCP image. The implementation plan will enumerate each call site with the chosen value. Without this audit, those pages regress from eager (today's default) to lazy, hurting LCP on every page that isn't the home.
+
+## Data flow
+
+1. **Build time** — `pages/index.tsx`'s `getStaticProps` runs:
+   - Fetches all posts and tags from Contentful.
+   - Validates tag config (existing `validateTagSeoConfig`, throws on mismatch).
+   - Generates RSS/Atom/JSON feeds via `generateFeeds( posts.items )`.
+   - Builds `CollectionPage` JSON-LD via `buildHomepageSchema( posts )`.
+   - Returns `{ posts, tags, tagSeoConfig, schema }`.
+2. **Render** — `Home` passes `posts`/`tags`/`tagSeoConfig` to `TaggedPostSections` and embeds `schema` via the `<JsonLd>` component. The "Browse all posts →" link points to `/page/2`.
+3. **`TaggedPostSections`** — for each tag (in `sortTagsById` order), filters and sorts posts in-component (a one-liner). Renders one `<section>` per non-empty tag, delegating the card grid to `BlogPostList`.
+4. **`BlogPostList`** — receives 3 pre-filtered posts, sorts and slices internally (no-op for already-sorted, length-3 input). The IntersectionObserver fade-in and long-press preview hooks both still work per-instance.
+
+Archive routes (`/page/[page]`, `/tags/*`) flow unchanged — they share `getArchiveStaticProps` and render `BlogArchive`.
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| Tag has 0 posts | Section omitted. |
+| Tag has 1 or 2 posts | Section renders with 1 or 2 cards; no padding. |
+| Tag in Contentful but missing from `data/tags.json` | `validateTagSeoConfig` throws at build (existing fail-fast). |
+| Tag in `data/tags.json` but missing from Contentful | `validateTagSeoConfig` throws at build. |
+| Post tagged with multiple tags | Appears in each tag's section. |
+| Post has no tags | Doesn't appear on home. Still reachable via `/page/[page]`. |
+| Post has no image | Existing `BlogPostList` already handles `pictureUrl = post.fields.image?.fields.file?.url \|\| ""`. |
+| `/page/1` accessed directly | `getStaticPaths` already skips `page=1` — unchanged. |
+| Post title contains `</script>` | `JsonLd` escapes `<` to `\u003c`, preventing script-tag breakout. |
+
+## Testing
+
+Vitest unit tests:
+
+- **`TaggedPostSections.test.tsx`**
+  - Renders one section per tag with at least one post.
+  - Sections with zero matching posts are omitted.
+  - Each section caps at `POSTS_PER_TAG_SECTION` (3).
+  - A post tagged with two tags appears in both sections.
+  - Section header links to `/tags/[tagId]`.
+  - Only the first section receives `firstCardPriority={true}`.
+- **`homepageSchema.test.ts`**
+  - Returns `@type: "CollectionPage"` with `name`, `description`, `url`, `isPartOf`.
+  - `hasPart` deduplicates posts even when they span multiple tags.
+  - Each `BlogPosting` has `headline`, `url`, `datePublished`, and (when image exists) `image`.
+- **`Picture.test.tsx`**
+  - `priority={true}` → `<img>` has `loading="eager"` and `fetchpriority="high"`.
+  - `priority={false}` (default) → `<img>` has `loading="lazy"`.
+- **`JsonLd.test.tsx`**
+  - Renders a `<script type="application/ld+json">` element.
+  - Escapes `<` characters in stringified JSON to `\u003c` (verified by feeding a schema whose string contains `</script>`).
+
+Existing `Home`/`BlogPostList` tests get re-pointed at `BlogArchive` (renamed component, identical behavior).
+
+## SEO impact
+
+**Positives**
+
+- More descriptive anchor text for tag links (full titles vs. short IDs).
+- More internal links from homepage (up to 30 posts vs. 10) plus 10 prominent tag-page links.
+- Cleaner heading hierarchy: each section gets `<h2>` (tag) wrapping post `<h3>`s.
+- `CollectionPage` JSON-LD declares the page-as-hub structure.
+
+**Non-regressions**
+
+- Title, description, canonical URL, and feed `<link rel="alternate">` headers unchanged for `/`.
+- Feeds (`generateFeeds`) build from full post list, unaffected by layout.
+- Sitemap (`next-sitemap`) enumerates routes — unaffected.
+- No new fragment URLs exposed (no anchor nav).
+- Cross-section duplicate posts: each post's canonical is `/post/[slug]`; homepage references aren't duplicate content.
+- `rel=next`/`rel=prev` not in use today — nothing to break.
+
+**Mitigations baked in**
+
+- LCP: `Picture.priority` + `BlogPostList.firstCardPriority` ensure exactly one above-the-fold image is eager + high-priority; rest are lazy.
+- CLS: verification step in implementation — confirm `Picture` reserves space at all breakpoints.
+- XSS: JSON-LD injection routes through `<JsonLd>`, which escapes `<` to neutralise `</script>` sequences in Contentful-sourced strings.
+
+## Migration / deploy
+
+- Static export → URLs unchanged → no redirects, no sitemap churn.
+- First deploy after merge: visitors to `/` see the new layout; archive routes look identical.
+- No Contentful schema changes, no env var changes, no build script changes.

--- a/src/__tests__/components/BlogPostList.test.tsx
+++ b/src/__tests__/components/BlogPostList.test.tsx
@@ -13,7 +13,9 @@ vi.mock( "next/link", () => ({
   ),
 }) );
 vi.mock( "@/components/Picture", () => ({
-  default: ({ alt }: { alt: string }) => <img alt={ alt } />,
+  default: ({ alt, priority }: { alt: string; priority?: boolean }) => (
+    <img alt={ alt } data-priority={ priority ? "true" : "false" } />
+  ),
 }) );
 vi.mock( "@/components/Tags", () => ({
   Tags: () => <div data-testid="tags" />,
@@ -122,5 +124,29 @@ describe( "BlogPostList", () => {
     const links = container.querySelectorAll( "a" );
     const hrefs = Array.from( links ).map( link => link.getAttribute( "href" ) );
     expect( hrefs ).toContain( "/post/post-0" );
+  });
+
+  it( "passes priority to the first card image only when firstCardPriority is true", () => {
+    const { container } = render(
+      <BlogPostList
+        posts={ makePosts( 3 ) as never[] }
+        page={ 1 }
+        firstCardPriority
+      />,
+    );
+    const images = container.querySelectorAll( "img" );
+    expect( images[0].getAttribute( "data-priority" ) ).toBe( "true" );
+    expect( images[1].getAttribute( "data-priority" ) ).toBe( "false" );
+    expect( images[2].getAttribute( "data-priority" ) ).toBe( "false" );
+  });
+
+  it( "does not mark any image priority when firstCardPriority is false (default)", () => {
+    const { container } = render(
+      <BlogPostList posts={ makePosts( 3 ) as never[] } page={ 1 } />,
+    );
+    const images = container.querySelectorAll( "img" );
+    images.forEach( image => {
+      expect( image.getAttribute( "data-priority" ) ).toBe( "false" );
+    });
   });
 });

--- a/src/__tests__/components/JsonLd.test.tsx
+++ b/src/__tests__/components/JsonLd.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { JsonLd } from "@/components/JsonLd";
+
+describe( "JsonLd", () => {
+  it( "renders a script tag with type application/ld+json", () => {
+    const { container } = render( <JsonLd schema={ { "@type": "WebSite" } } /> );
+    const script = container.querySelector( "script" );
+    expect( script?.getAttribute( "type" ) ).toBe( "application/ld+json" );
+  });
+
+  it( "stringifies the schema as the script body", () => {
+    const { container } = render(
+      <JsonLd schema={ { "@type": "WebSite", "name": "Audeos" } } />,
+    );
+    const script = container.querySelector( "script" );
+    expect( script?.textContent ).toContain( "\"@type\":\"WebSite\"" );
+    expect( script?.textContent ).toContain( "\"name\":\"Audeos\"" );
+  });
+
+  it( "escapes < to \\u003c so </script> in strings cannot break out", () => {
+    const malicious = { "@type": "WebSite", "headline": "Hi </script><script>alert(1)</script>" };
+    const { container } = render( <JsonLd schema={ malicious } /> );
+    const script = container.querySelector( "script" );
+    expect( script?.textContent ).not.toContain( "</script>" );
+    expect( script?.textContent ).toContain( "\\u003c/script\\u003e" );
+  });
+});

--- a/src/__tests__/components/Picture.test.tsx
+++ b/src/__tests__/components/Picture.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import Picture from "@/components/Picture";
+
+describe( "Picture", () => {
+  it( "lazy-loads the image by default", () => {
+    const { container } = render(
+      <Picture url="//img.test/photo.jpg" alt="alt" />,
+    );
+    const img = container.querySelector( "img" );
+    expect( img?.getAttribute( "loading" ) ).toBe( "lazy" );
+    expect( img?.getAttribute( "fetchpriority" ) ).toBeNull();
+  });
+
+  it( "marks the image as priority when priority is true", () => {
+    const { container } = render(
+      <Picture url="//img.test/photo.jpg" alt="alt" priority />,
+    );
+    const img = container.querySelector( "img" );
+    expect( img?.getAttribute( "loading" ) ).toBe( "eager" );
+    expect( img?.getAttribute( "fetchpriority" ) ).toBe( "high" );
+  });
+});

--- a/src/__tests__/components/TaggedPostSections.test.tsx
+++ b/src/__tests__/components/TaggedPostSections.test.tsx
@@ -178,4 +178,29 @@ describe( "TaggedPostSections", () => {
     expect( getByTestId( "bpl-alpha" ).getAttribute( "data-priority" ) ).toBe( "true" );
     expect( getByTestId( "bpl-beta" ).getAttribute( "data-priority" ) ).toBe( "false" );
   });
+
+  it( "renders nothing when no tags have posts", () => {
+    const { container } = render(
+      <TaggedPostSections
+        posts={ { items: [] } as never }
+        tags={ { items: [ tagAlpha, tagBeta ] } as never }
+        tagSeoConfig={ tagSeoConfig as never }
+      />,
+    );
+    expect( container.querySelectorAll( "section" ) ).toHaveLength( 0 );
+  });
+
+  it( "passes firstCardPriority to the first rendered section even when earlier tags are empty", () => {
+    const posts = {
+      items: [ makePost({ slug: "b1", date: "2026-04-01", tagIds: [ "beta" ] }) ],
+    };
+    const { getByTestId } = render(
+      <TaggedPostSections
+        posts={ posts as never }
+        tags={ { items: [ tagAlpha, tagBeta ] } as never }
+        tagSeoConfig={ tagSeoConfig as never }
+      />,
+    );
+    expect( getByTestId( "bpl-beta" ).getAttribute( "data-priority" ) ).toBe( "true" );
+  });
 });

--- a/src/__tests__/components/TaggedPostSections.test.tsx
+++ b/src/__tests__/components/TaggedPostSections.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+
+vi.mock( "@/constants", async importOriginal => ({
+  ...( await importOriginal<typeof import( "@/constants" )>() ),
+  POSTS_PER_TAG_SECTION: 3,
+}) );
+vi.mock( "@/utils/contentfulUtils", () => ({}) );
+vi.mock( "next/link", () => ({
+  default: ({ children, href, ...props }: React.ComponentProps<"a"> ) => (
+    <a href={ href } { ...props }>{ children }</a>
+  ),
+}) );
+vi.mock( "@/components/Home/BlogPostList", () => ({
+  default: ({
+    posts,
+    firstCardPriority,
+    tagId,
+  }: {
+    posts: { fields: { slug: string } }[];
+    firstCardPriority?: boolean;
+    tagId?: string;
+  }) => (
+    <ul
+      data-testid={ `bpl-${tagId}` }
+      data-priority={ firstCardPriority ? "true" : "false" }
+      data-count={ posts.length }
+    >
+      { posts.map( post => <li key={ post.fields.slug }>{ post.fields.slug }</li> ) }
+    </ul>
+  ),
+}) );
+
+import TaggedPostSections from "@/components/Home/TaggedPostSections";
+
+const tagAlpha = { sys: { id: "alpha" } };
+const tagBeta = { sys: { id: "beta" } };
+const tagEmpty = { sys: { id: "empty" } };
+
+const tagSeoConfig = {
+  alpha: { title: "Alpha Title", description: "", ogImage: null },
+  beta: { title: "Beta Title", description: "", ogImage: null },
+  empty: { title: "Empty Title", description: "", ogImage: null },
+};
+
+const makePost = ({
+  slug,
+  date,
+  tagIds,
+}: {
+  slug: string;
+  date: string;
+  tagIds: string[];
+}) => ({
+  sys: { id: slug, createdAt: date },
+  fields: { slug, title: slug, date, image: undefined },
+  metadata: { tags: tagIds.map( id => ({ sys: { id, type: "Link", linkType: "Tag" } }) ) },
+});
+
+beforeEach( () => {
+  vi.stubGlobal( "matchMedia", ( query: string ) => ({
+    matches: false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }) );
+});
+
+describe( "TaggedPostSections", () => {
+  it( "renders one section per tag that has at least one post", () => {
+    const posts = {
+      items: [
+        makePost({ slug: "a1", date: "2026-04-01", tagIds: [ "alpha" ] }),
+        makePost({ slug: "b1", date: "2026-04-02", tagIds: [ "beta" ] }),
+      ],
+    };
+    const { container } = render(
+      <TaggedPostSections
+        posts={ posts as never }
+        tags={ { items: [ tagAlpha, tagBeta, tagEmpty ] } as never }
+        tagSeoConfig={ tagSeoConfig as never }
+      />,
+    );
+    const sections = container.querySelectorAll( "section" );
+    expect( sections ).toHaveLength( 2 );
+    expect( sections[0].id ).toBe( "tag-alpha" );
+    expect( sections[1].id ).toBe( "tag-beta" );
+  });
+
+  it( "iterates tags alphabetically by id", () => {
+    const posts = {
+      items: [
+        makePost({ slug: "b1", date: "2026-04-01", tagIds: [ "beta" ] }),
+        makePost({ slug: "a1", date: "2026-04-01", tagIds: [ "alpha" ] }),
+      ],
+    };
+    const { container } = render(
+      <TaggedPostSections
+        posts={ posts as never }
+        tags={ { items: [ tagBeta, tagAlpha ] } as never }
+        tagSeoConfig={ tagSeoConfig as never }
+      />,
+    );
+    const sections = container.querySelectorAll( "section" );
+    expect( sections[0].id ).toBe( "tag-alpha" );
+    expect( sections[1].id ).toBe( "tag-beta" );
+  });
+
+  it( "caps each section at POSTS_PER_TAG_SECTION (3) most recent posts", () => {
+    const posts = {
+      items: [
+        makePost({ slug: "a1", date: "2026-04-01", tagIds: [ "alpha" ] }),
+        makePost({ slug: "a2", date: "2026-04-02", tagIds: [ "alpha" ] }),
+        makePost({ slug: "a3", date: "2026-04-03", tagIds: [ "alpha" ] }),
+        makePost({ slug: "a4", date: "2026-04-04", tagIds: [ "alpha" ] }),
+        makePost({ slug: "a5", date: "2026-04-05", tagIds: [ "alpha" ] }),
+      ],
+    };
+    const { getByTestId } = render(
+      <TaggedPostSections
+        posts={ posts as never }
+        tags={ { items: [ tagAlpha ] } as never }
+        tagSeoConfig={ tagSeoConfig as never }
+      />,
+    );
+    const list = getByTestId( "bpl-alpha" );
+    expect( list.getAttribute( "data-count" ) ).toBe( "3" );
+    const slugs = Array.from( list.querySelectorAll( "li" ) ).map( item => item.textContent );
+    expect( slugs ).toEqual( [ "a5", "a4", "a3" ] );
+  });
+
+  it( "shows a post tagged with two tags in both sections", () => {
+    const posts = {
+      items: [ makePost({ slug: "shared", date: "2026-04-01", tagIds: [ "alpha", "beta" ] }) ],
+    };
+    const { getByTestId } = render(
+      <TaggedPostSections
+        posts={ posts as never }
+        tags={ { items: [ tagAlpha, tagBeta ] } as never }
+        tagSeoConfig={ tagSeoConfig as never }
+      />,
+    );
+    expect( getByTestId( "bpl-alpha" ).getAttribute( "data-count" ) ).toBe( "1" );
+    expect( getByTestId( "bpl-beta" ).getAttribute( "data-count" ) ).toBe( "1" );
+  });
+
+  it( "links the section header to /tags/[tagId] using tagSeoConfig.title", () => {
+    const posts = {
+      items: [ makePost({ slug: "a1", date: "2026-04-01", tagIds: [ "alpha" ] }) ],
+    };
+    const { container } = render(
+      <TaggedPostSections
+        posts={ posts as never }
+        tags={ { items: [ tagAlpha ] } as never }
+        tagSeoConfig={ tagSeoConfig as never }
+      />,
+    );
+    const heading = container.querySelector( "h2 a" );
+    expect( heading?.getAttribute( "href" ) ).toBe( "/tags/alpha" );
+    expect( heading?.textContent ).toBe( "Alpha Title" );
+  });
+
+  it( "passes firstCardPriority only to the first rendered section", () => {
+    const posts = {
+      items: [
+        makePost({ slug: "a1", date: "2026-04-01", tagIds: [ "alpha" ] }),
+        makePost({ slug: "b1", date: "2026-04-01", tagIds: [ "beta" ] }),
+      ],
+    };
+    const { getByTestId } = render(
+      <TaggedPostSections
+        posts={ posts as never }
+        tags={ { items: [ tagAlpha, tagBeta ] } as never }
+        tagSeoConfig={ tagSeoConfig as never }
+      />,
+    );
+    expect( getByTestId( "bpl-alpha" ).getAttribute( "data-priority" ) ).toBe( "true" );
+    expect( getByTestId( "bpl-beta" ).getAttribute( "data-priority" ) ).toBe( "false" );
+  });
+});

--- a/src/__tests__/lib/homepageSchema.test.ts
+++ b/src/__tests__/lib/homepageSchema.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { buildHomepageSchema } from "@/lib/homepageSchema";
+
+const makePost = ({
+  id,
+  slug,
+  title,
+  date,
+  imageUrl,
+}: {
+  id: string;
+  slug: string;
+  title: string;
+  date: string;
+  imageUrl?: string;
+}) => ({
+  sys: { id, createdAt: date },
+  fields: {
+    slug,
+    title,
+    date,
+    image: imageUrl
+      ? { fields: { file: { url: imageUrl }, description: "" } }
+      : undefined,
+  },
+  metadata: { tags: [] },
+});
+
+describe( "buildHomepageSchema", () => {
+  it( "returns a CollectionPage with site-level metadata", () => {
+    const schema = buildHomepageSchema({
+      items: [ makePost({ id: "1", slug: "post-1", title: "Post 1", date: "2026-04-01" }) ],
+    } as never );
+    expect( schema[ "@context" ] ).toBe( "https://schema.org" );
+    expect( schema[ "@type" ] ).toBe( "CollectionPage" );
+    expect( schema.name ).toBeDefined();
+    expect( schema.description ).toBeDefined();
+    expect( schema.url ).toBeDefined();
+    expect( schema.isPartOf ).toEqual({
+      "@type": "WebSite",
+      "name": "Audeos.com",
+      "url": "https://www.audeos.com",
+    });
+  });
+
+  it( "includes one BlogPosting per post in hasPart", () => {
+    const schema = buildHomepageSchema({
+      items: [
+        makePost({ id: "1", slug: "post-1", title: "Post 1", date: "2026-04-01", imageUrl: "//img/1.jpg" }),
+        makePost({ id: "2", slug: "post-2", title: "Post 2", date: "2026-04-02" }),
+      ],
+    } as never );
+    expect( schema.hasPart ).toHaveLength( 2 );
+    expect( schema.hasPart[0] ).toMatchObject({
+      "@type": "BlogPosting",
+      "headline": "Post 1",
+      "url": "https://www.audeos.com/post/post-1",
+      "datePublished": "2026-04-01",
+      "image": "https://img/1.jpg",
+    });
+    expect( schema.hasPart[1] ).toMatchObject({
+      "@type": "BlogPosting",
+      "headline": "Post 2",
+      "url": "https://www.audeos.com/post/post-2",
+      "datePublished": "2026-04-02",
+    });
+    expect( schema.hasPart[1].image ).toBeUndefined();
+  });
+
+  it( "deduplicates posts by slug", () => {
+    const post = makePost({ id: "1", slug: "post-1", title: "Post 1", date: "2026-04-01" });
+    const schema = buildHomepageSchema({
+      items: [ post, post, post ],
+    } as never );
+    expect( schema.hasPart ).toHaveLength( 1 );
+  });
+});

--- a/src/components/BlogArchive/BlogArchive.tsx
+++ b/src/components/BlogArchive/BlogArchive.tsx
@@ -14,7 +14,7 @@ export interface BlogArchiveProps {
   posts: BlogPosts
   tags: TagCollection
   page: number
-  tagId?: string
+  tagId: string | null
   tagSeoConfig?: TagSeoConfig
 }
 
@@ -68,7 +68,7 @@ export default function BlogArchive({ posts, page, tags, tagId, tagSeoConfig }: 
         <main className={ styles.main }>
           <nav className={ styles.tagNav }>
             {
-              tags.items
+              [ ...tags.items ]
                 .sort( sortTagsById )
                 .map( tag => {
                   const isActive = tag.sys.id === tagId;
@@ -87,13 +87,13 @@ export default function BlogArchive({ posts, page, tags, tagId, tagSeoConfig }: 
           </nav>
           <BlogPostList
             posts={ filteredBlogPosts }
-            tagId={ tagId }
+            tagId={ tagId ?? undefined }
             page={ page }
           />
           <Pagination
             posts={ filteredBlogPosts }
             page={ page }
-            tagId={ tagId }
+            tagId={ tagId ?? undefined }
           />
         </main>
       </Layout>

--- a/src/components/BlogArchive/BlogArchive.tsx
+++ b/src/components/BlogArchive/BlogArchive.tsx
@@ -1,0 +1,102 @@
+import Link from "next/link";
+import styles from "@/styles/Home.module.scss";
+import { BlogPosts } from "@/utils/contentfulUtils";
+import BlogPostList from "@/components/Home/BlogPostList";
+import { Layout } from "@/components/Layout/Layout";
+import { TagCollection } from "contentful";
+import { sortTagsById } from "@/utils/blogPostUtils";
+import Pagination from "@/components/Home/Pagination";
+import { META_DESCRIPTION, META_IMAGE, META_TITLE, SITE_URL } from "@/constants";
+import { SeoHead } from "@/components/SeoHead";
+import { TagSeoConfig } from "@/types/tagConfig";
+
+export interface BlogArchiveProps {
+  posts: BlogPosts
+  tags: TagCollection
+  page: number
+  tagId?: string
+  tagSeoConfig?: TagSeoConfig
+}
+
+export default function BlogArchive({ posts, page, tags, tagId, tagSeoConfig }: BlogArchiveProps ) {
+  const filteredBlogPosts = posts.items
+    .filter( post => tagId === null || post.metadata.tags
+      .find( tag => tag.sys.id === tagId ) );
+
+  const isTagPage = Boolean( tagId );
+  const isPaginated = page > 1;
+
+  const tagLabel = tagSeoConfig?.title ?? "";
+
+  const pageTitle = isTagPage && isPaginated
+    ? `${tagLabel} — Page ${page} | Audeos.com`
+    : isTagPage
+      ? `${tagLabel} | Audeos.com`
+      : isPaginated
+        ? `Blog — Page ${page} | ${META_TITLE}`
+        : META_TITLE;
+
+  const pageDescription = isTagPage && tagSeoConfig
+    ? tagSeoConfig.description
+    : META_DESCRIPTION;
+
+  const ogImage = isTagPage && tagSeoConfig?.ogImage
+    ? tagSeoConfig.ogImage
+    : META_IMAGE;
+
+  const canonicalUrl = isTagPage && isPaginated
+    ? `${SITE_URL}/tags/${tagId}/page/${page}`
+    : isTagPage
+      ? `${SITE_URL}/tags/${tagId}`
+      : isPaginated
+        ? `${SITE_URL}/page/${page}`
+        : SITE_URL;
+
+  return (
+    <>
+      <SeoHead
+        title={ pageTitle }
+        canonicalUrl={ canonicalUrl }
+        description={ pageDescription }
+        ogImage={ ogImage }
+      >
+        <link rel="alternate" type="application/rss+xml" href="/rss.xml" />
+        <link rel="alternate" type="application/atom+xml" href="/atom.xml" />
+        <link rel="alternate" type="application/feed+json" href="/feed.json" />
+      </SeoHead>
+      <Layout isFullwidth>
+        <main className={ styles.main }>
+          <nav className={ styles.tagNav }>
+            {
+              tags.items
+                .sort( sortTagsById )
+                .map( tag => {
+                  const isActive = tag.sys.id === tagId;
+                  const href = isActive ? "/" : `/tags/${tag.sys.id}`;
+                  return (
+                    <Link
+                      key={ tag.sys.id }
+                      href={ href }
+                      className={ isActive ? styles.tagActive : styles.tag }
+                    >
+                      { tag.sys.id }
+                    </Link>
+                  );
+                })
+            }
+          </nav>
+          <BlogPostList
+            posts={ filteredBlogPosts }
+            tagId={ tagId }
+            page={ page }
+          />
+          <Pagination
+            posts={ filteredBlogPosts }
+            page={ page }
+            tagId={ tagId }
+          />
+        </main>
+      </Layout>
+    </>
+  );
+}

--- a/src/components/BlogArchive/getStaticProps.ts
+++ b/src/components/BlogArchive/getStaticProps.ts
@@ -1,0 +1,29 @@
+import { GetStaticPropsContext } from "next";
+import { getBlogPosts, getTags } from "@/utils/contentfulUtils";
+import { TagSeoConfigMap } from "@/types/tagConfig";
+import tagSeoConfigData from "../../../data/tags.json";
+import { validateTagSeoConfig } from "@/utils/tagSeoConfig";
+
+export async function getArchiveStaticProps( context: GetStaticPropsContext ) {
+  const tagId = context.params?.tagId || null;
+  const page: number = Number( context.params?.page ) || 1;
+  const tags = await getTags();
+  const posts = await getBlogPosts();
+
+  const tagConfig: TagSeoConfigMap = tagSeoConfigData satisfies TagSeoConfigMap;
+  const contentfulTagIds = tags.items.map( tag => tag.sys.id );
+  validateTagSeoConfig( tagConfig, contentfulTagIds );
+
+  const resolvedTagId = Array.isArray( tagId ) ? tagId[0] : tagId;
+  const tagSeoConfig = resolvedTagId ? tagConfig[resolvedTagId] : null;
+
+  return {
+    props: {
+      tagId,
+      posts,
+      tags,
+      page,
+      tagSeoConfig,
+    },
+  };
+}

--- a/src/components/Home/BlogPostList.tsx
+++ b/src/components/Home/BlogPostList.tsx
@@ -89,9 +89,10 @@ export interface BlogPostListProps {
   posts: BlogPost[]
   page: number
   tagId?: string
+  firstCardPriority?: boolean
 }
 
-export default function BlogPostList({ posts, page, tagId }: BlogPostListProps ) {
+export default function BlogPostList({ posts, page, tagId, firstCardPriority = false }: BlogPostListProps ) {
   const listRef = useRef<HTMLUListElement>( null );
 
   useEffect( () => {
@@ -129,7 +130,7 @@ export default function BlogPostList({ posts, page, tagId }: BlogPostListProps )
         [ ...posts ]
           .sort( sortBlogPostsByDate )
           .slice( PAGE_SIZE * ( page - 1 ), PAGE_SIZE * page )
-          .map( post => {
+          .map( ( post, cardIndex ) => {
 
             const url = `/post/${post.fields.slug}`;
             const pictureUrl = post.fields.image?.fields.file?.url || "";
@@ -144,6 +145,7 @@ export default function BlogPostList({ posts, page, tagId }: BlogPostListProps )
                       url={ pictureUrl }
                       maxWidth={ IMAGE_WIDTH }
                       alt={ altText }
+                      priority={ firstCardPriority && cardIndex === 0 }
                     />
                   </Link>
                   <figcaption>

--- a/src/components/Home/TaggedPostSections.tsx
+++ b/src/components/Home/TaggedPostSections.tsx
@@ -29,7 +29,10 @@ export default function TaggedPostSections({ posts, tags, tagSeoConfig }: Tagged
   return (
     <>
       { sections.map( ( section, sectionIndex ) => {
-        const config = tagSeoConfig[section.tagId];
+        const tagConfig = tagSeoConfig[section.tagId];
+        if( !tagConfig ) {
+          throw new Error( `TaggedPostSections: no tagSeoConfig entry for tag "${section.tagId}"` );
+        }
         return (
           <section
             key={ section.tagId }
@@ -38,9 +41,14 @@ export default function TaggedPostSections({ posts, tags, tagSeoConfig }: Tagged
           >
             <header className={ styles.tagSectionHeader }>
               <h2>
-                <Link href={ `/tags/${section.tagId}` }>{ config.title }</Link>
+                <Link href={ `/tags/${section.tagId}` }>{ tagConfig.title }</Link>
               </h2>
-              <Link href={ `/tags/${section.tagId}` } className={ styles.seeAll }>
+              <Link
+                href={ `/tags/${section.tagId}` }
+                className={ styles.seeAll }
+                aria-hidden="true"
+                tabIndex={ -1 }
+              >
                 See all →
               </Link>
             </header>

--- a/src/components/Home/TaggedPostSections.tsx
+++ b/src/components/Home/TaggedPostSections.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { TagCollection } from "contentful";
+import { BlogPosts } from "@/utils/contentfulUtils";
+import BlogPostList from "@/components/Home/BlogPostList";
+import { POSTS_PER_TAG_SECTION } from "@/constants";
+import { sortBlogPostsByDate, sortTagsById } from "@/utils/blogPostUtils";
+import { TagSeoConfigMap } from "@/types/tagConfig";
+import styles from "@/styles/Home.module.scss";
+
+export interface TaggedPostSectionsProps {
+  posts: BlogPosts;
+  tags: TagCollection;
+  tagSeoConfig: TagSeoConfigMap;
+}
+
+export default function TaggedPostSections({ posts, tags, tagSeoConfig }: TaggedPostSectionsProps ) {
+  const sections = [ ...tags.items ]
+    .sort( sortTagsById )
+    .map( tag => {
+      const tagId = tag.sys.id;
+      const tagPosts = posts.items
+        .filter( post => post.metadata.tags.some( postTag => postTag.sys.id === tagId ) )
+        .sort( sortBlogPostsByDate )
+        .slice( 0, POSTS_PER_TAG_SECTION );
+      return { tagId, tagPosts };
+    })
+    .filter( section => section.tagPosts.length > 0 );
+
+  return (
+    <>
+      { sections.map( ( section, sectionIndex ) => {
+        const config = tagSeoConfig[section.tagId];
+        return (
+          <section
+            key={ section.tagId }
+            id={ `tag-${section.tagId}` }
+            className={ styles.tagSection }
+          >
+            <header className={ styles.tagSectionHeader }>
+              <h2>
+                <Link href={ `/tags/${section.tagId}` }>{ config.title }</Link>
+              </h2>
+              <Link href={ `/tags/${section.tagId}` } className={ styles.seeAll }>
+                See all →
+              </Link>
+            </header>
+            <BlogPostList
+              posts={ section.tagPosts }
+              page={ 1 }
+              tagId={ section.tagId }
+              firstCardPriority={ sectionIndex === 0 }
+            />
+          </section>
+        );
+      }) }
+    </>
+  );
+}

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,10 @@
+export interface JsonLdProps {
+  schema: object;
+}
+
+export function JsonLd({ schema }: JsonLdProps ) {
+  const json = JSON.stringify( schema )
+    .replace( /</g, "\\u003c" )
+    .replace( />/g, "\\u003e" );
+  return <script type="application/ld+json">{ json }</script>;
+}

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,5 +1,5 @@
 export interface JsonLdProps {
-  schema: object;
+  schema: Record<string, unknown>;
 }
 
 export function JsonLd({ schema }: JsonLdProps ) {

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -37,7 +37,7 @@ export default function Picture({
         src={ getImgSrc( url, { width: maxWidth }) }
         alt={ alt }
         loading={ priority ? "eager" : "lazy" }
-        { ...( priority && { fetchPriority: "high" satisfies "high" }) }
+        { ...( priority ? { fetchPriority: "high" } : {}) }
       />
     </picture>
   );

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -5,6 +5,7 @@ export interface PictureProps {
   alt: string;
   maxWidth?: number;
   breakpoints?: number[],
+  priority?: boolean;
 }
 
 export default function Picture({
@@ -12,6 +13,7 @@ export default function Picture({
   maxWidth = CONTENT_IMAGE_WIDTH,
   alt,
   breakpoints = [ 749, 600, 350 ],
+  priority = false,
 }: PictureProps ) {
   return (
     <picture>
@@ -34,6 +36,8 @@ export default function Picture({
       <img
         src={ getImgSrc( url, { width: maxWidth }) }
         alt={ alt }
+        loading={ priority ? "eager" : "lazy" }
+        { ...( priority && { fetchPriority: "high" satisfies "high" }) }
       />
     </picture>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,3 +9,4 @@ export const COOKIE_CONSENT_KEY = "cookie-consent";
 export const POSTS_ANCHOR = "posts";
 export const PAGE_SIZE = 12;
 export const CONTENT_IMAGE_WIDTH = 750;
+export const POSTS_PER_TAG_SECTION = 3;

--- a/src/lib/homepageSchema.ts
+++ b/src/lib/homepageSchema.ts
@@ -1,0 +1,41 @@
+import { BlogPost, BlogPosts } from "@/utils/contentfulUtils";
+import { resolvePostDate } from "@/utils/blogPostUtils";
+import { META_DESCRIPTION, META_TITLE, SITE_URL } from "@/constants";
+
+function dedupeBySlug( posts: BlogPost[] ): BlogPost[] {
+  const seen = new Set<string>();
+  const unique: BlogPost[] = [];
+  posts.forEach( post => {
+    const slug = post.fields.slug;
+    if( !seen.has( slug ) ) {
+      seen.add( slug );
+      unique.push( post );
+    }
+  });
+  return unique;
+}
+
+export function buildHomepageSchema( posts: BlogPosts ) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": META_TITLE,
+    "description": META_DESCRIPTION,
+    "url": SITE_URL,
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "Audeos.com",
+      "url": SITE_URL,
+    },
+    "hasPart": dedupeBySlug( posts.items ).map( post => {
+      const imageUrl = post.fields.image?.fields.file?.url;
+      return {
+        "@type": "BlogPosting",
+        "headline": post.fields.title,
+        "url": `${SITE_URL}/post/${post.fields.slug}`,
+        "datePublished": resolvePostDate( post ),
+        "image": imageUrl ? `https:${imageUrl}` : undefined,
+      };
+    }),
+  };
+}

--- a/src/lib/homepageSchema.ts
+++ b/src/lib/homepageSchema.ts
@@ -24,7 +24,7 @@ export function buildHomepageSchema( posts: BlogPosts ) {
     "url": SITE_URL,
     "isPartOf": {
       "@type": "WebSite",
-      "name": "Audeos.com",
+      "name": META_TITLE,
       "url": SITE_URL,
     },
     "hasPart": dedupeBySlug( posts.items ).map( post => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,133 +1,72 @@
 import Link from "next/link";
 import styles from "@/styles/Home.module.scss";
 import { BlogPosts, getBlogPosts, getTags } from "@/utils/contentfulUtils";
-import BlogPostList from "@/components/Home/BlogPostList";
 import { Layout } from "@/components/Layout/Layout";
 import { TagCollection } from "contentful";
-import { sortTagsById } from "@/utils/blogPostUtils";
-import { GetStaticPropsContext } from "next";
-import Pagination from "@/components/Home/Pagination";
+import TaggedPostSections from "@/components/Home/TaggedPostSections";
 import { generateFeeds } from "@/lib/generateFeeds";
+import { buildHomepageSchema } from "@/lib/homepageSchema";
+import { JsonLd } from "@/components/JsonLd";
 import { META_DESCRIPTION, META_IMAGE, META_TITLE, SITE_URL } from "@/constants";
 import { SeoHead } from "@/components/SeoHead";
-import { TagSeoConfig, TagSeoConfigMap } from "@/types/tagConfig";
+import { TagSeoConfigMap } from "@/types/tagConfig";
 import tagSeoConfigData from "../../data/tags.json";
 import { validateTagSeoConfig } from "@/utils/tagSeoConfig";
 
 export interface HomeProps {
-  posts: BlogPosts
-  tags: TagCollection
-  page: number
-  tagId?: string
-  tagSeoConfig?: TagSeoConfig
+  posts: BlogPosts;
+  tags: TagCollection;
+  tagSeoConfig: TagSeoConfigMap;
+  schema: ReturnType<typeof buildHomepageSchema>;
 }
 
-export default function Home({ posts, page, tags, tagId, tagSeoConfig }: HomeProps ) {
-  const filteredBlogPosts = posts.items
-    .filter( post => tagId === null || post.metadata.tags
-      .find( tag => tag.sys.id === tagId ) );
-
-  const isTagPage = Boolean( tagId );
-  const isPaginated = page > 1;
-
-  const tagLabel = tagSeoConfig?.title ?? "";
-
-  const pageTitle = isTagPage && isPaginated
-    ? `${tagLabel} — Page ${page} | Audeos.com`
-    : isTagPage
-      ? `${tagLabel} | Audeos.com`
-      : isPaginated
-        ? `Blog — Page ${page} | ${META_TITLE}`
-        : META_TITLE;
-
-  const pageDescription = isTagPage && tagSeoConfig
-    ? tagSeoConfig.description
-    : META_DESCRIPTION;
-
-  const ogImage = isTagPage && tagSeoConfig?.ogImage
-    ? tagSeoConfig.ogImage
-    : META_IMAGE;
-
-  const canonicalUrl = isTagPage && isPaginated
-    ? `${SITE_URL}/tags/${tagId}/page/${page}`
-    : isTagPage
-      ? `${SITE_URL}/tags/${tagId}`
-      : isPaginated
-        ? `${SITE_URL}/page/${page}`
-        : SITE_URL;
-
+export default function Home({ posts, tags, tagSeoConfig, schema }: HomeProps ) {
   return (
     <>
       <SeoHead
-        title={ pageTitle }
-        canonicalUrl={ canonicalUrl }
-        description={ pageDescription }
-        ogImage={ ogImage }
+        title={ META_TITLE }
+        canonicalUrl={ SITE_URL }
+        description={ META_DESCRIPTION }
+        ogImage={ META_IMAGE }
       >
         <link rel="alternate" type="application/rss+xml" href="/rss.xml" />
         <link rel="alternate" type="application/atom+xml" href="/atom.xml" />
         <link rel="alternate" type="application/feed+json" href="/feed.json" />
+        <JsonLd schema={ schema } />
       </SeoHead>
       <Layout isFullwidth>
         <main className={ styles.main }>
-          <nav className={ styles.tagNav }>
-            {
-              tags.items
-                .sort( sortTagsById )
-                .map( tag => {
-                  const isActive = tag.sys.id === tagId;
-                  const href = isActive ? "/" : `/tags/${tag.sys.id}`;
-                  return (
-                    <Link
-                      key={ tag.sys.id }
-                      href={ href }
-                      className={ isActive ? styles.tagActive : styles.tag }
-                    >
-                      { tag.sys.id }
-                    </Link>
-                  );
-                })
-            }
-          </nav>
-          <BlogPostList
-            posts={ filteredBlogPosts }
-            tagId={ tagId }
-            page={ page }
+          <TaggedPostSections
+            posts={ posts }
+            tags={ tags }
+            tagSeoConfig={ tagSeoConfig }
           />
-          <Pagination
-            posts={ filteredBlogPosts }
-            page={ page }
-            tagId={ tagId }
-          />
+          <Link href="/page/2" className={ styles.allPostsLink }>
+            Browse all posts →
+          </Link>
         </main>
       </Layout>
     </>
   );
 }
 
-export async function getStaticProps( context: GetStaticPropsContext ) {
-  const tagId = context.params?.tagId || null;
-  const page: number = Number( context.params?.page ) || 1;
-  const tags = await getTags();
+export async function getStaticProps() {
   const posts = await getBlogPosts();
+  const tags = await getTags();
 
-  const tagConfig: TagSeoConfigMap = tagSeoConfigData satisfies TagSeoConfigMap;
+  const tagSeoConfig: TagSeoConfigMap = tagSeoConfigData satisfies TagSeoConfigMap;
   const contentfulTagIds = tags.items.map( tag => tag.sys.id );
-  validateTagSeoConfig( tagConfig, contentfulTagIds );
+  validateTagSeoConfig( tagSeoConfig, contentfulTagIds );
 
-  const resolvedTagId = Array.isArray( tagId ) ? tagId[0] : tagId;
-  const tagSeoConfig = resolvedTagId ? tagConfig[resolvedTagId] : null;
+  generateFeeds( posts.items );
+  const schema = buildHomepageSchema( posts );
 
-  if( !tagId && page === 1 ) {
-    generateFeeds( posts.items );
-  }
   return {
     props: {
-      tagId,
       posts,
       tags,
-      page,
       tagSeoConfig,
+      schema,
     },
   };
 }

--- a/src/pages/page/[page].tsx
+++ b/src/pages/page/[page].tsx
@@ -1,9 +1,10 @@
 import { getBlogPosts } from "@/utils/contentfulUtils";
-import Home, { getStaticProps as getStaticPropsHome } from "@/pages";
+import BlogArchive from "@/components/BlogArchive/BlogArchive";
+import { getArchiveStaticProps } from "@/components/BlogArchive/getStaticProps";
 import { PAGE_SIZE } from "@/constants";
 
 
-export const getStaticProps = getStaticPropsHome;
+export const getStaticProps = getArchiveStaticProps;
 
 export async function getStaticPaths() {
   const posts = await getBlogPosts();
@@ -20,4 +21,4 @@ export async function getStaticPaths() {
   };
 }
 
-export default Home;
+export default BlogArchive;

--- a/src/pages/tags/[tagId].tsx
+++ b/src/pages/tags/[tagId].tsx
@@ -1,8 +1,9 @@
 import { getTags } from "@/utils/contentfulUtils";
-import Home, { getStaticProps as getStaticPropsBase } from "@/pages";
+import BlogArchive from "@/components/BlogArchive/BlogArchive";
+import { getArchiveStaticProps } from "@/components/BlogArchive/getStaticProps";
 
 
-export const getStaticProps = getStaticPropsBase;
+export const getStaticProps = getArchiveStaticProps;
 
 
 export async function getStaticPaths() {
@@ -18,4 +19,4 @@ export async function getStaticPaths() {
   };
 }
 
-export default Home;
+export default BlogArchive;

--- a/src/pages/tags/[tagId]/page/[page].tsx
+++ b/src/pages/tags/[tagId]/page/[page].tsx
@@ -1,10 +1,10 @@
 import { getBlogPosts, getTags } from "@/utils/contentfulUtils";
-import Home from "@/pages";
+import BlogArchive from "@/components/BlogArchive/BlogArchive";
+import { getArchiveStaticProps } from "@/components/BlogArchive/getStaticProps";
 import { PAGE_SIZE } from "@/constants";
-import { getStaticProps as getStaticPropsBase } from "@/pages";
 
 
-export const getStaticProps = getStaticPropsBase;
+export const getStaticProps = getArchiveStaticProps;
 
 
 export async function getStaticPaths() {
@@ -34,4 +34,4 @@ export async function getStaticPaths() {
   };
 }
 
-export default Home;
+export default BlogArchive;

--- a/src/styles/Home.module.scss
+++ b/src/styles/Home.module.scss
@@ -278,3 +278,96 @@ ul.imageGallery {
     }
   }
 }
+
+.tagSection {
+  width: 100%;
+  margin-bottom: 4rem;
+
+  &:last-of-type {
+    margin-bottom: 2rem;
+  }
+}
+
+.tagSectionHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  width: 100%;
+  padding: 0 0.75rem;
+  margin-bottom: 1.5rem;
+
+  @media (min-width: 800px) {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+
+  @media (min-width: 872px) {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
+  }
+
+  @media (min-width: 1100px) {
+    padding-left: 3.5rem;
+    padding-right: 3.5rem;
+  }
+
+  @media (min-width: 1600px) {
+    padding-left: 4.5rem;
+    padding-right: 4.5rem;
+  }
+
+  > h2 {
+    margin: 0;
+    font-size: 1.75rem;
+    font-weight: 700;
+
+    > a {
+      text-decoration: none;
+      color: inherit;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}
+
+.seeAll {
+  font-size: 0.95rem;
+  font-weight: 500;
+  text-decoration: none;
+  opacity: 0.7;
+  transition: opacity 0.2s ease;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+.allPostsLink {
+  display: inline-block;
+  margin: 3rem auto 4rem;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 500;
+  text-decoration: none;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 8px;
+  transition: background 0.2s ease, border-color 0.2s ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.4);
+  }
+
+  @media (prefers-color-scheme: light) {
+    border-color: rgba(0, 0, 0, 0.25);
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.05);
+      border-color: rgba(0, 0, 0, 0.4);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Home page (`/`) now renders one `<section>` per Contentful tag with the 3 most recent posts in each, instead of a flat paginated list.
- The flat paginated archive remains at `/page/[page]`, reachable via a "Browse all posts →" link at the bottom of the home page.
- Tag pages (`/tags/[tagId]` and `/tags/[tagId]/page/[page]`) render unchanged via a new shared `BlogArchive` component extracted from the old `Home`.
- Adds `CollectionPage` JSON-LD on the home page (via a new `JsonLd` component that escapes `<` to neutralise `</script>` injection from Contentful-sourced strings) and threads a `priority` flag through `Picture` so only the LCP image loads eagerly; everything else is `loading="lazy"`.

## Test plan
- [x] `yarn test` — 158 tests across 22 files pass (Picture, JsonLd, homepageSchema, TaggedPostSections, BlogPostList, plus existing suites)
- [x] `yarn lint` — clean
- [x] `yarn build` — 115 static pages export; `dist/index.html` contains 1 JSON-LD script (parses as valid `CollectionPage`), exactly 1 `loading="eager"` image, 29 `loading="lazy"` images, and the "Browse all posts →" link
- [ ] Visit `/` — see tag sections (skipping any tag with zero posts), each capped at 3 cards
- [ ] Visit `/page/2` — flat archive view unchanged
- [ ] Visit `/tags/dj` — tag page unchanged
- [ ] Validate JSON-LD via Google's Rich Results Test

Spec: `docs/superpowers/specs/2026-04-27-tag-sections-index-design.md`
Plan: `docs/superpowers/plans/2026-04-27-tag-sections-index.md`