### PR TITLE
Bump next from 16.2.4 to 16.2.6 (clears 13 Dependabot alerts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "axios": "^1.15.0",
     "contentful": "^11.12.0",
     "fuse.js": "^7.3.0",
-    "next": "^16.2.1",
+    "next": "^16.2.6",
     "next-sitemap": "^4.2.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,10 +916,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/env@npm:16.2.4"
-  checksum: 10c0/4bf41f0da7cc97ca2a2f2b7f3fc81e14aba2afc280d32163b134b8f642b315fbabb5d9c224a783d8e759bbc73eedfc9acd048e772950395aa1e6290dd386d209
+"@next/env@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/env@npm:16.2.6"
+  checksum: 10c0/466722ce30a9561d29c08a7ba78091a47fef3644f422d04751c7124a24457ffe11eb25bb6c59c1e1d57735d9c68c58d185cc19ea58befd7a9c5b81dc05ca550d
   languageName: node
   linkType: hard
 
@@ -939,58 +939,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-darwin-arm64@npm:16.2.4"
+"@next/swc-darwin-arm64@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-darwin-arm64@npm:16.2.6"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-darwin-x64@npm:16.2.4"
+"@next/swc-darwin-x64@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-darwin-x64@npm:16.2.6"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-linux-arm64-gnu@npm:16.2.4"
+"@next/swc-linux-arm64-gnu@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-linux-arm64-gnu@npm:16.2.6"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-linux-arm64-musl@npm:16.2.4"
+"@next/swc-linux-arm64-musl@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-linux-arm64-musl@npm:16.2.6"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-linux-x64-gnu@npm:16.2.4"
+"@next/swc-linux-x64-gnu@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-linux-x64-gnu@npm:16.2.6"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-linux-x64-musl@npm:16.2.4"
+"@next/swc-linux-x64-musl@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-linux-x64-musl@npm:16.2.6"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-win32-arm64-msvc@npm:16.2.4"
+"@next/swc-win32-arm64-msvc@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-win32-arm64-msvc@npm:16.2.6"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-win32-x64-msvc@npm:16.2.4"
+"@next/swc-win32-x64-msvc@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-win32-x64-msvc@npm:16.2.6"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2469,7 +2469,7 @@ __metadata:
     eslint-config-next: "npm:^16.2.1"
     fuse.js: "npm:^7.3.0"
     jsdom: "npm:^29.0.1"
-    next: "npm:^16.2.1"
+    next: "npm:^16.2.6"
     next-sitemap: "npm:^4.2.3"
     react: "npm:^19.2.4"
     react-dom: "npm:^19.2.4"
@@ -6965,19 +6965,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^16.2.1":
-  version: 16.2.4
-  resolution: "next@npm:16.2.4"
+"next@npm:^16.2.6":
+  version: 16.2.6
+  resolution: "next@npm:16.2.6"
   dependencies:
-    "@next/env": "npm:16.2.4"
-    "@next/swc-darwin-arm64": "npm:16.2.4"
-    "@next/swc-darwin-x64": "npm:16.2.4"
-    "@next/swc-linux-arm64-gnu": "npm:16.2.4"
-    "@next/swc-linux-arm64-musl": "npm:16.2.4"
-    "@next/swc-linux-x64-gnu": "npm:16.2.4"
-    "@next/swc-linux-x64-musl": "npm:16.2.4"
-    "@next/swc-win32-arm64-msvc": "npm:16.2.4"
-    "@next/swc-win32-x64-msvc": "npm:16.2.4"
+    "@next/env": "npm:16.2.6"
+    "@next/swc-darwin-arm64": "npm:16.2.6"
+    "@next/swc-darwin-x64": "npm:16.2.6"
+    "@next/swc-linux-arm64-gnu": "npm:16.2.6"
+    "@next/swc-linux-arm64-musl": "npm:16.2.6"
+    "@next/swc-linux-x64-gnu": "npm:16.2.6"
+    "@next/swc-linux-x64-musl": "npm:16.2.6"
+    "@next/swc-win32-arm64-msvc": "npm:16.2.6"
+    "@next/swc-win32-x64-msvc": "npm:16.2.6"
     "@swc/helpers": "npm:0.5.15"
     baseline-browser-mapping: "npm:^2.9.19"
     caniuse-lite: "npm:^1.0.30001579"
@@ -7021,7 +7021,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10c0/81dc1ef30141891dc5cc999a0a6210c68305b585b3a7508799767572a9fb7e4c7dcb5a50f5fa3fabadf6a46c2273405360b1d6f17f89edd891da1746ae31c186
+  checksum: 10c0/3572071eb0e8051c3b007224dcf642037ce27a2f4b75c45f7e0fe7f2343e98e66604ce8696dde56ecd72963900d330d3a3af0f068f34cfc67520180263effa5f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps `next` from `16.2.4` → `16.2.6` (patch bump on the `^16.2.x` line; no API changes)
- Clears all 13 open Dependabot alerts on `next` — 7 high, 4 medium, 2 low
- `16.2.6` is the floor because GHSA-26hh-7cqf-hhc6 is patched only there; the other 12 are fixed in `16.2.5`

## Risk

Production blast radius is near zero. This is a static export (`output: "export"`) deployed to GitHub Pages — no Next.js server runs in prod, so the vulnerable middleware / RSC / image-optimization / cache / WebSocket code paths never execute against user traffic. The bump is hygiene: clears the GitHub UI noise and tightens the local `yarn dev` surface.

## Alerts cleared

| # | Sev | GHSA | Issue |
|---|---|---|---|
| 115 | high | `26hh-7cqf-hhc6` | Middleware/Proxy bypass via segment-prefetch (follow-up) |
| 112 | high | `mg66-mrh9-m8jx` | DoS via connection exhaustion (Cache Components) |
| 108 | high | `267c-6grr-h53f` | Middleware/Proxy bypass via segment-prefetch |
| 107 | high | `492v-c6pp-mqqv` | Middleware/Proxy bypass via dynamic route param injection |
| 106 | high | `c4j6-fc7j-m34r` | SSRF via WebSocket upgrades |
| 105 | high | `36qx-fr4f-26g5` | Middleware/Proxy bypass in Pages Router w/ i18n |
| 104 | high | `8h8q-6873-q5fj` | DoS via Server Components |
| 114 | med | `h64f-5h5j-jqjh` | DoS in Image Optimization API |
| 111 | med | `ffhc-5mcf-pf4q` | XSS in App Router w/ CSP nonces |
| 110 | med | `wfc6-r584-vfw7` | RSC cache poisoning |
| 109 | med | `gx5p-jg67-6x7h` | XSS in `beforeInteractive` scripts |
| 116 | low | `3g8h-86w9-wvmq` | Middleware/Proxy redirect cache-poisoning |
| 113 | low | `vfv6-92ff-j949` | RSC cache-busting collisions |

## Test plan
- [x] `yarn typecheck` — clean
- [x] `yarn test --run` — 192/192 pass across 24 files
- [ ] CI build (`yarn build`) green
- [ ] Dependabot alert list drops to zero after merge