### PR TITLE
fix: route home's Browse all posts link to /page/1

### DIFF
--- a/src/__tests__/components/Pagination.test.tsx
+++ b/src/__tests__/components/Pagination.test.tsx
@@ -31,7 +31,7 @@ describe( "Pagination", () => {
 
   it( "renders page number links for filter kind 'all'", () => {
     render( <Pagination posts={ makePosts( 7 ) as never[] } page={ 1 } filter={ { kind: "all" } } /> );
-    expect( screen.getByText( "1" ).getAttribute( "href" ) ).toBe( "/" );
+    expect( screen.getByText( "1" ).getAttribute( "href" ) ).toBe( "/page/1" );
     expect( screen.getByText( "2" ).getAttribute( "href" ) ).toBe( "/page/2" );
     expect( screen.getByText( "3" ).getAttribute( "href" ) ).toBe( "/page/3" );
   });
@@ -73,7 +73,7 @@ describe( "Pagination", () => {
     );
     const prevLink = screen.getByText( "prev" );
     expect( prevLink ).toBeInTheDocument();
-    expect( prevLink.getAttribute( "href" ) ).toBe( "/" );
+    expect( prevLink.getAttribute( "href" ) ).toBe( "/page/1" );
   });
 
   it( "renders a next link when there are more pages", () => {

--- a/src/components/FilteredArchive/getAllStaticProps.ts
+++ b/src/components/FilteredArchive/getAllStaticProps.ts
@@ -4,7 +4,7 @@ import { CategoryConfigMap } from "@/types/categoryConfig";
 import categoriesData from "../../../data/categories.json";
 import { validateCategoryConfig } from "@/utils/categoryConfig";
 import { ArchiveFilter, ArchiveSeo } from "@/types/archiveFilter";
-import { META_DESCRIPTION, META_IMAGE, META_TITLE, SITE_URL } from "@/constants";
+import { META_DESCRIPTION, META_IMAGE, SITE_URL } from "@/constants";
 
 export async function getAllStaticProps( context: GetStaticPropsContext ) {
   const page: number = Number( context.params?.page ) || 1;
@@ -17,10 +17,10 @@ export async function getAllStaticProps( context: GetStaticPropsContext ) {
   );
 
   const seo: ArchiveSeo = {
-    title: page > 1 ? `Blog — Page ${page} | Audeos.com` : META_TITLE,
+    title: `Blog — Page ${page} | Audeos.com`,
     description: META_DESCRIPTION,
     ogImage: META_IMAGE,
-    canonical: page > 1 ? `${SITE_URL}/page/${page}` : SITE_URL,
+    canonical: `${SITE_URL}/page/${page}`,
   };
 
   const filter: ArchiveFilter = { kind: "all" };

--- a/src/components/Home/Pagination.tsx
+++ b/src/components/Home/Pagination.tsx
@@ -23,8 +23,8 @@ function getPaginatorBase( filter: ArchiveFilter ): string {
 
 function getPaginatorUrl( pageNumber: number, filter: ArchiveFilter ): string {
   const base = getPaginatorBase( filter );
-  if( pageNumber === 1 ) {
-    return base === "/" ? "/" : base.replace( /\/$/, "" );
+  if( pageNumber === 1 && filter.kind !== "all" ) {
+    return base.replace( /\/$/, "" );
   }
   return `${base}page/${pageNumber}`;
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -38,7 +38,7 @@ export default function Home({ posts, categoryConfig, schema }: HomeProps ) {
             posts={ posts }
             categoryConfig={ categoryConfig }
           />
-          <Link href="/page/2" className={ styles.allPostsLink }>
+          <Link href="/page/1" className={ styles.allPostsLink }>
             Browse all posts →
           </Link>
         </main>

--- a/src/pages/page/[page].tsx
+++ b/src/pages/page/[page].tsx
@@ -11,7 +11,7 @@ export async function getStaticPaths() {
   const numPages = Math.ceil( posts.items.length / PAGE_SIZE );
   const paths: { params: { page: string } }[] = [];
 
-  for( let page = 2; page <= numPages; page++ ) {
+  for( let page = 1; page <= numPages; page++ ) {
     paths.push({ params: { page: page.toString() } });
   }
 


### PR DESCRIPTION
## Summary
- The home page is a category-grouped overview, not the chronological page 1 of the archive.
- The previous "Browse all posts →" link pointed to `/page/2`, which silently skipped the first 12 chronological posts because `/page/1` didn't exist as a static route.
- Now `/page/1` is generated and is the canonical chronological-archive entry point.

## Changes
- `pages/page/[page].tsx`: `getStaticPaths` includes `page=1`.
- `pages/index.tsx`: link target → `/page/1`.
- `Pagination`: page-1 link for `filter.kind === "all"` → `/page/1` (tag/category landing pages still use the un-paginated route as page 1, since they're not duplicate views).
- `getAllStaticProps`: drops the `page > 1` SEO conditionals — `/page/1` now has its own title (`Blog — Page 1 | Audeos.com`) and canonical (`/page/1`), distinct from the home (`/`).
- `Pagination.test.tsx`: updated assertions for new `kind: "all"` behavior.

## Verified
- `yarn test` — 169 tests across 24 files pass.
- `yarn lint` / `yarn build` — clean.
- `dist/page/1.html` exists with title `Blog — Page 1 | Audeos.com` and canonical `https://www.audeos.com/page/1`.
- Home's "Browse all posts" link points at `/page/1`.