### PR TITLE
chore: update repo references after rename to audeos.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This site is automatically deployed to **GitHub Pages** using GitHub Actions.
 
-[![Deploy](https://github.com/aud-eos/aud-eos.github.io/actions/workflows/nextjs.yml/badge.svg)](https://github.com/aud-eos/aud-eos.github.io/actions/workflows/nextjs.yml)
-[![Tests](https://github.com/aud-eos/aud-eos.github.io/actions/workflows/pr-build-stats.yml/badge.svg?label=tests)](https://github.com/aud-eos/aud-eos.github.io/actions/workflows/pr-build-stats.yml)
-[![Socket Security](https://github.com/aud-eos/aud-eos.github.io/actions/workflows/socket.yml/badge.svg)](https://github.com/aud-eos/aud-eos.github.io/actions/workflows/socket.yml)
+[![Deploy](https://github.com/aud-eos/audeos.com/actions/workflows/nextjs.yml/badge.svg)](https://github.com/aud-eos/audeos.com/actions/workflows/nextjs.yml)
+[![Tests](https://github.com/aud-eos/audeos.com/actions/workflows/pr-build-stats.yml/badge.svg?label=tests)](https://github.com/aud-eos/audeos.com/actions/workflows/pr-build-stats.yml)
+[![Socket Security](https://github.com/aud-eos/audeos.com/actions/workflows/socket.yml/badge.svg)](https://github.com/aud-eos/audeos.com/actions/workflows/socket.yml)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Fwww.audeos.com)](https://www.audeos.com)
 
 ![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js&logoColor=white)
@@ -13,8 +13,8 @@ This site is automatically deployed to **GitHub Pages** using GitHub Actions.
 ![Yarn](https://img.shields.io/badge/Yarn-4-2C8EBB?logo=yarn&logoColor=white)
 ![Tested with Vitest](https://img.shields.io/badge/tested%20with-vitest-6E9F18?logo=vitest&logoColor=white)
 
-![Last Commit](https://img.shields.io/github/last-commit/aud-eos/aud-eos.github.io/main)
-![Repo Size](https://img.shields.io/github/repo-size/aud-eos/aud-eos.github.io)
+![Last Commit](https://img.shields.io/github/last-commit/aud-eos/audeos.com/main)
+![Repo Size](https://img.shields.io/github/repo-size/aud-eos/audeos.com)
 
 ## Getting Started
 

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+www.audeos.com


### PR DESCRIPTION
## Summary

The GitHub repo was renamed from `aud-eos/aud-eos.github.io` → `aud-eos/audeos.com`. This PR fixes the in-repo references that don't ride GitHub's redirect, and protects the live site against future renames.

- **README badges** repointed at the new owner/repo slug. The 3 Actions badges and 2 shields.io repo-metadata badges (`last-commit`, `repo-size`) hit the GitHub API directly with the old slug and won't follow the HTML redirect — they'd silently 404 once the redirect cache lapses.
- **`public/CNAME`** added with `www.audeos.com`. GitHub Pages strips the custom-domain config on rename when no CNAME ships in the deployed artifact. With `output: "export"`, anything in `public/` is copied verbatim into `dist/`, so this restores (and pins) the custom domain. Without it, `actions/configure-pages` would fall back to a `/audeos.com` basePath and break every internal link, and the workflow's post-deploy curls of `https://www.audeos.com/...` would all 404.

The Footer's `https://github.com/aud-eos` link points at the org, not the repo, so it's unaffected.

## Test plan

- [ ] Confirm the live site at https://www.audeos.com still serves after merge
- [ ] Verify GitHub Pages settings show "Custom domain: www.audeos.com" with the green check after deploy
- [ ] Confirm the post-deploy `validate-core` / `validate-sitemap` / `validate-rss` jobs all pass against `https://www.audeos.com`
- [ ] Confirm README badges render with status (not "no status") on the merged PR view