### PR TITLE
ci: bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
@@ -96,7 +96,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
@@ -406,7 +406,7 @@ jobs:
             exit 1
           fi
       - name: Run Lighthouse CI
-        uses: treosh/lighthouse-ci-action@v11
+        uses: treosh/lighthouse-ci-action@v12
         with:
           urls: ${{ steps.lighthouse_urls.outputs.urls }}
           uploadArtifacts: true

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -28,6 +28,11 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+# Force JavaScript actions onto Node 24 ahead of the June 2026 deprecation
+# (silences "Node.js 20 is deprecated" warnings from transitive deps).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 env:
   NEXT_TELEMETRY_DISABLED: 1
 

--- a/.github/workflows/pr-build-stats.yml
+++ b/.github/workflows/pr-build-stats.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
@@ -53,7 +53,7 @@ jobs:
         run: corepack enable
 
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/pr-build-stats.yml
+++ b/.github/workflows/pr-build-stats.yml
@@ -8,6 +8,10 @@ permissions:
   contents: read
   pull-requests: write
 
+# Force JavaScript actions onto Node 24 ahead of the June 2026 deprecation.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/refresh-spotify-cache.yml
+++ b/.github/workflows/refresh-spotify-cache.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: write
 
+# Force JavaScript actions onto Node 24 ahead of the June 2026 deprecation.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   refresh:
     runs-on: ubuntu-latest

--- a/.github/workflows/refresh-spotify-cache.yml
+++ b/.github/workflows/refresh-spotify-cache.yml
@@ -25,7 +25,7 @@ jobs:
         run: corepack enable
 
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -18,6 +18,10 @@ concurrency:
   group: socket-scan-${{ github.ref }}-${{ github.sha }}
   cancel-in-progress: true
 
+# Force JavaScript actions onto Node 24 ahead of the June 2026 deprecation.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   socket-security:
     permissions:


### PR DESCRIPTION
## Summary

CI runners are dropping Node.js 20: forced upgrade to Node 24 on **June 2nd, 2026**, and Node 20 removed from runners entirely on **September 16th, 2026**. Two of our pinned actions still ran on Node 20:

- \`actions/cache@v4\` → \`@v5\` (5 occurrences across \`nextjs.yml\`, \`pr-build-stats.yml\`, \`refresh-spotify-cache.yml\`)
- \`treosh/lighthouse-ci-action@v11\` → \`@v12\` (in \`nextjs.yml\`)

After this PR, all directly-referenced actions support Node 24.

## Remaining warning (not fixable from our side)

The deprecation message also mentioned \`actions/upload-artifact@<sha>\`. We don't reference \`upload-artifact\` directly anywhere in our workflows — it's used internally by \`actions/deploy-pages@v5\` (or \`actions/configure-pages@v6\`). That warning will go away once those upstream actions update their dependencies; nothing for us to do here.

## Test plan

- [ ] Merge → next deploy run on \`main\` should no longer emit the \`actions/cache@v4\` Node 20 warning.
- [ ] Next PR build → no \`actions/cache@v4\` warning in the \`pr-build-stats\` workflow logs.
- [ ] Next Lighthouse CI run → no \`treosh/lighthouse-ci-action@v11\` Node 20 warning.