### PR TITLE
Bump actions/upload-pages-artifact from v4 to v5

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -176,7 +176,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Static export successfully built and validated." >> $GITHUB_STEP_SUMMARY
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
           retention-days: 1


### PR DESCRIPTION
## Summary
- Silences the Node.js 20 deprecation warning seen in the deploy job
- `upload-pages-artifact@v5.0.0` (Apr 2026) updates its internal pin from `upload-artifact@v4.6.2` (Node 20) to `upload-artifact@v7.0.0` (Node 24) — the exact SHA the warning flagged
- v5 adds an optional `include-hidden-files` input that defaults to `false`; our call site uses defaults, no configuration change needed
- Ref: [GitHub Actions Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

### Original warning

```
Node.js 20 is deprecated. The following actions target Node.js 20 but
are being forced to run on Node.js 24:
actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
```

## Test plan
- [ ] CI deploy job runs cleanly
- [ ] Node 20 deprecation warning no longer appears in the deploy logs
- [ ] Pages deploy still succeeds (artifact uploaded, site live)