### PR TITLE
feat: add stream status link to footer

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -59,8 +59,17 @@ export const Footer: FC = () => {
         </p>
       </div>
 
-      <div>
-        <button className={ styles.cookieLink } onClick={ resetCookieConsent }>
+      <div className={ styles.utilityLinks }>
+        <Link
+          href="https://status.audeos.fm"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={ styles.utilityLink }
+        >
+          Stream status
+        </Link>
+        <span className={ styles.utilityDivider } aria-hidden="true">·</span>
+        <button className={ styles.utilityLink } onClick={ resetCookieConsent }>
           Update Cookie Preferences
         </button>
       </div>

--- a/src/styles/Layout.module.scss
+++ b/src/styles/Layout.module.scss
@@ -158,10 +158,25 @@ footer.footer {
     margin: 2rem auto;
 }
 
-.cookieLink {
+.utilityLinks {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.utilityDivider {
+    font-size: 0.8rem;
+    opacity: 0.4;
+}
+
+.utilityLink {
     background: none;
     border: none;
+    padding: 0;
     color: inherit;
+    font: inherit;
     font-size: 0.8rem;
     opacity: 0.5;
     cursor: pointer;


### PR DESCRIPTION
## Summary

Adds a `Stream status` link pointing at https://status.audeos.fm in the footer, grouped inline with the existing cookie-preferences control as utility / site-meta links.

- **Placement:** in the same row as `Update Cookie Preferences`, separated by a `·` divider. Same row because both are small understated meta-links — distinct in register from the brand-following social-icon row above.
- **Class rename:** `.cookieLink` → `.utilityLink` (and corresponding `.utilityLinks` flex wrapper). The class is now applied to two elements with different defaults (`<a>` and `<button>`), so the name should describe the visual style, not the original sole usage.
- **Reset additions** (`padding: 0`, `font: inherit`) on `.utilityLink`. Browser default `<button>` renders with system-control font and a few pixels of inset padding — without these resets, the button would look slightly larger and use a different typeface than the new anchor sitting next to it. The cookie button looks marginally tighter than before in isolation; alongside the status link it now reads as a coherent pair.
- **Accessibility:** the divider is a presentational character wrapped in `aria-hidden="true"` so it's skipped by screen readers. The status link uses `rel="noopener noreferrer"` (consistent with `NowPlayingCard`'s external links).

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn test` — 24 files, 192 tests pass (no Footer tests exist)
- [x] `yarn format` — no diff
- [ ] Visual check on https://www.audeos.com after deploy: utility links render on one line, cookie button still triggers the cookie-consent reset, status link opens https://status.audeos.fm in a new tab
- [ ] Confirm typography between the link and button matches (same size, same font, same opacity)
- [ ] Mobile viewport: confirm the row wraps gracefully if there's not enough horizontal space (covered by `flex-wrap: wrap` on `.utilityLinks`)