### PR TITLE
Bootstrap infra/ + adopt audeos.com R53 zone & records (Phase 0+1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,42 @@ upgrade-latest:
 # TypeScript-only type check (no ESLint)
 typecheck:
 	@yarn typecheck
+
+# `make tofu-init` — initialize OpenTofu in infra/. Run once after cloning,
+# or whenever backend/provider config changes. Sources infra/.env first
+# (gitignored; copy from infra/.env.example and fill in values).
+tofu-init:
+	@cd infra && set -a && . ./.env && set +a && tofu init
+
+# `make tofu-plan` — show pending OpenTofu changes against AWS. Sources
+# infra/.env. Read-only; does not modify infrastructure. Pass extra flags
+# via ARGS, e.g. `make tofu-plan ARGS="-target=aws_route53_zone.audeos_com"`.
+tofu-plan:
+	@cd infra && set -a && . ./.env && set +a && tofu plan $(ARGS)
+
+# `make tofu-apply` — apply pending OpenTofu changes. Interactive — prompts
+# for "yes" before making changes. Never pass -auto-approve here; apply
+# against shared cloud infra needs human-in-loop confirmation. Pass extra
+# flags via ARGS, e.g. `make tofu-apply ARGS="-target=aws_route53_zone.audeos_com"`.
+tofu-apply:
+	@cd infra && set -a && . ./.env && set +a && tofu apply $(ARGS)
+
+# `make tofu-fmt` — auto-format infra/*.tf files. Run before commit.
+tofu-fmt:
+	@cd infra && tofu fmt -recursive
+
+# `make tofu-validate` — syntax + provider-arg check. No network calls,
+# no state lookups. Quick sanity check before tofu-plan.
+tofu-validate:
+	@cd infra && tofu validate
+
+# `make tofu-providers-lock` — populate `.terraform.lock.hcl` with `h1:`
+# hashes for every platform we run tofu on (local M-series macOS + the
+# linux_amd64 GH Actions runners + linux_arm64 for any future ARM runners
+# or Fly machines). Run after bumping a provider version.
+tofu-providers-lock:
+	@cd infra && set -a && . ./.env && set +a && \
+		tofu providers lock \
+			-platform=darwin_arm64 \
+			-platform=linux_amd64 \
+			-platform=linux_arm64

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,0 +1,6 @@
+# Local env for OpenTofu against the audeos AWS account (org-root).
+# Copy to .env and fill in values. .env is gitignored.
+
+# AWS profile (set up in ~/.aws/credentials). Used for both the S3
+# state backend and resource operations.
+AWS_PROFILE=audeos

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,16 @@
+# Local environment — never commit secrets
+.env
+
+# OpenTofu / Terraform local state
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfplan
+
+# Crash logs
+crash.log
+crash.*.log
+
+# Override files — only commit named overrides intentionally
+*_override.tf
+*_override.tf.json

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
+    "h1:H8CH2vfXXP/WQgJw+Qrn72umKs9UlGYQvn+QdnwO8Nc=",
+    "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
+  ]
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region  = "us-east-1"
+  profile = "audeos"
+
+  default_tags {
+    tags = {
+      ManagedBy = "OpenTofu"
+      Project   = "audeos.com"
+      Repo      = "aud-eos/audeos.com"
+    }
+  }
+}

--- a/infra/route53.tf
+++ b/infra/route53.tf
@@ -15,3 +15,200 @@ import {
   to = aws_route53_zone.audeos_com
   id = "Z04082853V3NSCPIUKILC"
 }
+
+# === GitHub Pages — apex A records (single RRSet, 4 IPs) ===
+# https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site
+# All four IPs are required; GH Pages serves from any of them.
+
+resource "aws_route53_record" "apex_a" {
+  zone_id = aws_route53_zone.audeos_com.zone_id
+  name    = "audeos.com"
+  type    = "A"
+  ttl     = 300
+  records = [
+    "185.199.108.153",
+    "185.199.109.153",
+    "185.199.110.153",
+    "185.199.111.153",
+  ]
+}
+
+import {
+  to = aws_route53_record.apex_a
+  id = "Z04082853V3NSCPIUKILC_audeos.com_A"
+}
+
+# === GitHub Pages — www subdomain ===
+
+resource "aws_route53_record" "www" {
+  zone_id = aws_route53_zone.audeos_com.zone_id
+  name    = "www.audeos.com"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["aud-eos.github.io"]
+}
+
+import {
+  to = aws_route53_record.www
+  id = "Z04082853V3NSCPIUKILC_www.audeos.com_CNAME"
+}
+
+# === ProtonMail — inbound mail ===
+# Two MX records (primary 10 / secondary 20) as a single RRSet.
+
+resource "aws_route53_record" "proton_mx" {
+  zone_id = aws_route53_zone.audeos_com.zone_id
+  name    = "audeos.com"
+  type    = "MX"
+  ttl     = 300
+  records = [
+    "10 mail.protonmail.ch",
+    "20 mailsec.protonmail.ch",
+  ]
+}
+
+import {
+  to = aws_route53_record.proton_mx
+  id = "Z04082853V3NSCPIUKILC_audeos.com_MX"
+}
+
+# Apex TXT carries BOTH the Proton SPF and the Proton domain-verification
+# token. R53 treats multiple TXT values at the same name as one RRSet.
+
+resource "aws_route53_record" "apex_txt" {
+  zone_id = aws_route53_zone.audeos_com.zone_id
+  name    = "audeos.com"
+  type    = "TXT"
+  ttl     = 300
+  # AWS provider stores TXT values unquoted in HCL; the provider adds
+  # the wire-level quoting itself. Order matches what's currently in
+  # R53 to keep imports drift-free.
+  records = [
+    "protonmail-verification=c5dc9678c3fb9d0aa648269749dd74abe49fea3c",
+    "v=spf1 include:_spf.protonmail.ch mx ~all",
+  ]
+}
+
+import {
+  to = aws_route53_record.apex_txt
+  id = "Z04082853V3NSCPIUKILC_audeos.com_TXT"
+}
+
+# === ProtonMail — DKIM ===
+# Three rotating selectors Proton issues per domain.
+
+resource "aws_route53_record" "proton_dkim_1" {
+  zone_id = aws_route53_zone.audeos_com.zone_id
+  name    = "protonmail._domainkey.audeos.com"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["protonmail.domainkey.dsok63rccxglsplvzwk27ssmbba5a5u34tbf4ub5tvacdeyzqoula.domains.proton.ch."]
+}
+
+import {
+  to = aws_route53_record.proton_dkim_1
+  id = "Z04082853V3NSCPIUKILC_protonmail._domainkey.audeos.com_CNAME"
+}
+
+resource "aws_route53_record" "proton_dkim_2" {
+  zone_id = aws_route53_zone.audeos_com.zone_id
+  name    = "protonmail2._domainkey.audeos.com"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["protonmail2.domainkey.dsok63rccxglsplvzwk27ssmbba5a5u34tbf4ub5tvacdeyzqoula.domains.proton.ch."]
+}
+
+import {
+  to = aws_route53_record.proton_dkim_2
+  id = "Z04082853V3NSCPIUKILC_protonmail2._domainkey.audeos.com_CNAME"
+}
+
+resource "aws_route53_record" "proton_dkim_3" {
+  zone_id = aws_route53_zone.audeos_com.zone_id
+  name    = "protonmail3._domainkey.audeos.com"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["protonmail3.domainkey.dsok63rccxglsplvzwk27ssmbba5a5u34tbf4ub5tvacdeyzqoula.domains.proton.ch."]
+}
+
+import {
+  to = aws_route53_record.proton_dkim_3
+  id = "Z04082853V3NSCPIUKILC_protonmail3._domainkey.audeos.com_CNAME"
+}
+
+# === DMARC — observation-mode policy on audeos.com ===
+
+resource "aws_route53_record" "dmarc" {
+  zone_id = aws_route53_zone.audeos_com.zone_id
+  name    = "_dmarc.audeos.com"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=DMARC1; p=quarantine"]
+}
+
+import {
+  to = aws_route53_record.dmarc
+  id = "Z04082853V3NSCPIUKILC__dmarc.audeos.com_TXT"
+}
+
+# === GitHub verification tokens ===
+# Domain-verification challenges issued by GitHub. Removing either
+# breaks the corresponding GitHub feature (org-verified domain badge,
+# Pages custom-domain enforcement).
+
+resource "aws_route53_record" "github_org_verification" {
+  zone_id = aws_route53_zone.audeos_com.zone_id
+  name    = "_gh-aud-eos-o.audeos.com"
+  type    = "TXT"
+  ttl     = 300
+  records = ["4f0fd67d98"]
+}
+
+import {
+  to = aws_route53_record.github_org_verification
+  id = "Z04082853V3NSCPIUKILC__gh-aud-eos-o.audeos.com_TXT"
+}
+
+resource "aws_route53_record" "github_pages_verification" {
+  zone_id = aws_route53_zone.audeos_com.zone_id
+  name    = "_github-pages-challenge-aud-eos.audeos.com"
+  type    = "TXT"
+  ttl     = 300
+  records = ["7f75747cd2e72f93a5a829efee1c7b"]
+}
+
+import {
+  to = aws_route53_record.github_pages_verification
+  id = "Z04082853V3NSCPIUKILC__github-pages-challenge-aud-eos.audeos.com_TXT"
+}
+
+# === Amazon SES — outbound mail via the mail.audeos.com subdomain ===
+# Bounce/complaint MX + SPF for the subdomain. SES DKIM CNAMEs are in
+# ses.tf because they depend on aws_ses_domain_identity.audeos_com
+# (added in PR B).
+
+resource "aws_route53_record" "mail_mx_ses" {
+  zone_id = aws_route53_zone.audeos_com.zone_id
+  name    = "mail.audeos.com"
+  type    = "MX"
+  ttl     = 300
+  records = ["10 feedback-smtp.us-east-1.amazonses.com"]
+}
+
+import {
+  to = aws_route53_record.mail_mx_ses
+  id = "Z04082853V3NSCPIUKILC_mail.audeos.com_MX"
+}
+
+resource "aws_route53_record" "mail_spf_ses" {
+  zone_id = aws_route53_zone.audeos_com.zone_id
+  name    = "mail.audeos.com"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=spf1 include:amazonses.com ~all"]
+}
+
+import {
+  to = aws_route53_record.mail_spf_ses
+  id = "Z04082853V3NSCPIUKILC_mail.audeos.com_TXT"
+}

--- a/infra/route53.tf
+++ b/infra/route53.tf
@@ -1,0 +1,17 @@
+# DNS for audeos.com via Route 53.
+#
+# Hosted zone existed before the original Cloudflare migration and was
+# preserved in R53 during the Cloudflare era. This file re-adopts it
+# under tofu with no changes to live records (Phase 1 of the
+# audeos.com extraction + R53 cutover, see
+# docs/superpowers/specs/2026-05-10-audeos-com-extraction-and-route53-cutover-design.md
+# in the audeos.fm repo).
+
+resource "aws_route53_zone" "audeos_com" {
+  name = "audeos.com"
+}
+
+import {
+  to = aws_route53_zone.audeos_com
+  id = "Z04082853V3NSCPIUKILC"
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,4 @@
+# Currently no variables — every resource targets the audeos AWS account
+# with hard-coded values (domain name, hosted zone ID). Variables file is
+# kept as a placeholder so adding the first variable later doesn't require
+# creating the file from scratch.

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "audeos-tofu-state"
+    key            = "audeos-com/terraform.tfstate"
+    region         = "us-west-2"
+    profile        = "audeos"
+    dynamodb_table = "audeos-tofu-locks"
+    encrypt        = true
+  }
+}


### PR DESCRIPTION
Phases 0 + 1 of the audeos.com extraction + R53 cutover. See `docs/superpowers/specs/2026-05-10-audeos-com-extraction-and-route53-cutover-design.md` and `docs/superpowers/plans/2026-05-10-audeos-com-extraction-and-route53-cutover.md` in the audeos.fm repo for full design + plan.

## Summary

- New `infra/` directory in this repo: Makefile targets (`tofu-init`, `tofu-plan`, `tofu-apply`, `tofu-fmt`, `tofu-validate`, `tofu-providers-lock`), tofu skeleton (`versions.tf`, `providers.tf`, `variables.tf`), gitignore + env template.
- Backend: shared `audeos-tofu-state` S3 bucket with key `audeos-com/terraform.tfstate`, same DynamoDB lock table as audeos.fm.
- AWS provider on `audeos` profile (org-root account); default tags `ManagedBy=OpenTofu, Project=audeos.com, Repo=aud-eos/audeos.com`.
- `aws_route53_zone.audeos_com` adopted via import (the dormant R53 zone `Z04082853V3NSCPIUKILC` preserved from before the original CF migration).
- 11 `aws_route53_record` resources adopted via import: GH Pages apex A (1 RRSet, 4 IPs), www CNAME, Proton MX (1 RRSet, 2 entries), apex TXT (1 RRSet: SPF + verification), Proton DKIM × 3, DMARC, GitHub org + Pages verification TXTs, mail.audeos.com SES MX + SPF.
- Two stale `play.audeos.com` records intentionally NOT adopted — cleanup in PR E.
- SES identity + DKIM CNAMEs are out of scope here (depend on `aws_ses_domain_identity.audeos_com`); they come in PR B.

## Plan output

```
Plan: 13 to import, 0 to add, 1 to change, 0 to destroy.
```

The "1 to change" is the zone's `default_tags` (ManagedBy/Project/Repo) being applied to the formerly-untagged zone. Pure metadata, no DNS impact.

Drift-fixes I made before plan came out clean:
- TXT values: AWS provider expects unquoted strings in HCL (provider adds wire-level quotes itself). My initial draft had escaped quotes (`"\"v=DMARC1; p=quarantine\""`) which would've shown drift; fixed to plain strings.
- CNAME values: Proton DKIM records in R53 have trailing dots; matched.

## Apply runbook

Operator (you) runs:

```sh
cd ~/dev/audeos.com
make tofu-apply
```

Type `yes`. Should report "Apply complete! Resources: 13 imported, 0 added, 1 changed, 0 destroyed." Then `make tofu-plan` should return "No changes."

After that, tell me "PR A applied" and I'll open PR B (SES adoption) + the coordinated PR C in the audeos.fm repo.

## Test plan

- [x] `make tofu-init` succeeded.
- [x] `make tofu-providers-lock` produces 3 h1 hashes (darwin_arm64, linux_amd64, linux_arm64).
- [x] `make tofu-validate` clean.
- [x] `make tofu-plan` exactly `13 to import, 0 to add, 1 to change, 0 to destroy`. All record imports drift-free; zone change is metadata only.
- [ ] After apply: `make tofu-plan` returns "No changes."
- [ ] DNS unchanged at the resolver level (`dig audeos.com A` still returns GH Pages IPs — should be invariant since only state changed, not records).
