### PR TITLE
Destroy stale play.audeos.com records (Phase 5, step 2 of 2)

### DIFF
--- a/infra/route53.tf
+++ b/infra/route53.tf
@@ -208,39 +208,6 @@ resource "aws_route53_record" "mail_spf_ses" {
   records = ["v=spf1 include:amazonses.com ~all"]
 }
 
-# === Stale play.audeos.com — Phase 5 cleanup ===
-# Adopted via import here purely so they can be destroyed via tofu in
-# the next PR. Originally pointed at a previous deployment (probably a
-# Vultr or similar host); intentionally removed from CF in audeos.fm
-# PR #249 but never deleted from R53 (which was dormant at the time).
-# Removed entirely in the follow-up PR.
-
-resource "aws_route53_record" "play_a" {
-  zone_id = aws_route53_zone.audeos_com.zone_id
-  name    = "play.audeos.com"
-  type    = "A"
-  ttl     = 300
-  records = ["149.248.214.157"]
-}
-
-import {
-  to = aws_route53_record.play_a
-  id = "Z04082853V3NSCPIUKILC_play.audeos.com_A"
-}
-
-resource "aws_route53_record" "play_aaaa" {
-  zone_id = aws_route53_zone.audeos_com.zone_id
-  name    = "play.audeos.com"
-  type    = "AAAA"
-  ttl     = 300
-  records = ["2a09:8280:1::10b:b583:0"]
-}
-
-import {
-  to = aws_route53_record.play_aaaa
-  id = "Z04082853V3NSCPIUKILC_play.audeos.com_AAAA"
-}
-
 import {
   to = aws_route53_record.mail_spf_ses
   id = "Z04082853V3NSCPIUKILC_mail.audeos.com_TXT"


### PR DESCRIPTION
Phase 5 cleanup, step 2 of 2 — the destroy. Pairs with #106 (state-only import).

## Summary

Removes the `aws_route53_record.play_a` + `aws_route53_record.play_aaaa` resources from `infra/route53.tf` (and their import blocks). Tofu plan now shows them in state but not in config → destroy.

## Plan output

```
Plan: 0 to add, 0 to change, 2 to destroy.
```

## Apply runbook

```sh
cd ~/dev/audeos.com && make tofu-apply
```

Type `yes`. Tofu calls R53 to delete both records. After apply:

```sh
dig play.audeos.com A +short          # expect: empty (NXDOMAIN propagating)
dig play.audeos.com AAAA +short       # expect: empty
make tofu-plan                        # expect: "No changes."
```

Once you confirm "PR E2 applied," the audeos.com extraction is fully complete and I'll wrap up with a session summary.

## Test plan

- [x] `make tofu-validate` clean.
- [x] `make tofu-plan` exactly `0 to add, 0 to change, 2 to destroy`.
- [ ] After apply: both `dig` queries return empty.
- [ ] `make tofu-plan` returns "No changes."
- [ ] No other audeos.com records affected (rest of zone unchanged).
