### PR TITLE
feat: handle transition holdover in NowPlayingCard

### DIFF
--- a/src/__tests__/components/NowPlayingCard.test.tsx
+++ b/src/__tests__/components/NowPlayingCard.test.tsx
@@ -76,10 +76,30 @@ describe( "NowPlayingCard", () => {
     expect( await screen.findByText( "On rotation" ) ).toBeInTheDocument();
   });
 
-  it( "renders 'No metadata available.' when track is null", async () => {
-    mockFetchOnce({ ...livePayload, track: null });
+  it( "renders the source label and CTA without track UI when track is null", async () => {
+    mockFetchOnce({ ...livePayload, track: null, source: "loop_fallback" });
     render( <NowPlayingCard /> );
-    expect( await screen.findByText( "No metadata available." ) ).toBeInTheDocument();
+    expect( await screen.findByText( "On rotation" ) ).toBeInTheDocument();
+    expect( screen.getByText( /Tune in/ ) ).toBeInTheDocument();
+    expect( screen.queryByText( "Day Party vol. 1" ) ).toBeNull();
+    expect( screen.queryByTestId( "now-playing-progress-fill" ) ).toBeNull();
+  });
+
+  it( "renders title and artist but hides the progress bar when timing fields are null (transition holdover)", async () => {
+    mockFetchOnce({
+      ...livePayload,
+      track: {
+        title: "Day Party vol. 1",
+        artist: "DJ Audeos",
+        started_at: null,
+        duration_ms: null,
+        position_ms: null,
+      },
+    });
+    render( <NowPlayingCard /> );
+    expect( await screen.findByText( "Day Party vol. 1" ) ).toBeInTheDocument();
+    expect( screen.getByText( "DJ Audeos" ) ).toBeInTheDocument();
+    expect( screen.queryByTestId( "now-playing-progress-fill" ) ).toBeNull();
   });
 
   it( "skips the artist line when track.artist is null", async () => {
@@ -341,13 +361,13 @@ describe( "NowPlayingCard", () => {
     }
   });
 
-  it( "renders progress bar at 0% when duration_ms is 0", async () => {
+  it( "hides the progress block when duration_ms is 0", async () => {
     mockFetchOnce({
       ...livePayload,
       track: { ...livePayload.track, position_ms: 0, duration_ms: 0 },
     });
     render( <NowPlayingCard /> );
-    const bar = await screen.findByTestId( "now-playing-progress-fill" );
-    expect( bar.style.width ).toBe( "0%" );
+    await screen.findByText( "Day Party vol. 1" );
+    expect( screen.queryByTestId( "now-playing-progress-fill" ) ).toBeNull();
   });
 });

--- a/src/components/NowPlaying/NowPlayingCard.module.scss
+++ b/src/components/NowPlaying/NowPlayingCard.module.scss
@@ -136,12 +136,6 @@
   opacity: 0.75;
 }
 
-.noMetadata {
-  margin: 0.6rem 0 0;
-  font-style: italic;
-  opacity: 0.6;
-}
-
 .progress {
   display: flex;
   align-items: center;

--- a/src/components/NowPlaying/NowPlayingCard.tsx
+++ b/src/components/NowPlaying/NowPlayingCard.tsx
@@ -23,9 +23,9 @@ function formatMs( ms: number ): string {
 type Track = {
   title: string;
   artist: string | null;
-  started_at: string;
-  duration_ms: number;
-  position_ms: number;
+  started_at: string | null;
+  duration_ms: number | null;
+  position_ms: number | null;
 };
 
 type NowPlaying = {
@@ -123,6 +123,7 @@ export default function NowPlayingCard() {
 
   useEffect( () => {
     if( !data?.track ) return;
+    if( data.track.duration_ms === null ) return;
     const capturedEpoch = epoch;
     const interval = setInterval( () => {
       dispatch({ type: "tick", epoch: capturedEpoch });
@@ -162,31 +163,29 @@ export default function NowPlayingCard() {
             <span /><span /><span /><span />
           </span>
         </p>
-        { data.track ? (
+        { data.track && (
           <div className={ styles.trackInfo }>
             <h2 className={ styles.trackTitle }>{ data.track.title }</h2>
             { data.track.artist && (
               <p className={ styles.artist }>{ data.track.artist }</p>
             ) }
-            <div className={ styles.progress }>
-              <div className={ styles.progressTrack }>
-                <div
-                  data-testid="now-playing-progress-fill"
-                  className={ styles.progressFill }
-                  style={ {
-                    width: data.track.duration_ms > 0
-                      ? `${Math.min( 100, ( displayPositionMs / data.track.duration_ms ) * 100 )}%`
-                      : "0%",
-                  } }
-                />
+            { data.track.duration_ms !== null && data.track.duration_ms > 0 && (
+              <div className={ styles.progress }>
+                <div className={ styles.progressTrack }>
+                  <div
+                    data-testid="now-playing-progress-fill"
+                    className={ styles.progressFill }
+                    style={ {
+                      width: `${Math.min( 100, ( displayPositionMs / data.track.duration_ms ) * 100 )}%`,
+                    } }
+                  />
+                </div>
+                <span className={ styles.progressTime }>
+                  { formatMs( displayPositionMs ) } / { formatMs( data.track.duration_ms ) }
+                </span>
               </div>
-              <span className={ styles.progressTime }>
-                { formatMs( displayPositionMs ) } / { formatMs( data.track.duration_ms ) }
-              </span>
-            </div>
+            ) }
           </div>
-        ) : (
-          <p className={ styles.noMetadata }>No metadata available.</p>
         ) }
         { data.next_track && (
           <p className={ styles.upNext }>


### PR DESCRIPTION
## Summary

Mirrors the API contract change from [aud-eos/play.audeos.com#42](https://github.com/aud-eos/play.audeos.com/pull/42), which holds the previous song's title/artist during short transitions (DJ drops, jingles, stings) and nullifies timing fields so the progress bar doesn't render a stuck/jittery state.

- **Transition holdover**: title/artist persist; progress block hides (no fake \"5-second song\" feel).
- **Loop with nothing to play**: source badge alone (\"On rotation\", \"● Live now\") — no fallback \"No metadata available.\" copy. The badge is self-sufficient.

## Changes

- `Track` type: `started_at`, `duration_ms`, `position_ms` are now nullable
- Progress block guarded on `duration_ms !== null && duration_ms > 0` (previous inline `> 0` fallback became unreachable and was removed)
- `noMetadata` else-branch removed; matching SCSS rule deleted
- Tick \`useEffect\` skips the 1Hz interval when \`duration_ms\` is null

## Test plan

- [x] \`yarn lint\` (ESLint + tsc)
- [x] \`yarn test src/__tests__/components/NowPlayingCard.test.tsx\` — 29/29 passing
  - Replaced the \"No metadata available.\" test → asserts source label + CTA render with no track UI when \`track\` is null
  - Replaced the \"0% width when duration_ms is 0\" test → asserts the progress block is hidden
  - Added a transition-holdover test → title/artist render without a progress bar when timing fields are null
- [ ] Visual check post-merge: tune in during a transition and confirm the progress bar disappears while title/artist persist