### PR TITLE
feat: point NowPlayingCard at audeos.fm

### DIFF
--- a/src/__tests__/components/NowPlayingCard.test.tsx
+++ b/src/__tests__/components/NowPlayingCard.test.tsx
@@ -48,7 +48,7 @@ describe( "NowPlayingCard", () => {
     const fetchMock = vi.fn( async () => ({ ok: true, status: 200, json: async () => livePayload }) );
     vi.stubGlobal( "fetch", fetchMock );
     render( <NowPlayingCard /> );
-    expect( fetchMock ).toHaveBeenCalledWith( "https://play.audeos.com/api/now-playing/main" );
+    expect( fetchMock ).toHaveBeenCalledWith( "https://audeos.fm/api/now-playing/main" );
   });
 
   it( "renders the track title and artist after the fetch resolves", async () => {

--- a/src/components/NowPlaying/NowPlayingCard.tsx
+++ b/src/components/NowPlaying/NowPlayingCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useReducer } from "react";
-import { AUDEOS_PLAY_ORIGIN } from "@/constants";
+import { STREAM_ORIGIN } from "@/constants";
 import styles from "./NowPlayingCard.module.scss";
 
 const MAIN_CHANNEL_SLUG = "main";
@@ -89,7 +89,7 @@ export default function NowPlayingCard() {
     const fetchOnce = async () => {
       try {
         const response = await fetch(
-          `${AUDEOS_PLAY_ORIGIN}/api/now-playing/${MAIN_CHANNEL_SLUG}`,
+          `${STREAM_ORIGIN}/api/now-playing/${MAIN_CHANNEL_SLUG}`,
         );
         if( !response.ok ) throw new Error( `HTTP ${response.status}` );
         const payload = await response.json() as NowPlaying;
@@ -134,7 +134,7 @@ export default function NowPlayingCard() {
   if( errored ) {
     return (
       <a
-        href={ `${AUDEOS_PLAY_ORIGIN}/channels/${MAIN_CHANNEL_SLUG}` }
+        href={ `${STREAM_ORIGIN}/channels/${MAIN_CHANNEL_SLUG}` }
         target="_blank"
         rel="noopener noreferrer"
         className={ styles.offline }
@@ -151,7 +151,7 @@ export default function NowPlayingCard() {
 
   return (
     <a
-      href={ `${AUDEOS_PLAY_ORIGIN}/channels/${data.channel.slug}` }
+      href={ `${STREAM_ORIGIN}/channels/${data.channel.slug}` }
       target="_blank"
       rel="noopener noreferrer"
       className={ styles.card }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,4 +12,4 @@ export const CONTENT_IMAGE_WIDTH = 750;
 export const POSTS_PER_TAG_SECTION = 3;
 export const POSTS_PER_CATEGORY_SECTION = 6;
 export const CATEGORY_IDS = [ "music", "events", "lifestyle" ] as const;
-export const AUDEOS_PLAY_ORIGIN = "https://play.audeos.com";
+export const STREAM_ORIGIN = "https://audeos.fm";


### PR DESCRIPTION
## Summary

The streaming player moved from `play.audeos.com` to its own domain `audeos.fm`. This points the home-page now-playing widget at the new domain and renames the constant to match its new purpose.

- **Endpoint update** — `NowPlayingCard` polls `https://audeos.fm/api/now-playing/main` (was `play.audeos.com`) and deep-links into `https://audeos.fm/channels/{slug}` for both the live card and the offline-fallback card.
- **Constant rename** — `AUDEOS_PLAY_ORIGIN` → `STREAM_ORIGIN` in `src/constants.ts`. The old name was a literal nod to the `play.audeos.com` subdomain; with `audeos.fm` the "PLAY" suffix is misleading. The new name is purpose-oriented (mirroring `SITE_URL` next to it) so the next domain change is just a value swap, not another rename pass.
- **Test assertion** updated to the new URL.

Historical specs/plans under `docs/superpowers/` reference `play.audeos.com` — those are point-in-time design records and stay frozen on purpose.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn test` — 24 files, 192 tests pass
- [x] `yarn format` — no diff
- [ ] After merge: load https://www.audeos.com, confirm the NowPlayingCard renders track info (DevTools Network tab should show a 200 from `audeos.fm/api/now-playing/main`)
- [ ] Click the card, confirm it opens `audeos.fm/channels/main` in a new tab
- [ ] Throttle network to "Offline" briefly, refresh — confirm the offline-fallback card links to `audeos.fm/channels/main`