### PR TITLE
fix: merge duplicate env blocks breaking nextjs workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -32,8 +32,6 @@ concurrency:
 # (silences "Node.js 20 is deprecated" warnings from transitive deps).
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
-env:
   NEXT_TELEMETRY_DISABLED: 1
 
 jobs:


### PR DESCRIPTION
## Summary

PR #94 introduced two top-level \`env:\` blocks in \`.github/workflows/nextjs.yml\`. YAML rejects duplicate keys at the same level, so workflow validation fails with:

> Invalid workflow file (Line: 36, Col: 1): 'env' is already defined

The \`Deploy Next.js site to Pages\` workflow has been failing on every commit to main since #94 merged.

## Fix

Merge the two \`env:\` blocks into one:

\`\`\`yaml
env:
  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
  NEXT_TELEMETRY_DISABLED: 1
\`\`\`

Net diff: 2 deletions (the redundant \`env:\` line + its trailing blank line). Both env vars are preserved.

## Why this happened

The original workflow already had \`env: { NEXT_TELEMETRY_DISABLED: 1 }\` at the top level. PR #94 added \`env: { FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true }\` as a second block instead of merging into the existing one. The other three workflow files weren't affected because they didn't have a pre-existing top-level \`env:\` block.

(Replaces #95, which had merge conflicts because its branch base predated the broken state.)

## Test plan

- [ ] Merge → next push to main triggers the workflow → validation passes (no more \"'env' is already defined\" error).
- [ ] Verify a deploy actually completes end-to-end.