### PR TITLE
perf: memoize Contentful fetches within a single build

### DIFF
--- a/src/utils/contentfulUtils.ts
+++ b/src/utils/contentfulUtils.ts
@@ -25,45 +25,51 @@ export type BlogPost = Entry<TypeBlogPostSkeleton, "WITHOUT_UNRESOLVABLE_LINKS",
 export type AuthorCollection = EntryCollection<TypeAuthorSkeleton, "WITHOUT_UNRESOLVABLE_LINKS", string>;
 export type Author = Entry<TypeAuthorSkeleton, "WITHOUT_UNRESOLVABLE_LINKS", string>;
 
-// Retrieve the list of blog posts from Contentful
+// Module-level Promise caches. Next.js's static export build is one Node
+// process — a single fetch per collection is shared across every page's
+// getStaticPaths and getStaticProps. Cuts per-build CDA calls from ~200 to 3.
+// Slug-based lookups derive from the cached collection (no extra fetches).
+let blogPostsPromise: Promise<BlogPosts> | null = null;
+let tagsPromise: Promise<TagCollection> | null = null;
+let authorsPromise: Promise<AuthorCollection> | null = null;
+
 export const getBlogPosts = async (): Promise<BlogPosts> => {
-  const response = await client.withoutUnresolvableLinks.getEntries<TypeBlogPostSkeleton>({
-    content_type: CONTENT_TYPE_BLOG_POST,
-    limit: 1000,
-  });
-  return response;
+  if( !blogPostsPromise ) {
+    blogPostsPromise = client.withoutUnresolvableLinks.getEntries<TypeBlogPostSkeleton>({
+      content_type: CONTENT_TYPE_BLOG_POST,
+      limit: 1000,
+    });
+  }
+  return blogPostsPromise;
 };
 
 
 export const getBlogPost = async (
   slug: EntryFields.Text,
 ): Promise<BlogPost | undefined> => {
-  // Fetch all results where `fields.slug` is equal to the `slug` param
-  const response = await client.withoutUnresolvableLinks.getEntries<TypeBlogPostSkeleton>({
-    content_type: CONTENT_TYPE_BLOG_POST,
-    "fields.slug": slug,
-  });
-  return response.items[0];
+  const all = await getBlogPosts();
+  return all.items.find( post => post.fields.slug === slug );
 };
 
 
 export const getTags = async (): Promise<TagCollection> => {
-  const response = await client.getTags();
-  return response;
+  if( !tagsPromise ) {
+    tagsPromise = client.getTags();
+  }
+  return tagsPromise;
 };
 
 export const getAuthors = async (): Promise<AuthorCollection> => {
-  const response = await client.withoutUnresolvableLinks.getEntries<TypeAuthorSkeleton>({
-    content_type: CONTENT_TYPE_AUTHOR,
-    limit: 1000,
-  });
-  return response;
+  if( !authorsPromise ) {
+    authorsPromise = client.withoutUnresolvableLinks.getEntries<TypeAuthorSkeleton>({
+      content_type: CONTENT_TYPE_AUTHOR,
+      limit: 1000,
+    });
+  }
+  return authorsPromise;
 };
 
 export const getAuthor = async ( slug: EntryFields.Text ): Promise<Author | undefined> => {
-  const response = await client.withoutUnresolvableLinks.getEntries<TypeAuthorSkeleton>({
-    content_type: CONTENT_TYPE_AUTHOR,
-    "fields.slug": slug,
-  });
-  return response.items[0];
+  const all = await getAuthors();
+  return all.items.find( author => author.fields.slug === slug );
 };


### PR DESCRIPTION
## Summary

Cuts per-build Contentful CDA calls from ~200 down to **3**. Module-level Promise caches in `src/utils/contentfulUtils.ts` ensure each collection (posts, tags, authors) is fetched exactly once per build process. Slug-based lookups (`getBlogPost`, `getAuthor`) derive from the cached collection instead of issuing their own slug-filtered queries.

## Why

Next.js's static export build is one Node process. Today, every `getStaticPaths` and `getStaticProps` invocation calls `getBlogPosts()` / `getTags()` / `getAuthors()` independently. Contentful's SDK doesn't cache, so each is a fresh CDA call. With ~100+ generated paths across the site, a single build makes ~200 CDA calls.

With the 100K monthly API quota, this single change reclaims thousands of calls per month. The 85-publish backfill from PR #88 (which fired 85 webhooks → 85 builds) consumed an estimated **~18,000** CDA calls; with this change it would have consumed ~250.

## Per-build call breakdown

| Caller | Before | After |
|---|---|---|
| `getStaticPaths` (4 routes that fetch posts) | 4× `getBlogPosts` | 1× shared |
| `/page/[page]` (~8 paths) | 8× `getBlogPosts` | 0 (cached) |
| `/tags/[tagId]` (10 paths) | 10× `getBlogPosts` | 0 (cached) |
| `/tags/[tagId]/page/[page]` (~10 paths) | 10× `getBlogPosts` | 0 (cached) |
| `/category/[slug]` (3 paths) | 3× `getBlogPosts` | 0 (cached) |
| `/category/[slug]/page/[page]` (5 paths) | 5× `getBlogPosts` | 0 (cached) |
| `/post/[slug]` (85 paths) | 85× `getBlogPost(slug)` + 85× `getBlogPosts` | 0 (slug derived from cache) |
| `/author/[slug]` (1 path) | 1× `getAuthor(slug)` | 0 (slug derived from cache) |
| `/search`, `/`, getStaticPaths(tags) | misc | 0 (cached) |
| **Total** | **~216 calls** | **3 calls** |

## Behavior change to be aware of

In dev mode (`yarn dev`), the cache persists for the lifetime of the dev server. Restart `yarn dev` to see Contentful content changes. For production builds (one-shot Node process), the cache lifetime is exactly one build — no staleness concern.

## Verified

- `yarn typecheck` — clean.
- `yarn lint` — clean.
- `yarn test` — 169 tests across 24 files pass. Tests mock `getBlogPost` and `getBlogPosts` separately, so the implementation change is invisible to them.

**Did NOT run `yarn build`** — would burn API calls against the 75% quota. The actual call reduction becomes visible on the next merged deploy.

## Risks

- **Slug query semantics:** `getBlogPost(slug)` and `getAuthor(slug)` previously queried Contentful with a `fields.slug=` filter (returning only that entry plus its links). They now derive from the full cached collection. Both APIs already use `WITHOUT_UNRESOLVABLE_LINKS`, so the data shape should be identical. If a slug appears in the cached collection, it returns the matched entry; if not, returns `undefined` (same as before).
- **Stale-cache in dev:** see "Behavior change" above.