### PR TITLE
fix: merge duplicate env blocks breaking nextjs workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -32,8 +32,6 @@ concurrency:
 # (silences "Node.js 20 is deprecated" warnings from transitive deps).
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
-env:
   NEXT_TELEMETRY_DISABLED: 1
 
 jobs:

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
@@ -96,7 +96,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
@@ -406,7 +406,7 @@ jobs:
             exit 1
           fi
       - name: Run Lighthouse CI
-        uses: treosh/lighthouse-ci-action@v11
+        uses: treosh/lighthouse-ci-action@v12
         with:
           urls: ${{ steps.lighthouse_urls.outputs.urls }}
           uploadArtifacts: true

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -28,6 +28,11 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+# Force JavaScript actions onto Node 24 ahead of the June 2026 deprecation
+# (silences "Node.js 20 is deprecated" warnings from transitive deps).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 env:
   NEXT_TELEMETRY_DISABLED: 1
 

--- a/.github/workflows/pr-build-stats.yml
+++ b/.github/workflows/pr-build-stats.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
@@ -53,7 +53,7 @@ jobs:
         run: corepack enable
 
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/pr-build-stats.yml
+++ b/.github/workflows/pr-build-stats.yml
@@ -8,6 +8,10 @@ permissions:
   contents: read
   pull-requests: write
 
+# Force JavaScript actions onto Node 24 ahead of the June 2026 deprecation.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/refresh-spotify-cache.yml
+++ b/.github/workflows/refresh-spotify-cache.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: write
 
+# Force JavaScript actions onto Node 24 ahead of the June 2026 deprecation.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   refresh:
     runs-on: ubuntu-latest

--- a/.github/workflows/refresh-spotify-cache.yml
+++ b/.github/workflows/refresh-spotify-cache.yml
@@ -25,7 +25,7 @@ jobs:
         run: corepack enable
 
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -18,6 +18,10 @@ concurrency:
   group: socket-scan-${{ github.ref }}-${{ github.sha }}
   cancel-in-progress: true
 
+# Force JavaScript actions onto Node 24 ahead of the June 2026 deprecation.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   socket-security:
     permissions:


### PR DESCRIPTION
## Summary

PR #94 introduced two top-level \`env:\` blocks in \`.github/workflows/nextjs.yml\`. YAML rejects duplicate keys at the same level, so workflow validation fails with:

> Invalid workflow file (Line: 36, Col: 1): 'env' is already defined

The \`Deploy Next.js site to Pages\` workflow has been failing on every commit to main since #94 merged.

## Fix

Merge the two \`env:\` blocks into one:

\`\`\`yaml
env:
  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
  NEXT_TELEMETRY_DISABLED: 1
\`\`\`

Net diff: 2 deletions (the redundant \`env:\` line + its trailing blank line). Both env vars are preserved.

## Why this happened

The original workflow already had \`env: { NEXT_TELEMETRY_DISABLED: 1 }\` at the top level. PR #94 added \`env: { FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true }\` as a second block instead of merging into the existing one. The other three workflow files weren't affected because they didn't have a pre-existing top-level \`env:\` block.

## Test plan

- [ ] Merge → next push to main triggers the workflow → validation passes (no more \"'env' is already defined\" error).
- [ ] Verify a deploy actually completes end-to-end.