### PR TITLE
Tighten _dmarc.audeos.com from p=quarantine to p=reject

### DIFF
--- a/infra/route53.tf
+++ b/infra/route53.tf
@@ -136,14 +136,17 @@ import {
   id = "Z04082853V3NSCPIUKILC_protonmail3._domainkey.audeos.com_CNAME"
 }
 
-# === DMARC — observation-mode policy on audeos.com ===
+# === DMARC — reject ===
+# audeos.com has no legitimate domain-aligned outbound mail after the
+# SES decom in PR #109. Any From: *@audeos.com claim is spoofed — tell
+# receivers to reject outright.
 
 resource "aws_route53_record" "dmarc" {
   zone_id = aws_route53_zone.audeos_com.zone_id
   name    = "_dmarc.audeos.com"
   type    = "TXT"
   ttl     = 300
-  records = ["v=DMARC1; p=quarantine"]
+  records = ["v=DMARC1; p=reject"]
 }
 
 import {


### PR DESCRIPTION
## Why

audeos.com has no legitimate domain-aligned outbound mail after the SES decom in #109. Any `From: *@audeos.com` claim is spoofed, so receivers should reject outright rather than quarantine.

## What

Change `_dmarc.audeos.com` TXT record:

- Before: `v=DMARC1; p=quarantine`
- After: `v=DMARC1; p=reject`

Comment in `route53.tf` also updated to explain the policy.

## Not affected

- ProtonMail inbound on `audeos.com` — DMARC applies to outbound only, so receiving stays fully functional
- Proton's own outbound — replies from the `@audeos.com` mailbox use Proton's domains, not `audeos.com`, so they were never relying on `audeos.com` DKIM/SPF in the first place

## Plan

```
Plan: 0 to add, 1 to change, 0 to destroy.
```

In-place TXT record update on Route 53. No DNS churn beyond the value swap; receivers pick up the new policy on next refresh (TTL 300s).

Closes #108.