### PR TITLE
Adopt stale play.audeos.com records (Phase 5, step 1 of 2)

### DIFF
--- a/infra/route53.tf
+++ b/infra/route53.tf
@@ -208,6 +208,39 @@ resource "aws_route53_record" "mail_spf_ses" {
   records = ["v=spf1 include:amazonses.com ~all"]
 }
 
+# === Stale play.audeos.com — Phase 5 cleanup ===
+# Adopted via import here purely so they can be destroyed via tofu in
+# the next PR. Originally pointed at a previous deployment (probably a
+# Vultr or similar host); intentionally removed from CF in audeos.fm
+# PR #249 but never deleted from R53 (which was dormant at the time).
+# Removed entirely in the follow-up PR.
+
+resource "aws_route53_record" "play_a" {
+  zone_id = aws_route53_zone.audeos_com.zone_id
+  name    = "play.audeos.com"
+  type    = "A"
+  ttl     = 300
+  records = ["149.248.214.157"]
+}
+
+import {
+  to = aws_route53_record.play_a
+  id = "Z04082853V3NSCPIUKILC_play.audeos.com_A"
+}
+
+resource "aws_route53_record" "play_aaaa" {
+  zone_id = aws_route53_zone.audeos_com.zone_id
+  name    = "play.audeos.com"
+  type    = "AAAA"
+  ttl     = 300
+  records = ["2a09:8280:1::10b:b583:0"]
+}
+
+import {
+  to = aws_route53_record.play_aaaa
+  id = "Z04082853V3NSCPIUKILC_play.audeos.com_AAAA"
+}
+
 import {
   to = aws_route53_record.mail_spf_ses
   id = "Z04082853V3NSCPIUKILC_mail.audeos.com_TXT"


### PR DESCRIPTION
Phase 5 cleanup, step 1 of 2.

The R53 zone for audeos.com (re-adopted in #104) carries two records that were never moved to Cloudflare during the original migration and represent a long-dormant deployment:

- `play.audeos.com A 149.248.214.157`
- `play.audeos.com AAAA 2a09:8280:1::10b:b583:0`

These were intentionally removed from Cloudflare in audeos.fm PR #249 ("Adopt audeos.com DNS into OpenTofu + remove stale play.audeos.com") but left in R53 (which was dormant at the time). Now that R53 is authoritative again, time to clean them up.

## Two-PR approach

Tofu can't import + destroy in one apply (the import has to land in state before the next plan can compute "this is in state but not in config → destroy"). So:

- **This PR (E1)**: declare the records + import blocks. Apply imports them into state. Pure state operation, no AWS change.
- **Follow-up PR (E2)**: remove the resources from config. Apply destroys them via R53 API.

## Plan output

```
Plan: 2 to import, 0 to add, 0 to change, 0 to destroy.
```

## Apply runbook

`cd ~/dev/audeos.com && make tofu-apply` — type `yes`. Records get imported into state with no drift; `dig play.audeos.com A` continues to return `149.248.214.157` (R53 unchanged).

After apply, tell me "PR E1 applied" and I'll open PR E2 to actually delete them.

## Test plan

- [x] `make tofu-validate` clean.
- [x] `make tofu-plan` exactly `2 to import, 0 to add, 0 to change, 0 to destroy`.
- [ ] After apply: `make tofu-plan` returns "No changes."
- [ ] `dig play.audeos.com A +short` still returns `149.248.214.157` (state-only change; record itself unchanged).
