### PR TITLE
chore: add rel="noopener noreferrer" to footer social links + lint enforcement

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,20 @@ const eslintConfig = defineConfig( [ ...nextTypescript, ...nextVitals, {
     "@next/next/no-img-element": "off",
   },
 }, {
+  // Tell anchor-aware react/jsx-a11y rules that next/link's <Link> is a link.
+  // Without this, react/jsx-no-target-blank silently skips <Link target="_blank">
+  // because the rule only inspects native <a>/<area> elements.
+  settings: {
+    linkComponents: [
+      { name: "Link", linkAttribute: "href" },
+    ],
+  },
+}, {
   rules: {
+    // Next's preset disables this rule. Re-enable it so target="_blank" without
+    // rel="noopener noreferrer" is caught at lint time, including on Next's <Link>
+    // (see linkComponents setting above). Catches a real foot-gun: tabnabbing.
+    "react/jsx-no-target-blank": [ "error", { allowReferrer: false, enforceDynamicLinks: "always" } ],
     "indent": [ "error", 2 ],
     "array-bracket-spacing": [ 2, "always" ],
     "arrow-parens": [ 2, "as-needed" ],

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -47,7 +47,12 @@ export const Footer: FC = () => {
 
       <div className={ styles.socialLinks }>
         { SOCIAL_LINKS.map( ({ href, icon: Icon, title }) => (
-          <Link key={ href } href={ href } target="_blank">
+          <Link
+            key={ href }
+            href={ href }
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <Icon size={ ICON_SIZE } title={ title } />
           </Link>
         ) ) }


### PR DESCRIPTION
## Summary

Follow-up to #102. The Footer's social-icon row was the only `target="_blank"` link in the codebase missing an explicit `rel="noopener noreferrer"`. This adds the attribute and — more importantly — fixes the lint blind spot that let the omission slip past review in the first place.

### Why lint didn't catch it

`react/jsx-no-target-blank` only inspects native `<a>` and `<area>` elements by default. Next's `<Link>` is a custom component, so the rule silently skipped it. On top of that, `eslint-config-next`'s preset disables the rule entirely (severity `0` in the resolved config — confirmed via `eslint --print-config`). Two layers of "this rule isn't running on the code we care about."

### Changes

1. **`src/components/Layout/Footer.tsx`** — add `rel="noopener noreferrer"` to the social-icon `<Link>`. Matches the convention already used by `NowPlayingCard`, `TikTokEmbed`, `YouTubeEmbed`, `SoundCloudEmbed`, `LocationMap`, and the footer status link from #102.
2. **`eslint.config.mjs`** — two config additions:
   - `settings.linkComponents: [{ name: "Link", linkAttribute: "href" }]` so anchor-aware rules treat Next's `<Link>` as an anchor.
   - Re-enable `react/jsx-no-target-blank` with `allowReferrer: false, enforceDynamicLinks: "always"`. With the `linkComponents` setting above, the rule now covers both native `<a>` and `<Link>`.

### Verification (this is the part worth scrutinizing)

I confirmed the rule actually fires now by temporarily stripping `rel` from the social `<Link>` and re-running `yarn lint`:

```
src/components/Layout/Footer.tsx
  50:11  error  Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers  react/jsx-no-target-blank

✖ 1 problem (1 error, 0 warnings)
```

Then restored `rel` and re-ran the full pipeline — clean. So future regressions of this exact bug will fail lint, not slip through.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [x] `yarn test` — 24 files, 192 tests pass
- [x] `yarn format` — no diff
- [x] Verified the rule fires when `rel` is missing (then reverted)
- [ ] After merge: confirm clicking a social icon still opens the platform in a new tab