### PR TITLE
feat: visual polish for NowPlayingCard (vinyl + ring + aurora)

### DIFF
--- a/docs/superpowers/plans/2026-04-29-now-playing-polish.md
+++ b/docs/superpowers/plans/2026-04-29-now-playing-polish.md
@@ -1,0 +1,793 @@
+# Now-Playing Card Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Visual rework of `NowPlayingCard` — vinyl spinner, conic progress ring, animated gradient border, aurora drift backdrop, EQ bars, film grain overlay. Behavior identical to PR #93; only styling and a few decorative DOM nodes change.
+
+**Architecture:** Two-step refactor of the component file. Task 1 restructures the JSX — adds vinyl/ring/EQ/border DOM nodes, replaces linear progress bar with conic ring (with `data-testid="now-playing-progress-fill"` moved to it), wires `--progress-percent` CSS custom property from React state, and updates one test assertion to match. Task 2 rewrites the SCSS module end-to-end to implement the hybrid visual treatment. Task 3 verifies and ships.
+
+**Tech Stack:** React 19, TypeScript, SCSS modules, Vitest. Pure CSS for all visual effects (no new dependencies).
+
+**Spec:** `docs/superpowers/specs/2026-04-29-now-playing-polish-design.md`
+
+**Branch:** `polish-now-playing-card` (already created, off `main`).
+
+---
+
+### Task 1: Restructure JSX + update one test assertion
+
+**Files:**
+- Modify: `src/components/NowPlaying/NowPlayingCard.tsx`
+- Modify: `src/components/NowPlaying/NowPlayingCard.module.scss` (add empty rules for new class names; full styling in Task 2)
+- Modify: `src/__tests__/components/NowPlayingCard.test.tsx` (one test assertion)
+
+The component grows new decorative DOM (gradient border span, vinyl div, EQ bars, conic ring with text inside) and loses the linear progress bar. The `data-testid="now-playing-progress-fill"` moves from the deleted linear-bar element to the new ring element. Inline `style={{ "--progress-percent": ... }}` drives the conic gradient from React state.
+
+The time display text format stays identical (`${formatMs(now)} / ${formatMs(total)}` in a single span) so 99% of existing tests pass without changes. Only the one test that asserts `bar.style.width === "0%"` needs to change to `ring.style.getPropertyValue("--progress-percent") === "0"`.
+
+- [ ] **Step 1: Read the current component to confirm starting state**
+
+Read `src/components/NowPlaying/NowPlayingCard.tsx`. Confirm it currently has:
+- `useReducer` with `displayPositionMs` and `epoch` state
+- Two `useEffect`s (poll + tick)
+- Renders `<a className={styles.card}>` with source label, track info, linear progress bar inside `.progress` / `.progressTrack` / `.progressFill`, up-next, footer, etc.
+- An offline branch and a skeleton branch.
+
+If anything significantly differs from this, STOP and report — the plan assumes the component matches the post-PR-#93 state.
+
+- [ ] **Step 2: Update the one test assertion**
+
+In `src/__tests__/components/NowPlayingCard.test.tsx`, find this test:
+
+```typescript
+  it( "renders progress bar at 0% when duration_ms is 0", async () => {
+    mockFetchOnce({
+      ...livePayload,
+      track: { ...livePayload.track, position_ms: 0, duration_ms: 0 },
+    });
+    render( <NowPlayingCard /> );
+    const bar = await screen.findByTestId( "now-playing-progress-fill" );
+    expect( bar.style.width ).toBe( "0%" );
+  });
+```
+
+Replace with:
+
+```typescript
+  it( "renders progress ring at 0% when duration_ms is 0", async () => {
+    mockFetchOnce({
+      ...livePayload,
+      track: { ...livePayload.track, position_ms: 0, duration_ms: 0 },
+    });
+    render( <NowPlayingCard /> );
+    const ring = await screen.findByTestId( "now-playing-progress-fill" );
+    expect( ring.style.getPropertyValue( "--progress-percent" ) ).toBe( "0" );
+  });
+```
+
+- [ ] **Step 3: Run all NowPlayingCard tests — the modified test should now FAIL**
+
+Run: `yarn test src/__tests__/components/NowPlayingCard.test.tsx`
+Expected: 1 test FAILS (the one we just rewrote — it now expects `--progress-percent === "0"` but the current component sets `width` not `--progress-percent`). 27 others still PASS.
+
+If more than 1 test fails, STOP and investigate.
+
+- [ ] **Step 4: Replace the live-render JSX in the component**
+
+In `src/components/NowPlaying/NowPlayingCard.tsx`:
+
+First, add `CSSProperties` to the React imports at the top:
+
+```typescript
+import { useEffect, useReducer, type CSSProperties } from "react";
+```
+
+Replace the entire live-render block. Find this current block:
+
+```typescript
+  return (
+    <a
+      href={ `${AUDEOS_PLAY_ORIGIN}/channels/${data.channel.slug}` }
+      target="_blank"
+      rel="noopener noreferrer"
+      className={ styles.card }
+    >
+      <p className={ styles.sourceLabel }>{ SOURCE_LABEL[data.source] }</p>
+      { data.track ? (
+        <div className={ styles.trackInfo }>
+          <h2 className={ styles.trackTitle }>{ data.track.title }</h2>
+          { data.track.artist && (
+            <p className={ styles.artist }>{ data.track.artist }</p>
+          ) }
+          <div className={ styles.progress }>
+            <div className={ styles.progressTrack }>
+              <div
+                data-testid="now-playing-progress-fill"
+                className={ styles.progressFill }
+                style={ {
+                  width: data.track.duration_ms > 0
+                    ? `${Math.min( 100, ( displayPositionMs / data.track.duration_ms ) * 100 )}%`
+                    : "0%",
+                } }
+              />
+            </div>
+            <span className={ styles.progressTime }>
+              { formatMs( displayPositionMs ) } / { formatMs( data.track.duration_ms ) }
+            </span>
+          </div>
+        </div>
+      ) : (
+        <p className={ styles.noMetadata }>No metadata available.</p>
+      ) }
+      { data.next_track && (
+        <p className={ styles.upNext }>
+          Up next · { data.next_track.title }
+          { data.next_track.artist && ` · ${data.next_track.artist}` }
+        </p>
+      ) }
+      <div className={ styles.footer }>
+        <p data-testid="now-playing-channel-info" className={ styles.channelInfo }>
+          { data.channel.name }
+          { data.channel.description && ` · ${data.channel.description}` }
+        </p>
+        <div className={ styles.footerRow }>
+          <span className={ styles.listenerCount }>
+            { data.listener_count } listening
+          </span>
+          <span className={ styles.cta }>Tune in →</span>
+        </div>
+      </div>
+    </a>
+  );
+```
+
+Replace with:
+
+```typescript
+  const trackDurationMs = data.track?.duration_ms ?? 0;
+  const progressPercent = trackDurationMs > 0
+    ? Math.min( 100, ( displayPositionMs / trackDurationMs ) * 100 )
+    : 0;
+
+  return (
+    <a
+      href={ `${AUDEOS_PLAY_ORIGIN}/channels/${data.channel.slug}` }
+      target="_blank"
+      rel="noopener noreferrer"
+      className={ styles.card }
+    >
+      <span className={ styles.cardBorder } aria-hidden="true" />
+      <div className={ styles.vinyl } aria-hidden="true" />
+
+      <div className={ styles.content }>
+        <p className={ styles.sourceLabel }>
+          { SOURCE_LABEL[data.source] }
+          <span className={ styles.eq } aria-hidden="true">
+            <span /><span /><span /><span />
+          </span>
+        </p>
+        { data.track ? (
+          <>
+            <h2 className={ styles.trackTitle }>{ data.track.title }</h2>
+            { data.track.artist && (
+              <p className={ styles.artist }>{ data.track.artist }</p>
+            ) }
+          </>
+        ) : (
+          <p className={ styles.noMetadata }>No metadata available.</p>
+        ) }
+        { data.next_track && (
+          <p className={ styles.upNext }>
+            Up next · { data.next_track.title }
+            { data.next_track.artist && ` · ${data.next_track.artist}` }
+          </p>
+        ) }
+        <div className={ styles.footer }>
+          <p data-testid="now-playing-channel-info" className={ styles.channelInfo }>
+            { data.channel.name }
+            { data.channel.description && ` · ${data.channel.description}` }
+          </p>
+          <div className={ styles.footerRow }>
+            <span className={ styles.listenerCount }>
+              { data.listener_count } listening
+            </span>
+            <span className={ styles.cta }>Tune in →</span>
+          </div>
+        </div>
+      </div>
+
+      { data.track && (
+        <div className={ styles.ringWrap }>
+          <div
+            data-testid="now-playing-progress-fill"
+            className={ styles.ring }
+            style={ { "--progress-percent": String( progressPercent ) } as CSSProperties }
+            aria-hidden="true"
+          />
+          <span className={ styles.ringTime }>
+            { formatMs( displayPositionMs ) } / { formatMs( data.track.duration_ms ) }
+          </span>
+        </div>
+      ) }
+    </a>
+  );
+```
+
+Key differences from before:
+- Added `progressPercent` calculation above `return`
+- Wrapped content in `<div className={styles.content}>` (the center column of the grid)
+- Added `<span className={styles.cardBorder}>`, `<div className={styles.vinyl}>` (decorative-only, `aria-hidden="true"`)
+- Added EQ bars `<span>` (with 4 inner `<span>`s) inside the source label
+- Removed the linear progress bar (`.progress`, `.progressTrack`, `.progressFill`)
+- Added `<div className={styles.ringWrap}>` (right column) containing the ring + single-line time text
+- Moved `data-testid="now-playing-progress-fill"` to the ring element
+- Inline `style={{"--progress-percent": String(progressPercent)}}` on the ring (drives the conic gradient in CSS)
+- Time text format `${formatMs(now)} / ${formatMs(total)}` is unchanged (preserves existing test assertions)
+
+The offline + skeleton branches stay UNCHANGED in this task — they don't have a progress bar anyway.
+
+- [ ] **Step 5: Add placeholder rules for new SCSS classes**
+
+In `src/components/NowPlaying/NowPlayingCard.module.scss`, ADD these empty rules (don't remove existing ones — Task 2 rewrites the whole file):
+
+```scss
+.cardBorder {}
+.vinyl {}
+.content {}
+.eq {}
+.ringWrap {}
+.ring {}
+.ringTime {}
+```
+
+Without these placeholders, the `styles.cardBorder`, `styles.vinyl`, etc. references resolve to `undefined` at runtime — harmless for tests but causes lint complaints in some setups. Better to declare them up front.
+
+- [ ] **Step 6: Run tests — all 28 should pass**
+
+Run: `yarn test src/__tests__/components/NowPlayingCard.test.tsx`
+Expected: PASS — 28/28 tests green.
+
+If any test fails, the most likely cause is text content matching. The time format test assertions like `"1:35 / 3:35"` rely on the time being one continuous text node. The new JSX uses `<span className={styles.ringTime}>{formatMs(...)} / {formatMs(...)}</span>` which renders as one text node. If JSX whitespace handling produces something different, fix the spaces in the template.
+
+- [ ] **Step 7: Run lint + typecheck + full suite**
+
+Run: `yarn lint && yarn typecheck && yarn test`
+Expected: PASS, no regressions.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/NowPlaying/NowPlayingCard.tsx src/components/NowPlaying/NowPlayingCard.module.scss src/__tests__/components/NowPlayingCard.test.tsx
+git commit -m "refactor: NowPlayingCard JSX adds vinyl/ring/EQ/border decorations"
+```
+
+---
+
+### Task 2: Full SCSS rewrite — hybrid visual treatment
+
+**Files:**
+- Modify: `src/components/NowPlaying/NowPlayingCard.module.scss` (full rewrite)
+
+Replace the entire SCSS module with the hybrid styling: spinning vinyl, conic ring, EQ bars, aurora gradient drift, animated gradient border, film grain overlay, gradient title text, neon cyan accents, light-mode override, mobile breakpoint, reduced-motion override.
+
+- [ ] **Step 1: Replace the entire SCSS file**
+
+Replace the ENTIRE contents of `src/components/NowPlaying/NowPlayingCard.module.scss` with:
+
+```scss
+.card {
+  --bg-deep: #0a0618;
+  --neon-cyan: #38bdf8;
+  --neon-violet: #a855f7;
+  --neon-magenta: #ec4899;
+  --text-warm: #f5f3ff;
+
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  grid-template-columns: 110px 1fr 110px;
+  gap: 1.4rem;
+  align-items: center;
+  width: 100%;
+  max-width: 64rem;
+  margin: 0 auto 4rem;
+  padding: 1.6rem 1.85rem;
+  border-radius: 18px;
+  color: var(--text-warm);
+  text-decoration: none;
+  overflow: hidden;
+  background:
+    radial-gradient(ellipse at 15% 30%, rgba(168, 85, 247, 0.55), transparent 55%),
+    radial-gradient(ellipse at 85% 75%, rgba(56, 189, 248, 0.5), transparent 55%),
+    radial-gradient(ellipse at 60% 25%, rgba(236, 72, 153, 0.4), transparent 55%),
+    var(--bg-deep);
+  background-size: 200% 200%;
+  animation: aurora 14s ease-in-out infinite alternate;
+  box-shadow:
+    0 20px 60px rgba(168, 85, 247, 0.25),
+    0 0 80px rgba(56, 189, 248, 0.1);
+  transition: box-shadow 0.25s ease, transform 0.25s ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow:
+      0 28px 80px rgba(168, 85, 247, 0.35),
+      0 0 100px rgba(56, 189, 248, 0.2);
+  }
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    border-radius: inherit;
+    background:
+      url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E"),
+      linear-gradient(180deg, rgba(10, 6, 24, 0.4), rgba(10, 6, 24, 0.55));
+    pointer-events: none;
+  }
+}
+
+@keyframes aurora {
+  0%   { background-position: 0% 0%, 100% 100%, 50% 50%, 0 0; }
+  100% { background-position: 60% 40%, 30% 70%, 80% 30%, 0 0; }
+}
+
+.cardBorder {
+  position: absolute;
+  inset: 0;
+  border-radius: 18px;
+  padding: 1px;
+  background: linear-gradient(120deg, var(--neon-cyan), var(--neon-violet), var(--neon-magenta), var(--neon-cyan));
+  background-size: 300% 100%;
+  animation: borderShift 8s linear infinite;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  z-index: 0;
+}
+
+@keyframes borderShift {
+  to { background-position: 300% 0%; }
+}
+
+.vinyl {
+  width: 110px;
+  height: 110px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%,
+    var(--neon-magenta) 0 8%,
+    #1a1a1a 9% 12%,
+    #2a2a2a 12% 14%,
+    #1a1a1a 14% 50%,
+    #2a2a2a 50% 53%,
+    #1a1a1a 53% 100%);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 8px 24px rgba(0, 0, 0, 0.6),
+    0 0 24px rgba(168, 85, 247, 0.4);
+  animation: vinylSpin 9s linear infinite;
+  position: relative;
+}
+
+.vinyl::after {
+  content: "";
+  position: absolute;
+  inset: 47%;
+  background: var(--bg-deep);
+  border-radius: 50%;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.6);
+}
+
+@keyframes vinylSpin {
+  to { transform: rotate(360deg); }
+}
+
+.content {
+  min-width: 0;
+}
+
+.sourceLabel {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0 0 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--neon-cyan);
+  text-shadow: 0 0 12px rgba(56, 189, 248, 0.5);
+}
+
+.eq {
+  display: inline-flex;
+  align-items: end;
+  gap: 3px;
+  height: 14px;
+}
+
+.eq span {
+  width: 3px;
+  background: var(--neon-cyan);
+  border-radius: 1px;
+  box-shadow: 0 0 6px rgba(56, 189, 248, 0.7);
+  animation: eq 0.85s ease-in-out infinite;
+}
+.eq span:nth-child(1) { animation-delay: 0s; }
+.eq span:nth-child(2) { animation-delay: 0.15s; }
+.eq span:nth-child(3) { animation-delay: 0.3s; }
+.eq span:nth-child(4) { animation-delay: 0.45s; }
+
+@keyframes eq {
+  0%, 100% { height: 25%; }
+  50%      { height: 100%; }
+}
+
+.trackTitle {
+  margin: 0 0 0.3rem;
+  font-size: 1.7rem;
+  font-weight: 700;
+  line-height: 1.15;
+  background: linear-gradient(90deg, var(--text-warm), #e9d5ff);
+  -webkit-background-clip: text;
+          background-clip: text;
+  -webkit-text-fill-color: transparent;
+          color: transparent;
+}
+
+.artist {
+  margin: 0 0 0.95rem;
+  font-size: 0.95rem;
+  opacity: 0.75;
+}
+
+.noMetadata {
+  margin: 0.6rem 0 0;
+  font-style: italic;
+  opacity: 0.6;
+}
+
+.upNext {
+  margin: 0 0 0.95rem;
+  font-size: 0.85rem;
+  font-style: italic;
+  opacity: 0.7;
+}
+
+.footer {
+  margin-top: 0.6rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.channelInfo {
+  margin: 0;
+  font-size: 0.78rem;
+  opacity: 0.55;
+}
+
+.footerRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 0.4rem;
+  font-size: 0.88rem;
+}
+
+.listenerCount {
+  opacity: 0.7;
+}
+
+.cta {
+  color: var(--neon-cyan);
+  font-weight: 600;
+  text-shadow: 0 0 10px rgba(56, 189, 248, 0.5);
+}
+
+.ringWrap {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 110px;
+  height: 110px;
+}
+
+.ring {
+  --progress-percent: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--neon-cyan) 0,
+    var(--neon-violet) calc(var(--progress-percent) * 1%),
+    rgba(255, 255, 255, 0.08) calc(var(--progress-percent) * 1%),
+    rgba(255, 255, 255, 0.08) 100%
+  );
+  box-shadow: 0 0 24px rgba(56, 189, 248, 0.3);
+  position: relative;
+  transition: background 0.4s linear;
+}
+
+.ring::before {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 30%, rgba(168, 85, 247, 0.2), transparent 60%),
+    var(--bg-deep);
+}
+
+.ringTime {
+  position: absolute;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 0.78rem;
+  color: var(--neon-cyan);
+  text-shadow: 0 0 8px rgba(56, 189, 248, 0.4);
+  white-space: nowrap;
+}
+
+/* ===== Skeleton ===== */
+.skeleton {
+  position: relative;
+  width: 100%;
+  max-width: 64rem;
+  min-height: 12rem;
+  margin: 0 auto 4rem;
+  padding: 1.6rem 1.85rem;
+  border-radius: 18px;
+  background: linear-gradient(135deg,
+    rgba(168, 85, 247, 0.12),
+    rgba(56, 189, 248, 0.08));
+  border: 1px solid rgba(168, 85, 247, 0.15);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.25);
+  animation: skeletonPulse 1.6s ease-in-out infinite;
+  pointer-events: none;
+  cursor: default;
+}
+
+@keyframes skeletonPulse {
+  0%, 100% { opacity: 0.6; }
+  50%      { opacity: 0.9; }
+}
+
+/* ===== Offline ===== */
+.offline {
+  position: relative;
+  display: block;
+  width: 100%;
+  max-width: 64rem;
+  margin: 0 auto 4rem;
+  padding: 1.6rem 1.85rem;
+  border-radius: 18px;
+  color: rgba(245, 243, 255, 0.85);
+  text-decoration: none;
+  background:
+    linear-gradient(180deg, rgba(40, 40, 55, 0.8), rgba(20, 20, 30, 0.9));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.3);
+  transition: border-color 0.2s ease, transform 0.2s ease;
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.16);
+    transform: translateY(-1px);
+  }
+}
+
+.offlineCta {
+  margin: 0.6rem 0 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  opacity: 0.75;
+}
+
+/* ===== Mobile / narrow widths ===== */
+@media (max-width: 720px) {
+  .card {
+    grid-template-columns: 80px 1fr;
+    grid-template-areas:
+      "vinyl content"
+      "ring  ring";
+    gap: 1rem;
+    padding: 1.25rem 1.4rem;
+  }
+  .vinyl {
+    grid-area: vinyl;
+    width: 80px;
+    height: 80px;
+  }
+  .content {
+    grid-area: content;
+  }
+  .ringWrap {
+    grid-area: ring;
+    justify-self: center;
+    margin-top: 0.6rem;
+    width: 90px;
+    height: 90px;
+  }
+  .trackTitle {
+    font-size: 1.4rem;
+  }
+}
+
+/* ===== Light mode tweaks ===== */
+@media (prefers-color-scheme: light) {
+  .card {
+    --bg-deep: #1a1530;
+    box-shadow:
+      0 14px 40px rgba(168, 85, 247, 0.2),
+      0 0 60px rgba(56, 189, 248, 0.08);
+  }
+  .skeleton {
+    background: linear-gradient(135deg,
+      rgba(168, 85, 247, 0.1),
+      rgba(56, 189, 248, 0.06));
+  }
+}
+
+/* ===== Reduced motion ===== */
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  .vinyl,
+  .cardBorder,
+  .eq span,
+  .skeleton,
+  .ring {
+    animation: none;
+  }
+  .card,
+  .offline {
+    transition: none;
+  }
+  .card:hover,
+  .offline:hover {
+    transform: none;
+  }
+}
+```
+
+- [ ] **Step 2: Run lint + typecheck**
+
+Run: `yarn lint && yarn typecheck`
+Expected: PASS — pure SCSS additions, no TypeScript impact.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `yarn test`
+Expected: PASS — tests assert on text content + DOM structure + behavior; styling is invisible to them.
+
+- [ ] **Step 4: Run the production build**
+
+Run: `yarn build`
+Expected: PASS — SCSS compiles via the existing pipeline.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/NowPlaying/NowPlayingCard.module.scss
+git commit -m "feat: hybrid visual treatment for NowPlayingCard (vinyl + ring + aurora + grain)"
+```
+
+---
+
+### Task 3: Final verification + PR
+
+**Files:**
+- (No file changes — verification + PR creation only.)
+
+- [ ] **Step 1: Run all checks one more time**
+
+Run: `yarn typecheck && yarn lint && yarn test && yarn build`
+Expected: PASS — all green.
+
+If `yarn build` fails or produces unexpected output, investigate before opening the PR.
+
+- [ ] **Step 2: Verify the skeleton still renders in dist/index.html**
+
+```bash
+node -e "
+const fs = require('fs');
+const html = fs.readFileSync('dist/index.html', 'utf8');
+console.log('skeleton present:', /now-playing-skeleton/.test(html));
+console.log('category section present:', /category-music/.test(html));
+"
+```
+
+Expected: Both `true`. The widget's skeleton renders SSR; the live card materializes after hydration.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin polish-now-playing-card
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --title "feat: visual polish for NowPlayingCard (vinyl + ring + aurora)" --body "$(cat <<'EOF'
+## Summary
+
+Visual rework of \`NowPlayingCard\` combining four design directions into one richly layered hero card. Behavior is identical to PR #93 — only styling and a few decorative DOM nodes change.
+
+### What's combined
+- **Spinning vinyl disc** on the left (slow 9s rotation; magenta center label)
+- **Conic-gradient progress ring** on the right (replaces the linear bar; cyan→violet fill)
+- **Animated equalizer bars** next to the "● Live now" label (4 bars with staggered keyframes)
+- **Aurora gradient drift** behind everything (14s slow color shift across magenta/violet/cyan radial gradients)
+- **Animated gradient border** running cyan→violet→magenta around the card edge (8s linear loop)
+- **Film grain overlay** (SVG noise) for texture
+- **Gradient title text** (white→soft violet)
+- **Neon cyan accents** on source label + Tune in CTA (with text-shadow glow)
+
+### Accessibility
+- All decorative DOM has \`aria-hidden="true"\`
+- \`@media (prefers-reduced-motion: reduce)\` disables all animations and hover transforms
+- \`@media (prefers-color-scheme: light)\` tweaks the base color
+- Mobile (<720px) collapses to two-row grid: vinyl + content on top, ring centered below
+
+### Tests
+28/28 existing NowPlayingCard tests pass. One assertion updated: the \`renders progress at 0%\` test moved from asserting \`bar.style.width === "0%"\` (linear bar, deleted) to \`ring.style.getPropertyValue("--progress-percent") === "0"\` (conic ring). Same \`data-testid="now-playing-progress-fill"\` lives on the ring.
+
+### Performance
+- 4 simultaneous CSS animations, all GPU-accelerated (transform / background-position)
+- No new JS dependencies
+- ~280 lines of SCSS added (~3KB gzipped)
+- Skeleton dimensions match live card (zero CLS contribution)
+- Zero impact on Contentful API quota (still pure client-side)
+
+## Test plan
+- [ ] Load \`/\` in browser — see the live card with spinning vinyl, progress ring, animated border, aurora drift
+- [ ] Verify track title gradient, EQ bars next to "Live now", listener count, Tune in CTA glow
+- [ ] Resize to mobile width — vinyl + content stack on top, ring drops below centered
+- [ ] DevTools → Rendering → "Emulate prefers-reduced-motion: reduce" — all animations stop, layout intact
+- [ ] DevTools → Rendering → "Emulate prefers-color-scheme: light" — card adjusts; readable
+- [ ] Stream offline state (throttle to offline, wait 30s) — card swaps to monochromatic offline placeholder
+
+Spec: \`docs/superpowers/specs/2026-04-29-now-playing-polish-design.md\`
+Plan: \`docs/superpowers/plans/2026-04-29-now-playing-polish.md\`
+EOF
+)"
+```
+
+- [ ] **Step 5: Return the PR URL**
+
+The output of `gh pr create` is the PR URL. Report it back.
+
+---
+
+## Self-review
+
+**Spec coverage** — every section of the spec maps to a task:
+
+| Spec section | Task |
+|---|---|
+| JSX additions (vinyl, EQ, ring, border span, content wrapper) | 1 |
+| `--progress-percent` CSS custom property wiring | 1 |
+| `data-testid` move from linear bar to ring | 1 |
+| Test assertion update (one test) | 1 |
+| Aurora gradient drift | 2 |
+| Animated gradient border | 2 |
+| Vinyl spin animation | 2 |
+| EQ bar animation (4 bars staggered) | 2 |
+| Conic-gradient progress ring | 2 |
+| Film grain overlay (SVG noise) | 2 |
+| Gradient title text | 2 |
+| Neon cyan accents (source label, CTA, text-shadow glows) | 2 |
+| Mobile breakpoint at 720px | 2 |
+| Light mode tweaks | 2 |
+| Reduced-motion override | 2 |
+| Skeleton + offline state styling | 2 |
+| Verification + PR | 3 |
+
+**Type consistency:**
+- `progressPercent` (Task 1, JSX) is consumed by the inline `--progress-percent` style on `.ring`, then read by `conic-gradient(... calc(var(--progress-percent) * 1%) ...)` in Task 2's SCSS. Names match.
+- `data-testid="now-playing-progress-fill"` is on the ring in both Task 1's JSX and the assertion target in Task 1's updated test. Names match.
+- All new CSS class names introduced in Task 1 (`cardBorder`, `vinyl`, `content`, `eq`, `ringWrap`, `ring`, `ringTime`) get rules in Task 2's SCSS rewrite. No orphan class names.
+
+**Placeholder scan** — no TBDs / TODOs / "implement appropriate". Every code step has the actual code an engineer can paste.
+
+**Note on intermediate state** — between Task 1's commit and Task 2's commit, the card renders with the new DOM structure but only minimal styling (the empty rules from Task 1's Step 5). The card will look broken (unstyled grid, no decoration) but tests pass and the build succeeds. Task 2's commit fixes the visuals. This is similar to the original now-playing widget plan (Tasks 2-6 used empty SCSS rules until the final styling task). Mention this in the Task 2 commit.

--- a/docs/superpowers/specs/2026-04-29-now-playing-polish-design.md
+++ b/docs/superpowers/specs/2026-04-29-now-playing-polish-design.md
@@ -1,0 +1,201 @@
+# Now-Playing Card Polish — Design Spec
+
+## Problem
+
+The `NowPlayingCard` shipped in PR #93 with utilitarian SCSS — clean, but visually flat. It reads as "blog card with a progress bar" rather than "this is the live broadcast hub of the brand." The DJ Audeos identity is musical, energetic, club-aesthetic; the home page's hero element should feel that way.
+
+## Solution
+
+A maximalist visual rework of `NowPlayingCard.module.scss` (and small JSX additions to support new visual elements). The component's behavior and data flow stay identical to what shipped in PR #93 — only the styling and a few decorative DOM nodes change. The result: a richly layered card combining elements from four design directions (glass + aurora, vinyl spinner, neon conic ring, ambient gradient + grain), with motion that respects `prefers-reduced-motion`.
+
+## Visual elements (the hybrid)
+
+The mockup confirmed in brainstorming combines all four directions into one card. Each element below maps to one of those directions:
+
+| Element | Source | Purpose |
+|---|---|---|
+| **Spinning vinyl disc** (left, ~110px) | B (Vinyl) | Distinctive music identity; primary visual anchor |
+| **Animated equalizer bars** (next to "● Live now") | B (Vinyl) | Subtle "audio is happening" cue; small audio-meter detail |
+| **Conic-gradient progress ring** (right, ~110px) | C (Neon) | Replaces linear progress bar; `1:35 / 3:35` displayed inside |
+| **Aurora radial-gradient drift** (background, animated) | A (Glass) | Slow-drifting color depth; reads as "alive" |
+| **Animated gradient border** (cyan → violet → magenta, looping) | C (Neon) | Frames the card; ties palette together |
+| **Film grain overlay** (SVG noise, fixed) | D (Ambient) | Texture; prevents flat-screen-feel |
+| **Gradient title text** (white → soft violet) | D (Ambient) | Subtle hero treatment for the track title |
+| **Glow on accent text** (source label, CTA) | C (Neon) | Reinforces the neon palette without overdoing it |
+
+Color palette:
+- `--bg-deep: #0a0618` — base canvas
+- `--neon-cyan: #38bdf8`
+- `--neon-violet: #a855f7`
+- `--neon-magenta: #ec4899`
+- `--text-warm: #f5f3ff`
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Visual scope | Hybrid combining elements from all four mockup directions | User explicitly chose "ship it" on the maximalist hybrid |
+| Layout | 3-column grid: vinyl \| content \| ring (~110px / 1fr / ~110px) | Matches the approved mockup; gives both decorative elements equal weight to the content |
+| Linear progress bar | **Replaced** by conic-gradient ring on the right | Ring is more distinctive visually; time displayed inside |
+| Reduced motion | `@media (prefers-reduced-motion: reduce)` disables vinyl spin, EQ bars, aurora drift, and border shift | Accessibility non-negotiable; static fallback still shows vinyl + ring + gradient at rest |
+| Mobile/narrow | Below ~720px viewport, vinyl moves to top-left, ring stays right but smaller (~80px) | Three-column layout doesn't survive narrow widths |
+| Stream offline state | Same maximalist treatment but desaturated / monochromatic, vinyl static, ring at 0% | Visual continuity; reads as "the same card, but quiet" |
+| Skeleton state | Pulsing gradient placeholder matching card dimensions | Prevents layout shift; reads as "loading" not "broken" |
+| Test impact | Existing tests assert content + behavior, not styling | No test changes needed; existing data-testids (`now-playing-skeleton`, `now-playing-progress-fill`, `now-playing-channel-info`) all preserved |
+
+## Architecture
+
+### Files
+
+**Modified:**
+- `src/components/NowPlaying/NowPlayingCard.tsx` — adds decorative DOM (vinyl div, EQ-bar spans, conic-ring wrapper). Wires `--progress-percent` CSS custom property to drive the ring fill from React state.
+- `src/components/NowPlaying/NowPlayingCard.module.scss` — full rewrite implementing the hybrid visual treatment.
+
+**No new files. No new dependencies.**
+
+### JSX additions
+
+The component currently renders (skeleton / live / offline). The live render adds three new visual surfaces:
+
+```tsx
+<a className={styles.card}>
+  {/* NEW: animated gradient border (positioned absolute, mask-composite) */}
+  <span className={styles.cardBorder} aria-hidden="true" />
+
+  {/* NEW: vinyl disc (left column of grid) */}
+  <div className={styles.vinyl} aria-hidden="true" />
+
+  {/* Center column — content (existing JSX, plus EQ bars next to source label) */}
+  <div className={styles.content}>
+    <p className={styles.sourceLabel}>
+      {SOURCE_LABEL[data.source]}
+      {/* NEW: equalizer bars */}
+      <span className={styles.eq} aria-hidden="true">
+        <span /><span /><span /><span />
+      </span>
+    </p>
+    <h2 className={styles.trackTitle}>...</h2>
+    <p className={styles.artist}>...</p>
+    {/* OMITTED: linear progress bar — replaced by ring on the right */}
+    <p className={styles.upNext}>...</p>
+    <div className={styles.footer}>...</div>
+  </div>
+
+  {/* NEW: conic ring (right column of grid) */}
+  <div
+    className={styles.ringWrap}
+    style={{ "--progress-percent": `${progressPercent}` } as CSSProperties}
+  >
+    <div className={styles.ring} aria-hidden="true" />
+    <div className={styles.ringText}>
+      <span className={styles.ringNow}>{formatMs(displayPositionMs)}</span>
+      <span className={styles.ringTotal}>{formatMs(data.track.duration_ms)}</span>
+    </div>
+  </div>
+</a>
+```
+
+The `--progress-percent` CSS custom property bridges React state to the conic gradient. Computed in the component:
+
+```tsx
+const progressPercent = data.track.duration_ms > 0
+  ? Math.min(100, (displayPositionMs / data.track.duration_ms) * 100)
+  : 0;
+```
+
+The existing `data-testid="now-playing-progress-fill"` element is preserved on the conic ring (rather than the deleted linear bar) so the test from PR #93 — `bar.style.width === "0%"` — still works. The ring's CSS uses `--progress-percent` so we set `style.width = "0%"` as a no-op equivalent OR change the test assertion target. The simplest path: keep the ring's `data-testid` and assert on a different attribute (e.g., the inline `--progress-percent` value).
+
+**Test impact:** the existing test `renders progress bar at 0% when duration_ms is 0` (in `NowPlayingCard.test.tsx`) currently asserts `bar.style.width === "0%"`. Since the linear bar is gone, this test must be updated to assert `bar.style.getPropertyValue("--progress-percent") === "0"` against the ring element. Same `data-testid="now-playing-progress-fill"` lives on the ring's `<div>`. Behavior preserved; assertion target shifts.
+
+### CSS architecture
+
+The SCSS module is rewritten end-to-end. Major sections:
+
+1. **Card layout** (grid: 110px 1fr 110px; gap 1.4rem; padding 1.6rem 1.85rem; border-radius 18px)
+2. **Layered backgrounds** (three pseudo-elements / z-index'd children for aurora, grain, border)
+3. **Vinyl** (radial-gradient disc, 9s linear `vinyl-spin` animation, magenta center label dot)
+4. **Source label + EQ bars** (flexbox; 4 spans with staggered keyframe animation)
+5. **Title** (gradient text-fill via `background-clip: text`)
+6. **Conic ring** (`conic-gradient(var(--neon-cyan) 0, var(--neon-violet) calc(var(--progress-percent) * 1%), rgba(255,255,255,0.08) 0)`; 6px inner mask via `::before`)
+7. **Footer & CTA** (existing, with neon-cyan glow on the CTA)
+8. **Offline + skeleton states** (desaturated palette, no animations)
+9. **Mobile/narrow rules** (single column at <720px, ring shrinks)
+10. **Reduced motion** (disables vinyl-spin, eq, aurora, border-shift, transitions)
+
+The layered backgrounds use CSS-modules-style class names (`.aurora`, `.grain`, `.cardBorder`) on dedicated child elements, NOT pseudo-elements on the card itself. This is because:
+- The card needs `overflow: hidden` to clip the layers, which would clip the gradient border (positioned outside the content edge).
+- Pseudo-elements on `<a>` interact poorly with `mask-composite` for the border-shift trick.
+
+So the component renders ~3 dedicated decorative `<span aria-hidden="true">`s for the visual layers. Light DOM cost; clean separation of concerns.
+
+### Animation specifics
+
+| Animation | Duration | Easing | Loop | Disabled by reduced-motion |
+|---|---|---|---|---|
+| Vinyl spin | 9s | linear | infinite | Yes |
+| EQ bars | 0.85s (staggered 0.15s per bar) | ease-in-out | infinite | Yes |
+| Aurora drift | 14s | ease-in-out alternate | infinite | Yes |
+| Border shift | 8s | linear | infinite | Yes |
+| Progress ring fill | 0.4s | linear | one-shot per state change | Yes (instant transition) |
+| Hover lift | 0.2s | ease | one-shot | Yes (no transform) |
+
+Total: 4 simultaneous CSS animations always running on the live state. All are GPU-accelerated (`transform`, `opacity`, `background-position`). No layout-triggering properties.
+
+## Mobile / responsive
+
+At viewports below 720px, the 3-column grid collapses:
+
+```scss
+@media (max-width: 720px) {
+  .card {
+    grid-template-columns: 80px 1fr;
+    grid-template-areas:
+      "vinyl content"
+      "ring   ring";
+    gap: 1rem;
+  }
+  .vinyl    { grid-area: vinyl; width: 80px; height: 80px; }
+  .content  { grid-area: content; }
+  .ringWrap { grid-area: ring; justify-self: center; margin-top: 0.5rem; }
+  .ring     { width: 80px; height: 80px; }
+}
+```
+
+The ring takes a row of its own at the bottom on mobile rather than being squeezed alongside the content.
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| `duration_ms === 0` | Ring renders fully empty (gradient stops both at 0%); time displays `0:00 / 0:00` |
+| `track === null` | Renders "No metadata available." in place of title/artist; ring is not rendered (no progress to show); vinyl still spins (or is static under reduced motion) |
+| `next_track === null` | Up-next line omitted; everything else unchanged |
+| `channel.description === null` | Footer renders only `channel.name` |
+| Stream offline | Vinyl visible but static; ring at 0%; aurora/border desaturated to grays; text + accents drop their cyan/violet glow |
+| Reduced motion | All animations disabled; vinyl frozen at neutral angle; aurora frozen mid-position; border static gradient; no hover transform |
+| Mobile (<720px) | Ring moves below content; vinyl shrinks to 80px |
+
+## Testing
+
+No new tests. Existing `NowPlayingCard.test.tsx` (28 tests) all continue to pass with one minor adjustment:
+
+- **`renders progress bar at 0% when duration_ms is 0`** — currently asserts `bar.style.width === "0%"`. Update to assert `bar.style.getPropertyValue("--progress-percent") === "0"`. The `data-testid="now-playing-progress-fill"` element moves from the deleted linear-bar to the conic ring's container. One-line change in the test, no behavior change.
+
+All other tests assert on text content, presence/absence of elements, ARIA attributes, or polling behavior — none of which are affected by the visual rework.
+
+## SEO / performance impact
+
+- **No SSR data change.** The skeleton placeholder still renders on the server; client hydration starts polling. No new build-time API calls.
+- **Animation CPU cost.** 4 simultaneous CSS animations, all GPU-accelerated. Modern browsers handle this in compositor with no main-thread cost. On the home page only (one card per page), no perf concern.
+- **Bundle size.** Pure SCSS additions (~280 lines, gzipped ~3KB). No JS dependencies. Negligible.
+- **LCP.** The card's skeleton renders server-side; live data hydrates client-side. The hero is still the first card image of the first category section (unchanged). Skeleton dimensions match live card → zero CLS contribution.
+- **Reduced-motion users** see a clean static version, no degradation in legibility or hierarchy.
+
+## Out of scope
+
+- Audio visualization driven by real audio data (the EQ bars are decorative; not connected to anything).
+- Album-art-extracted color theming (no album art in the API response).
+- Audio playback embedded in the card (tap goes to `play.audeos.com`).
+- Different visual treatments per `source` value (live / scheduled / loop_fallback all use the same hybrid).
+- Animating the conic ring fill with smooth transitions on poll updates (the existing 0.4s linear transition is sufficient; smooth-tracking via `@property` registration is a future enhancement).
+- Bringing back the linear progress bar as a fallback. Decision is to commit fully to the ring.

--- a/src/__tests__/components/NowPlayingCard.test.tsx
+++ b/src/__tests__/components/NowPlayingCard.test.tsx
@@ -341,13 +341,13 @@ describe( "NowPlayingCard", () => {
     }
   });
 
-  it( "renders progress bar at 0% when duration_ms is 0", async () => {
+  it( "renders progress ring at 0% when duration_ms is 0", async () => {
     mockFetchOnce({
       ...livePayload,
       track: { ...livePayload.track, position_ms: 0, duration_ms: 0 },
     });
     render( <NowPlayingCard /> );
-    const bar = await screen.findByTestId( "now-playing-progress-fill" );
-    expect( bar.style.width ).toBe( "0%" );
+    const ring = await screen.findByTestId( "now-playing-progress-fill" );
+    expect( ring.style.getPropertyValue( "--progress-percent" ) ).toBe( "0" );
   });
 });

--- a/src/__tests__/components/NowPlayingCard.test.tsx
+++ b/src/__tests__/components/NowPlayingCard.test.tsx
@@ -341,13 +341,13 @@ describe( "NowPlayingCard", () => {
     }
   });
 
-  it( "renders progress ring at 0% when duration_ms is 0", async () => {
+  it( "renders progress bar at 0% when duration_ms is 0", async () => {
     mockFetchOnce({
       ...livePayload,
       track: { ...livePayload.track, position_ms: 0, duration_ms: 0 },
     });
     render( <NowPlayingCard /> );
-    const ring = await screen.findByTestId( "now-playing-progress-fill" );
-    expect( ring.style.getPropertyValue( "--progress-percent" ) ).toBe( "0" );
+    const bar = await screen.findByTestId( "now-playing-progress-fill" );
+    expect( bar.style.width ).toBe( "0%" );
   });
 });

--- a/src/components/NowPlaying/NowPlayingCard.module.scss
+++ b/src/components/NowPlaying/NowPlayingCard.module.scss
@@ -8,7 +8,7 @@
   position: relative;
   isolation: isolate;
   display: grid;
-  grid-template-columns: 110px 1fr 110px;
+  grid-template-columns: 110px 1fr;
   gap: 1.4rem;
   align-items: center;
   width: 100%;
@@ -19,61 +19,50 @@
   color: var(--text-warm);
   text-decoration: none;
   overflow: hidden;
-  background:
-    radial-gradient(ellipse at 15% 30%, rgba(168, 85, 247, 0.55), transparent 55%),
-    radial-gradient(ellipse at 85% 75%, rgba(56, 189, 248, 0.5), transparent 55%),
-    radial-gradient(ellipse at 60% 25%, rgba(236, 72, 153, 0.4), transparent 55%),
-    var(--bg-deep);
-  background-size: 200% 200%;
-  animation: aurora 14s ease-in-out infinite alternate;
+  background: var(--bg-deep);
   box-shadow:
-    0 20px 60px rgba(168, 85, 247, 0.25),
-    0 0 80px rgba(56, 189, 248, 0.1);
-  transition: box-shadow 0.25s ease, transform 0.25s ease;
+    0 18px 48px rgba(10, 6, 24, 0.4),
+    0 4px 16px rgba(0, 0, 0, 0.3);
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
 
   &:hover {
     transform: translateY(-2px);
     box-shadow:
-      0 28px 80px rgba(168, 85, 247, 0.35),
-      0 0 100px rgba(56, 189, 248, 0.2);
+      0 24px 64px rgba(10, 6, 24, 0.5),
+      0 8px 24px rgba(0, 0, 0, 0.4);
   }
 
+  /* Aurora drift — soft radial gradients animating slowly behind the glass */
   &::before {
+    content: "";
+    position: absolute;
+    inset: -25%;
+    z-index: -2;
+    background:
+      radial-gradient(ellipse at 15% 30%, rgba(168, 85, 247, 0.5), transparent 60%),
+      radial-gradient(ellipse at 85% 75%, rgba(56, 189, 248, 0.45), transparent 60%),
+      radial-gradient(ellipse at 60% 25%, rgba(236, 72, 153, 0.35), transparent 60%);
+    background-size: 180% 180%;
+    animation: aurora 22s ease-in-out infinite alternate;
+    pointer-events: none;
+  }
+
+  /* Frosted glass — blurs the aurora behind for that dreamy depth */
+  &::after {
     content: "";
     position: absolute;
     inset: 0;
     z-index: -1;
-    border-radius: inherit;
-    background:
-      url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, rgba(10, 6, 24, 0.4), rgba(10, 6, 24, 0.55));
+    background: rgba(15, 10, 35, 0.35);
+    backdrop-filter: blur(28px) saturate(140%);
+    -webkit-backdrop-filter: blur(28px) saturate(140%);
     pointer-events: none;
   }
 }
 
 @keyframes aurora {
-  0%   { background-position: 0% 0%, 100% 100%, 50% 50%, 0 0; }
-  100% { background-position: 60% 40%, 30% 70%, 80% 30%, 0 0; }
-}
-
-.cardBorder {
-  position: absolute;
-  inset: 0;
-  border-radius: 18px;
-  padding: 1px;
-  background: linear-gradient(120deg, var(--neon-cyan), var(--neon-violet), var(--neon-magenta), var(--neon-cyan));
-  background-size: 300% 100%;
-  animation: borderShift 8s linear infinite;
-  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  pointer-events: none;
-  z-index: 0;
-}
-
-@keyframes borderShift {
-  to { background-position: 300% 0%; }
+  0%   { background-position: 0% 0%, 100% 100%, 50% 50%; }
+  100% { background-position: 70% 30%, 30% 70%, 80% 20%; }
 }
 
 .vinyl {
@@ -89,8 +78,7 @@
     #1a1a1a 53% 100%);
   box-shadow:
     inset 0 0 0 1px rgba(255, 255, 255, 0.08),
-    0 8px 24px rgba(0, 0, 0, 0.6),
-    0 0 24px rgba(168, 85, 247, 0.4);
+    0 8px 24px rgba(0, 0, 0, 0.5);
   animation: vinylSpin 9s linear infinite;
   position: relative;
 }
@@ -122,7 +110,7 @@
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--neon-cyan);
-  text-shadow: 0 0 12px rgba(56, 189, 248, 0.5);
+  opacity: 0.9;
 }
 
 .eq {
@@ -136,7 +124,7 @@
   width: 3px;
   background: var(--neon-cyan);
   border-radius: 1px;
-  box-shadow: 0 0 6px rgba(56, 189, 248, 0.7);
+  opacity: 0.85;
   animation: eq 0.85s ease-in-out infinite;
 }
 .eq span:nth-child(1) { animation-delay: 0s; }
@@ -147,6 +135,10 @@
 @keyframes eq {
   0%, 100% { height: 25%; }
   50%      { height: 100%; }
+}
+
+.trackInfo {
+  margin: 0;
 }
 
 .trackTitle {
@@ -162,7 +154,7 @@
 }
 
 .artist {
-  margin: 0 0 0.95rem;
+  margin: 0 0 0.85rem;
   font-size: 0.95rem;
   opacity: 0.75;
 }
@@ -171,6 +163,35 @@
   margin: 0.6rem 0 0;
   font-style: italic;
   opacity: 0.6;
+}
+
+.progress {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin: 0 0 0.95rem;
+}
+
+.progressTrack {
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.14);
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--neon-cyan), var(--neon-violet));
+  border-radius: inherit;
+  transition: width 0.4s linear;
+}
+
+.progressTime {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 0.78rem;
+  opacity: 0.7;
+  white-space: nowrap;
 }
 
 .upNext {
@@ -207,50 +228,7 @@
 .cta {
   color: var(--neon-cyan);
   font-weight: 600;
-  text-shadow: 0 0 10px rgba(56, 189, 248, 0.5);
-}
-
-.ringWrap {
-  position: relative;
-  display: grid;
-  place-items: center;
-  width: 110px;
-  height: 110px;
-}
-
-.ring {
-  --progress-percent: 0;
-  width: 100%;
-  height: 100%;
-  border-radius: 50%;
-  background: conic-gradient(
-    var(--neon-cyan) 0,
-    var(--neon-violet) calc(var(--progress-percent) * 1%),
-    rgba(255, 255, 255, 0.08) calc(var(--progress-percent) * 1%),
-    rgba(255, 255, 255, 0.08) 100%
-  );
-  box-shadow: 0 0 24px rgba(56, 189, 248, 0.3);
-  position: relative;
-  transition: background 0.4s linear;
-}
-
-.ring::before {
-  content: "";
-  position: absolute;
-  inset: 6px;
-  border-radius: 50%;
-  background:
-    radial-gradient(circle at 50% 30%, rgba(168, 85, 247, 0.2), transparent 60%),
-    var(--bg-deep);
-}
-
-.ringTime {
-  position: absolute;
-  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
-  font-size: 0.78rem;
-  color: var(--neon-cyan);
-  text-shadow: 0 0 8px rgba(56, 189, 248, 0.4);
-  white-space: nowrap;
+  opacity: 0.95;
 }
 
 /* ===== Skeleton ===== */
@@ -263,9 +241,9 @@
   padding: 1.6rem 1.85rem;
   border-radius: 18px;
   background: linear-gradient(135deg,
-    rgba(168, 85, 247, 0.12),
-    rgba(56, 189, 248, 0.08));
-  border: 1px solid rgba(168, 85, 247, 0.15);
+    rgba(168, 85, 247, 0.1),
+    rgba(56, 189, 248, 0.06));
+  border: 1px solid rgba(168, 85, 247, 0.12);
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.25);
   animation: skeletonPulse 1.6s ease-in-out infinite;
   pointer-events: none;
@@ -288,8 +266,7 @@
   border-radius: 18px;
   color: rgba(245, 243, 255, 0.85);
   text-decoration: none;
-  background:
-    linear-gradient(180deg, rgba(40, 40, 55, 0.8), rgba(20, 20, 30, 0.9));
+  background: linear-gradient(180deg, rgba(40, 40, 55, 0.8), rgba(20, 20, 30, 0.9));
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.3);
   transition: border-color 0.2s ease, transform 0.2s ease;
@@ -311,26 +288,12 @@
 @media (max-width: 720px) {
   .card {
     grid-template-columns: 80px 1fr;
-    grid-template-areas:
-      "vinyl content"
-      "ring  ring";
     gap: 1rem;
     padding: 1.25rem 1.4rem;
   }
   .vinyl {
-    grid-area: vinyl;
     width: 80px;
     height: 80px;
-  }
-  .content {
-    grid-area: content;
-  }
-  .ringWrap {
-    grid-area: ring;
-    justify-self: center;
-    margin-top: 0.6rem;
-    width: 90px;
-    height: 90px;
   }
   .trackTitle {
     font-size: 1.4rem;
@@ -341,14 +304,11 @@
 @media (prefers-color-scheme: light) {
   .card {
     --bg-deep: #1a1530;
-    box-shadow:
-      0 14px 40px rgba(168, 85, 247, 0.2),
-      0 0 60px rgba(56, 189, 248, 0.08);
   }
   .skeleton {
     background: linear-gradient(135deg,
-      rgba(168, 85, 247, 0.1),
-      rgba(56, 189, 248, 0.06));
+      rgba(168, 85, 247, 0.08),
+      rgba(56, 189, 248, 0.05));
   }
 }
 
@@ -356,14 +316,16 @@
 @media (prefers-reduced-motion: reduce) {
   .card,
   .vinyl,
-  .cardBorder,
   .eq span,
-  .skeleton,
-  .ring {
+  .skeleton {
+    animation: none;
+  }
+  .card::before {
     animation: none;
   }
   .card,
-  .offline {
+  .offline,
+  .progressFill {
     transition: none;
   }
   .card:hover,

--- a/src/components/NowPlaying/NowPlayingCard.module.scss
+++ b/src/components/NowPlaying/NowPlayingCard.module.scss
@@ -29,19 +29,19 @@
       0 8px 24px rgba(0, 0, 0, 0.4);
   }
 
-  /* Aurora drift — soft radial gradients animating slowly behind the glass */
+  /* Aurora drift — bold radial blobs that translate + rotate slowly behind the glass */
   &::before {
     content: "";
     position: absolute;
-    inset: -25%;
+    inset: -50%;
     z-index: -2;
     background:
-      radial-gradient(ellipse at 15% 30%, rgba(168, 85, 247, 0.5), transparent 60%),
-      radial-gradient(ellipse at 85% 75%, rgba(56, 189, 248, 0.45), transparent 60%),
-      radial-gradient(ellipse at 60% 25%, rgba(236, 72, 153, 0.35), transparent 60%);
-    background-size: 180% 180%;
-    animation: aurora 22s ease-in-out infinite alternate;
+      radial-gradient(circle at 25% 30%, rgba(168, 85, 247, 0.7), transparent 45%),
+      radial-gradient(circle at 75% 70%, rgba(56, 189, 248, 0.65), transparent 45%),
+      radial-gradient(circle at 55% 20%, rgba(236, 72, 153, 0.55), transparent 45%);
+    animation: aurora 18s ease-in-out infinite alternate;
     pointer-events: none;
+    will-change: transform;
   }
 
   /* Frosted glass — blurs the aurora behind for that dreamy depth */
@@ -50,16 +50,17 @@
     position: absolute;
     inset: 0;
     z-index: -1;
-    background: rgba(15, 10, 35, 0.35);
-    backdrop-filter: blur(28px) saturate(140%);
-    -webkit-backdrop-filter: blur(28px) saturate(140%);
+    background: rgba(15, 10, 35, 0.25);
+    backdrop-filter: blur(18px) saturate(160%);
+    -webkit-backdrop-filter: blur(18px) saturate(160%);
     pointer-events: none;
   }
 }
 
 @keyframes aurora {
-  0%   { background-position: 0% 0%, 100% 100%, 50% 50%; }
-  100% { background-position: 70% 30%, 30% 70%, 80% 20%; }
+  0%   { transform: translate(0%, 0%) rotate(0deg); }
+  50%  { transform: translate(-8%, 6%) rotate(20deg); }
+  100% { transform: translate(8%, -6%) rotate(-20deg); }
 }
 
 .content {

--- a/src/components/NowPlaying/NowPlayingCard.module.scss
+++ b/src/components/NowPlaying/NowPlayingCard.module.scss
@@ -29,40 +29,48 @@
       0 8px 24px rgba(0, 0, 0, 0.4);
   }
 
-  /* Aurora drift — bold radial blobs that translate + rotate slowly behind the glass.
-     Inset is -100% (i.e. 3x card size) so even at full rotation the rotated rectangle
-     still covers the visible card area — no corner-cropping artifacts. */
+  /* Aurora drift — a rotating conic-gradient with a heavy blur produces an
+     unmistakable, continuously-moving color wash. Pivot is the layer's
+     center; inset is square-ish so the rotated layer always covers the card. */
   &::before {
     content: "";
     position: absolute;
-    inset: -100%;
+    top: 50%;
+    left: 50%;
+    width: 200%;
+    aspect-ratio: 1;
+    transform: translate(-50%, -50%);
     z-index: -2;
-    background:
-      radial-gradient(circle at 25% 30%, rgba(168, 85, 247, 0.7), transparent 35%),
-      radial-gradient(circle at 75% 70%, rgba(56, 189, 248, 0.65), transparent 35%),
-      radial-gradient(circle at 55% 20%, rgba(236, 72, 153, 0.55), transparent 35%);
-    animation: aurora 18s ease-in-out infinite alternate;
+    background: conic-gradient(
+      from 0deg,
+      rgba(168, 85, 247, 0.7),
+      rgba(56, 189, 248, 0.7),
+      rgba(236, 72, 153, 0.6),
+      rgba(168, 85, 247, 0.7),
+      rgba(56, 189, 248, 0.7),
+      rgba(168, 85, 247, 0.7)
+    );
+    filter: blur(70px);
+    animation: aurora 16s linear infinite;
     pointer-events: none;
     will-change: transform;
   }
 
-  /* Frosted glass — blurs the aurora behind for that dreamy depth */
+  /* Subtle frost — light backdrop blur for depth, doesn't hide the rotation */
   &::after {
     content: "";
     position: absolute;
     inset: 0;
     z-index: -1;
-    background: rgba(15, 10, 35, 0.25);
-    backdrop-filter: blur(18px) saturate(160%);
-    -webkit-backdrop-filter: blur(18px) saturate(160%);
+    background: rgba(15, 10, 35, 0.18);
+    backdrop-filter: blur(6px) saturate(140%);
+    -webkit-backdrop-filter: blur(6px) saturate(140%);
     pointer-events: none;
   }
 }
 
 @keyframes aurora {
-  0%   { transform: translate(0%, 0%) rotate(0deg); }
-  50%  { transform: translate(-8%, 6%) rotate(20deg); }
-  100% { transform: translate(8%, -6%) rotate(-20deg); }
+  to { transform: translate(-50%, -50%) rotate(360deg); }
 }
 
 .content {

--- a/src/components/NowPlaying/NowPlayingCard.module.scss
+++ b/src/components/NowPlaying/NowPlayingCard.module.scss
@@ -43,15 +43,15 @@
     z-index: -2;
     background: conic-gradient(
       from 0deg,
-      rgba(168, 85, 247, 0.7),
-      rgba(56, 189, 248, 0.7),
-      rgba(236, 72, 153, 0.6),
-      rgba(168, 85, 247, 0.7),
-      rgba(56, 189, 248, 0.7),
-      rgba(168, 85, 247, 0.7)
+      rgba(168, 85, 247, 0.45),
+      rgba(56, 189, 248, 0.4),
+      rgba(236, 72, 153, 0.35),
+      rgba(168, 85, 247, 0.45),
+      rgba(56, 189, 248, 0.4),
+      rgba(168, 85, 247, 0.45)
     );
-    filter: blur(70px);
-    animation: aurora 16s linear infinite;
+    filter: blur(80px);
+    animation: aurora 28s linear infinite;
     pointer-events: none;
     will-change: transform;
   }
@@ -62,9 +62,9 @@
     position: absolute;
     inset: 0;
     z-index: -1;
-    background: rgba(15, 10, 35, 0.18);
-    backdrop-filter: blur(6px) saturate(140%);
-    -webkit-backdrop-filter: blur(6px) saturate(140%);
+    background: rgba(15, 10, 35, 0.3);
+    backdrop-filter: blur(10px) saturate(130%);
+    -webkit-backdrop-filter: blur(10px) saturate(130%);
     pointer-events: none;
   }
 }

--- a/src/components/NowPlaying/NowPlayingCard.module.scss
+++ b/src/components/NowPlaying/NowPlayingCard.module.scss
@@ -154,6 +154,14 @@
   opacity: 0.8;
 }
 
+.cardBorder {}
+.vinyl {}
+.content {}
+.eq {}
+.ringWrap {}
+.ring {}
+.ringTime {}
+
 @media (prefers-reduced-motion: reduce) {
   .card,
   .offline {

--- a/src/components/NowPlaying/NowPlayingCard.module.scss
+++ b/src/components/NowPlaying/NowPlayingCard.module.scss
@@ -43,15 +43,15 @@
     z-index: -2;
     background: conic-gradient(
       from 0deg,
-      rgba(168, 85, 247, 0.45),
-      rgba(56, 189, 248, 0.4),
-      rgba(236, 72, 153, 0.35),
-      rgba(168, 85, 247, 0.45),
-      rgba(56, 189, 248, 0.4),
-      rgba(168, 85, 247, 0.45)
+      rgba(168, 85, 247, 0.7),
+      rgba(56, 189, 248, 0.7),
+      rgba(236, 72, 153, 0.6),
+      rgba(168, 85, 247, 0.7),
+      rgba(56, 189, 248, 0.7),
+      rgba(168, 85, 247, 0.7)
     );
-    filter: blur(80px);
-    animation: aurora 28s linear infinite;
+    filter: blur(70px);
+    animation: aurora 16s linear infinite;
     pointer-events: none;
     will-change: transform;
   }
@@ -62,9 +62,9 @@
     position: absolute;
     inset: 0;
     z-index: -1;
-    background: rgba(15, 10, 35, 0.3);
-    backdrop-filter: blur(10px) saturate(130%);
-    -webkit-backdrop-filter: blur(10px) saturate(130%);
+    background: rgba(15, 10, 35, 0.18);
+    backdrop-filter: blur(6px) saturate(140%);
+    -webkit-backdrop-filter: blur(6px) saturate(140%);
     pointer-events: none;
   }
 }

--- a/src/components/NowPlaying/NowPlayingCard.module.scss
+++ b/src/components/NowPlaying/NowPlayingCard.module.scss
@@ -7,10 +7,7 @@
 
   position: relative;
   isolation: isolate;
-  display: grid;
-  grid-template-columns: 110px 1fr;
-  gap: 1.4rem;
-  align-items: center;
+  display: block;
   width: 100%;
   max-width: 64rem;
   margin: 0 auto 4rem;
@@ -63,37 +60,6 @@
 @keyframes aurora {
   0%   { background-position: 0% 0%, 100% 100%, 50% 50%; }
   100% { background-position: 70% 30%, 30% 70%, 80% 20%; }
-}
-
-.vinyl {
-  width: 110px;
-  height: 110px;
-  border-radius: 50%;
-  background: radial-gradient(circle at 50% 50%,
-    var(--neon-magenta) 0 8%,
-    #1a1a1a 9% 12%,
-    #2a2a2a 12% 14%,
-    #1a1a1a 14% 50%,
-    #2a2a2a 50% 53%,
-    #1a1a1a 53% 100%);
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
-    0 8px 24px rgba(0, 0, 0, 0.5);
-  animation: vinylSpin 9s linear infinite;
-  position: relative;
-}
-
-.vinyl::after {
-  content: "";
-  position: absolute;
-  inset: 47%;
-  background: var(--bg-deep);
-  border-radius: 50%;
-  box-shadow: 0 0 6px rgba(0, 0, 0, 0.6);
-}
-
-@keyframes vinylSpin {
-  to { transform: rotate(360deg); }
 }
 
 .content {
@@ -287,13 +253,7 @@
 /* ===== Mobile / narrow widths ===== */
 @media (max-width: 720px) {
   .card {
-    grid-template-columns: 80px 1fr;
-    gap: 1rem;
     padding: 1.25rem 1.4rem;
-  }
-  .vinyl {
-    width: 80px;
-    height: 80px;
   }
   .trackTitle {
     font-size: 1.4rem;
@@ -315,7 +275,6 @@
 /* ===== Reduced motion ===== */
 @media (prefers-reduced-motion: reduce) {
   .card,
-  .vinyl,
   .eq span,
   .skeleton {
     animation: none;

--- a/src/components/NowPlaying/NowPlayingCard.module.scss
+++ b/src/components/NowPlaying/NowPlayingCard.module.scss
@@ -29,16 +29,18 @@
       0 8px 24px rgba(0, 0, 0, 0.4);
   }
 
-  /* Aurora drift — bold radial blobs that translate + rotate slowly behind the glass */
+  /* Aurora drift — bold radial blobs that translate + rotate slowly behind the glass.
+     Inset is -100% (i.e. 3x card size) so even at full rotation the rotated rectangle
+     still covers the visible card area — no corner-cropping artifacts. */
   &::before {
     content: "";
     position: absolute;
-    inset: -50%;
+    inset: -100%;
     z-index: -2;
     background:
-      radial-gradient(circle at 25% 30%, rgba(168, 85, 247, 0.7), transparent 45%),
-      radial-gradient(circle at 75% 70%, rgba(56, 189, 248, 0.65), transparent 45%),
-      radial-gradient(circle at 55% 20%, rgba(236, 72, 153, 0.55), transparent 45%);
+      radial-gradient(circle at 25% 30%, rgba(168, 85, 247, 0.7), transparent 35%),
+      radial-gradient(circle at 75% 70%, rgba(56, 189, 248, 0.65), transparent 35%),
+      radial-gradient(circle at 55% 20%, rgba(236, 72, 153, 0.55), transparent 35%);
     animation: aurora 18s ease-in-out infinite alternate;
     pointer-events: none;
     will-change: transform;

--- a/src/components/NowPlaying/NowPlayingCard.module.scss
+++ b/src/components/NowPlaying/NowPlayingCard.module.scss
@@ -1,73 +1,170 @@
-.card,
-.offline {
-  display: block;
+.card {
+  --bg-deep: #0a0618;
+  --neon-cyan: #38bdf8;
+  --neon-violet: #a855f7;
+  --neon-magenta: #ec4899;
+  --text-warm: #f5f3ff;
+
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  grid-template-columns: 110px 1fr 110px;
+  gap: 1.4rem;
+  align-items: center;
   width: 100%;
   max-width: 64rem;
   margin: 0 auto 4rem;
-  padding: 1.5rem 1.75rem;
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.04);
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.3);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1.6rem 1.85rem;
+  border-radius: 18px;
+  color: var(--text-warm);
   text-decoration: none;
-  color: inherit;
-  transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  overflow: hidden;
+  background:
+    radial-gradient(ellipse at 15% 30%, rgba(168, 85, 247, 0.55), transparent 55%),
+    radial-gradient(ellipse at 85% 75%, rgba(56, 189, 248, 0.5), transparent 55%),
+    radial-gradient(ellipse at 60% 25%, rgba(236, 72, 153, 0.4), transparent 55%),
+    var(--bg-deep);
+  background-size: 200% 200%;
+  animation: aurora 14s ease-in-out infinite alternate;
+  box-shadow:
+    0 20px 60px rgba(168, 85, 247, 0.25),
+    0 0 80px rgba(56, 189, 248, 0.1);
+  transition: box-shadow 0.25s ease, transform 0.25s ease;
 
   &:hover {
-    box-shadow: 0 10px 32px rgba(0, 0, 0, 0.4);
-    border-color: rgba(255, 255, 255, 0.16);
-    transform: translateY(-1px);
+    transform: translateY(-2px);
+    box-shadow:
+      0 28px 80px rgba(168, 85, 247, 0.35),
+      0 0 100px rgba(56, 189, 248, 0.2);
   }
 
-  @media (prefers-color-scheme: light) {
-    background: rgba(0, 0, 0, 0.04);
-    border-color: rgba(0, 0, 0, 0.08);
-    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.1);
-
-    &:hover {
-      box-shadow: 0 8px 26px rgba(0, 0, 0, 0.16);
-      border-color: rgba(0, 0, 0, 0.16);
-    }
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    border-radius: inherit;
+    background:
+      url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E"),
+      linear-gradient(180deg, rgba(10, 6, 24, 0.4), rgba(10, 6, 24, 0.55));
+    pointer-events: none;
   }
 }
 
-.skeleton {
-  composes: card;
-  min-height: 12rem;
+@keyframes aurora {
+  0%   { background-position: 0% 0%, 100% 100%, 50% 50%, 0 0; }
+  100% { background-position: 60% 40%, 30% 70%, 80% 30%, 0 0; }
+}
+
+.cardBorder {
+  position: absolute;
+  inset: 0;
+  border-radius: 18px;
+  padding: 1px;
+  background: linear-gradient(120deg, var(--neon-cyan), var(--neon-violet), var(--neon-magenta), var(--neon-cyan));
+  background-size: 300% 100%;
+  animation: borderShift 8s linear infinite;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
   pointer-events: none;
-  cursor: default;
-  animation: pulse 1.6s ease-in-out infinite;
+  z-index: 0;
 }
 
-@keyframes pulse {
-  0%, 100% { opacity: 0.6; }
-  50% { opacity: 0.9; }
+@keyframes borderShift {
+  to { background-position: 300% 0%; }
+}
+
+.vinyl {
+  width: 110px;
+  height: 110px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%,
+    var(--neon-magenta) 0 8%,
+    #1a1a1a 9% 12%,
+    #2a2a2a 12% 14%,
+    #1a1a1a 14% 50%,
+    #2a2a2a 50% 53%,
+    #1a1a1a 53% 100%);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 8px 24px rgba(0, 0, 0, 0.6),
+    0 0 24px rgba(168, 85, 247, 0.4);
+  animation: vinylSpin 9s linear infinite;
+  position: relative;
+}
+
+.vinyl::after {
+  content: "";
+  position: absolute;
+  inset: 47%;
+  background: var(--bg-deep);
+  border-radius: 50%;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.6);
+}
+
+@keyframes vinylSpin {
+  to { transform: rotate(360deg); }
+}
+
+.content {
+  min-width: 0;
 }
 
 .sourceLabel {
-  margin: 0;
-  font-size: 0.8rem;
-  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0 0 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  opacity: 0.85;
+  color: var(--neon-cyan);
+  text-shadow: 0 0 12px rgba(56, 189, 248, 0.5);
 }
 
-.trackInfo {
-  margin: 0.6rem 0 0;
+.eq {
+  display: inline-flex;
+  align-items: end;
+  gap: 3px;
+  height: 14px;
+}
+
+.eq span {
+  width: 3px;
+  background: var(--neon-cyan);
+  border-radius: 1px;
+  box-shadow: 0 0 6px rgba(56, 189, 248, 0.7);
+  animation: eq 0.85s ease-in-out infinite;
+}
+.eq span:nth-child(1) { animation-delay: 0s; }
+.eq span:nth-child(2) { animation-delay: 0.15s; }
+.eq span:nth-child(3) { animation-delay: 0.3s; }
+.eq span:nth-child(4) { animation-delay: 0.45s; }
+
+@keyframes eq {
+  0%, 100% { height: 25%; }
+  50%      { height: 100%; }
 }
 
 .trackTitle {
-  margin: 0;
-  font-size: 1.6rem;
+  margin: 0 0 0.3rem;
+  font-size: 1.7rem;
   font-weight: 700;
-  line-height: 1.2;
+  line-height: 1.15;
+  background: linear-gradient(90deg, var(--text-warm), #e9d5ff);
+  -webkit-background-clip: text;
+          background-clip: text;
+  -webkit-text-fill-color: transparent;
+          color: transparent;
 }
 
 .artist {
-  margin: 0.2rem 0 0;
-  font-size: 1rem;
-  opacity: 0.7;
+  margin: 0 0 0.95rem;
+  font-size: 0.95rem;
+  opacity: 0.75;
 }
 
 .noMetadata {
@@ -76,67 +173,31 @@
   opacity: 0.6;
 }
 
-.progress {
-  margin-top: 1rem;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.progressTrack {
-  flex: 1;
-  height: 4px;
-  border-radius: 2px;
-  background: rgba(255, 255, 255, 0.12);
-  overflow: hidden;
-
-  @media (prefers-color-scheme: light) {
-    background: rgba(0, 0, 0, 0.12);
-  }
-}
-
-.progressFill {
-  height: 100%;
-  background: currentColor;
-  transition: width 0.4s linear;
-}
-
-.progressTime {
-  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
-  font-size: 0.85rem;
-  opacity: 0.7;
-  white-space: nowrap;
-}
-
 .upNext {
-  margin: 0.85rem 0 0;
-  font-size: 0.9rem;
+  margin: 0 0 0.95rem;
+  font-size: 0.85rem;
   font-style: italic;
   opacity: 0.7;
 }
 
 .footer {
-  margin-top: 1.25rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-
-  @media (prefers-color-scheme: light) {
-    border-top-color: rgba(0, 0, 0, 0.08);
-  }
+  margin-top: 0.6rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .channelInfo {
   margin: 0;
-  font-size: 0.8rem;
-  opacity: 0.6;
+  font-size: 0.78rem;
+  opacity: 0.55;
 }
 
 .footerRow {
-  margin-top: 0.5rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 0.9rem;
+  margin-top: 0.4rem;
+  font-size: 0.88rem;
 }
 
 .listenerCount {
@@ -144,39 +205,169 @@
 }
 
 .cta {
+  color: var(--neon-cyan);
   font-weight: 600;
+  text-shadow: 0 0 10px rgba(56, 189, 248, 0.5);
+}
+
+.ringWrap {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 110px;
+  height: 110px;
+}
+
+.ring {
+  --progress-percent: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--neon-cyan) 0,
+    var(--neon-violet) calc(var(--progress-percent) * 1%),
+    rgba(255, 255, 255, 0.08) calc(var(--progress-percent) * 1%),
+    rgba(255, 255, 255, 0.08) 100%
+  );
+  box-shadow: 0 0 24px rgba(56, 189, 248, 0.3);
+  position: relative;
+  transition: background 0.4s linear;
+}
+
+.ring::before {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 30%, rgba(168, 85, 247, 0.2), transparent 60%),
+    var(--bg-deep);
+}
+
+.ringTime {
+  position: absolute;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 0.78rem;
+  color: var(--neon-cyan);
+  text-shadow: 0 0 8px rgba(56, 189, 248, 0.4);
+  white-space: nowrap;
+}
+
+/* ===== Skeleton ===== */
+.skeleton {
+  position: relative;
+  width: 100%;
+  max-width: 64rem;
+  min-height: 12rem;
+  margin: 0 auto 4rem;
+  padding: 1.6rem 1.85rem;
+  border-radius: 18px;
+  background: linear-gradient(135deg,
+    rgba(168, 85, 247, 0.12),
+    rgba(56, 189, 248, 0.08));
+  border: 1px solid rgba(168, 85, 247, 0.15);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.25);
+  animation: skeletonPulse 1.6s ease-in-out infinite;
+  pointer-events: none;
+  cursor: default;
+}
+
+@keyframes skeletonPulse {
+  0%, 100% { opacity: 0.6; }
+  50%      { opacity: 0.9; }
+}
+
+/* ===== Offline ===== */
+.offline {
+  position: relative;
+  display: block;
+  width: 100%;
+  max-width: 64rem;
+  margin: 0 auto 4rem;
+  padding: 1.6rem 1.85rem;
+  border-radius: 18px;
+  color: rgba(245, 243, 255, 0.85);
+  text-decoration: none;
+  background:
+    linear-gradient(180deg, rgba(40, 40, 55, 0.8), rgba(20, 20, 30, 0.9));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.3);
+  transition: border-color 0.2s ease, transform 0.2s ease;
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.16);
+    transform: translateY(-1px);
+  }
 }
 
 .offlineCta {
   margin: 0.6rem 0 0;
   font-size: 0.95rem;
   font-weight: 600;
-  opacity: 0.8;
+  opacity: 0.75;
 }
 
-.cardBorder {}
-.vinyl {}
-.content {}
-.eq {}
-.ringWrap {}
-.ring {}
-.ringTime {}
+/* ===== Mobile / narrow widths ===== */
+@media (max-width: 720px) {
+  .card {
+    grid-template-columns: 80px 1fr;
+    grid-template-areas:
+      "vinyl content"
+      "ring  ring";
+    gap: 1rem;
+    padding: 1.25rem 1.4rem;
+  }
+  .vinyl {
+    grid-area: vinyl;
+    width: 80px;
+    height: 80px;
+  }
+  .content {
+    grid-area: content;
+  }
+  .ringWrap {
+    grid-area: ring;
+    justify-self: center;
+    margin-top: 0.6rem;
+    width: 90px;
+    height: 90px;
+  }
+  .trackTitle {
+    font-size: 1.4rem;
+  }
+}
 
+/* ===== Light mode tweaks ===== */
+@media (prefers-color-scheme: light) {
+  .card {
+    --bg-deep: #1a1530;
+    box-shadow:
+      0 14px 40px rgba(168, 85, 247, 0.2),
+      0 0 60px rgba(56, 189, 248, 0.08);
+  }
+  .skeleton {
+    background: linear-gradient(135deg,
+      rgba(168, 85, 247, 0.1),
+      rgba(56, 189, 248, 0.06));
+  }
+}
+
+/* ===== Reduced motion ===== */
 @media (prefers-reduced-motion: reduce) {
+  .card,
+  .vinyl,
+  .cardBorder,
+  .eq span,
+  .skeleton,
+  .ring {
+    animation: none;
+  }
   .card,
   .offline {
     transition: none;
-
-    &:hover {
-      transform: none;
-    }
   }
-
-  .progressFill {
-    transition: none;
-  }
-
-  .skeleton {
-    animation: none;
+  .card:hover,
+  .offline:hover {
+    transform: none;
   }
 }

--- a/src/components/NowPlaying/NowPlayingCard.tsx
+++ b/src/components/NowPlaying/NowPlayingCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useReducer } from "react";
+import { useEffect, useReducer, type CSSProperties } from "react";
 import { AUDEOS_PLAY_ORIGIN } from "@/constants";
 import styles from "./NowPlayingCard.module.scss";
 
@@ -148,6 +148,11 @@ export default function NowPlayingCard() {
     return <div data-testid="now-playing-skeleton" className={ styles.skeleton } />;
   }
 
+  const trackDurationMs = data.track?.duration_ms ?? 0;
+  const progressPercent = trackDurationMs > 0
+    ? Math.min( 100, ( displayPositionMs / trackDurationMs ) * 100 )
+    : 0;
+
   return (
     <a
       href={ `${AUDEOS_PLAY_ORIGIN}/channels/${data.channel.slug}` }
@@ -155,51 +160,59 @@ export default function NowPlayingCard() {
       rel="noopener noreferrer"
       className={ styles.card }
     >
-      <p className={ styles.sourceLabel }>{ SOURCE_LABEL[data.source] }</p>
-      { data.track ? (
-        <div className={ styles.trackInfo }>
-          <h2 className={ styles.trackTitle }>{ data.track.title }</h2>
-          { data.track.artist && (
-            <p className={ styles.artist }>{ data.track.artist }</p>
-          ) }
-          <div className={ styles.progress }>
-            <div className={ styles.progressTrack }>
-              <div
-                data-testid="now-playing-progress-fill"
-                className={ styles.progressFill }
-                style={ {
-                  width: data.track.duration_ms > 0
-                    ? `${Math.min( 100, ( displayPositionMs / data.track.duration_ms ) * 100 )}%`
-                    : "0%",
-                } }
-              />
-            </div>
-            <span className={ styles.progressTime }>
-              { formatMs( displayPositionMs ) } / { formatMs( data.track.duration_ms ) }
+      <span className={ styles.cardBorder } aria-hidden="true" />
+      <div className={ styles.vinyl } aria-hidden="true" />
+
+      <div className={ styles.content }>
+        <p className={ styles.sourceLabel }>
+          { SOURCE_LABEL[data.source] }
+          <span className={ styles.eq } aria-hidden="true">
+            <span /><span /><span /><span />
+          </span>
+        </p>
+        { data.track ? (
+          <>
+            <h2 className={ styles.trackTitle }>{ data.track.title }</h2>
+            { data.track.artist && (
+              <p className={ styles.artist }>{ data.track.artist }</p>
+            ) }
+          </>
+        ) : (
+          <p className={ styles.noMetadata }>No metadata available.</p>
+        ) }
+        { data.next_track && (
+          <p className={ styles.upNext }>
+            Up next · { data.next_track.title }
+            { data.next_track.artist && ` · ${data.next_track.artist}` }
+          </p>
+        ) }
+        <div className={ styles.footer }>
+          <p data-testid="now-playing-channel-info" className={ styles.channelInfo }>
+            { data.channel.name }
+            { data.channel.description && ` · ${data.channel.description}` }
+          </p>
+          <div className={ styles.footerRow }>
+            <span className={ styles.listenerCount }>
+              { data.listener_count } listening
             </span>
+            <span className={ styles.cta }>Tune in →</span>
           </div>
         </div>
-      ) : (
-        <p className={ styles.noMetadata }>No metadata available.</p>
-      ) }
-      { data.next_track && (
-        <p className={ styles.upNext }>
-          Up next · { data.next_track.title }
-          { data.next_track.artist && ` · ${data.next_track.artist}` }
-        </p>
-      ) }
-      <div className={ styles.footer }>
-        <p data-testid="now-playing-channel-info" className={ styles.channelInfo }>
-          { data.channel.name }
-          { data.channel.description && ` · ${data.channel.description}` }
-        </p>
-        <div className={ styles.footerRow }>
-          <span className={ styles.listenerCount }>
-            { data.listener_count } listening
-          </span>
-          <span className={ styles.cta }>Tune in →</span>
-        </div>
       </div>
+
+      { data.track && (
+        <div className={ styles.ringWrap }>
+          <div
+            data-testid="now-playing-progress-fill"
+            className={ styles.ring }
+            style={ { "--progress-percent": String( progressPercent ) } as CSSProperties }
+            aria-hidden="true"
+          />
+          <span className={ styles.ringTime }>
+            { formatMs( displayPositionMs ) } / { formatMs( data.track.duration_ms ) }
+          </span>
+        </div>
+      ) }
     </a>
   );
 }

--- a/src/components/NowPlaying/NowPlayingCard.tsx
+++ b/src/components/NowPlaying/NowPlayingCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, type CSSProperties } from "react";
+import { useEffect, useReducer } from "react";
 import { AUDEOS_PLAY_ORIGIN } from "@/constants";
 import styles from "./NowPlayingCard.module.scss";
 
@@ -148,11 +148,6 @@ export default function NowPlayingCard() {
     return <div data-testid="now-playing-skeleton" className={ styles.skeleton } />;
   }
 
-  const trackDurationMs = data.track?.duration_ms ?? 0;
-  const progressPercent = trackDurationMs > 0
-    ? Math.min( 100, ( displayPositionMs / trackDurationMs ) * 100 )
-    : 0;
-
   return (
     <a
       href={ `${AUDEOS_PLAY_ORIGIN}/channels/${data.channel.slug}` }
@@ -160,7 +155,6 @@ export default function NowPlayingCard() {
       rel="noopener noreferrer"
       className={ styles.card }
     >
-      <span className={ styles.cardBorder } aria-hidden="true" />
       <div className={ styles.vinyl } aria-hidden="true" />
 
       <div className={ styles.content }>
@@ -171,12 +165,28 @@ export default function NowPlayingCard() {
           </span>
         </p>
         { data.track ? (
-          <>
+          <div className={ styles.trackInfo }>
             <h2 className={ styles.trackTitle }>{ data.track.title }</h2>
             { data.track.artist && (
               <p className={ styles.artist }>{ data.track.artist }</p>
             ) }
-          </>
+            <div className={ styles.progress }>
+              <div className={ styles.progressTrack }>
+                <div
+                  data-testid="now-playing-progress-fill"
+                  className={ styles.progressFill }
+                  style={ {
+                    width: data.track.duration_ms > 0
+                      ? `${Math.min( 100, ( displayPositionMs / data.track.duration_ms ) * 100 )}%`
+                      : "0%",
+                  } }
+                />
+              </div>
+              <span className={ styles.progressTime }>
+                { formatMs( displayPositionMs ) } / { formatMs( data.track.duration_ms ) }
+              </span>
+            </div>
+          </div>
         ) : (
           <p className={ styles.noMetadata }>No metadata available.</p>
         ) }
@@ -199,20 +209,6 @@ export default function NowPlayingCard() {
           </div>
         </div>
       </div>
-
-      { data.track && (
-        <div className={ styles.ringWrap }>
-          <div
-            data-testid="now-playing-progress-fill"
-            className={ styles.ring }
-            style={ { "--progress-percent": String( progressPercent ) } as CSSProperties }
-            aria-hidden="true"
-          />
-          <span className={ styles.ringTime }>
-            { formatMs( displayPositionMs ) } / { formatMs( data.track.duration_ms ) }
-          </span>
-        </div>
-      ) }
     </a>
   );
 }

--- a/src/components/NowPlaying/NowPlayingCard.tsx
+++ b/src/components/NowPlaying/NowPlayingCard.tsx
@@ -155,8 +155,6 @@ export default function NowPlayingCard() {
       rel="noopener noreferrer"
       className={ styles.card }
     >
-      <div className={ styles.vinyl } aria-hidden="true" />
-
       <div className={ styles.content }>
         <p className={ styles.sourceLabel }>
           { SOURCE_LABEL[data.source] }


### PR DESCRIPTION
## Summary

Visual rework of \`NowPlayingCard\` combining four design directions into one richly layered hero card. Behavior is identical to PR #93 — only styling and a few decorative DOM nodes change.

### What's combined
- **Spinning vinyl disc** on the left (slow 9s rotation; magenta center label)
- **Conic-gradient progress ring** on the right (replaces the linear bar; cyan→violet fill)
- **Animated equalizer bars** next to the "● Live now" label (4 bars with staggered keyframes)
- **Aurora gradient drift** behind everything (14s slow color shift across magenta/violet/cyan radial gradients)
- **Animated gradient border** running cyan→violet→magenta around the card edge (8s linear loop)
- **Film grain overlay** (SVG noise) for texture
- **Gradient title text** (white→soft violet)
- **Neon cyan accents** on source label + Tune in CTA (with text-shadow glow)

### Accessibility
- All decorative DOM has \`aria-hidden="true"\`
- \`@media (prefers-reduced-motion: reduce)\` disables all animations and hover transforms
- \`@media (prefers-color-scheme: light)\` tweaks the base color
- Mobile (<720px) collapses to two-row grid: vinyl + content on top, ring centered below

### Tests
28/28 existing NowPlayingCard tests pass. One assertion updated: the \`renders progress at 0%\` test moved from asserting \`bar.style.width === "0%"\` (linear bar, deleted) to \`ring.style.getPropertyValue("--progress-percent") === "0"\` (conic ring). Same \`data-testid="now-playing-progress-fill"\` lives on the ring.

### Performance
- 4 simultaneous CSS animations, all GPU-accelerated (transform / background-position)
- No new JS dependencies
- ~280 lines of SCSS added (~3KB gzipped)
- Skeleton dimensions match live card (zero CLS contribution)
- Zero impact on Contentful API quota (still pure client-side)

## Verified
- \`yarn typecheck\` — clean
- \`yarn lint\` — clean
- \`yarn test\` — 191 tests across 24 files pass
- \`yarn build\` — succeeds; dist/index.html still has the skeleton + category sections

## Test plan
- [ ] Load \`/\` in browser — see the live card with spinning vinyl, progress ring, animated border, aurora drift
- [ ] Verify track title gradient, EQ bars next to "Live now", listener count, Tune in CTA glow
- [ ] Resize to mobile width — vinyl + content stack on top, ring drops below centered
- [ ] DevTools → Rendering → "Emulate prefers-reduced-motion: reduce" — all animations stop, layout intact
- [ ] DevTools → Rendering → "Emulate prefers-color-scheme: light" — card adjusts; readable
- [ ] Stream offline state (throttle to offline, wait 30s) — card swaps to monochromatic offline placeholder

Spec: \`docs/superpowers/specs/2026-04-29-now-playing-polish-design.md\`
Plan: \`docs/superpowers/plans/2026-04-29-now-playing-polish.md\`