### PR TITLE
Match post cover aspect ratio to index thumbnails

### DIFF
--- a/src/styles/BlogPost.module.scss
+++ b/src/styles/BlogPost.module.scss
@@ -79,7 +79,7 @@
       }
 
       > figure {
-        height: 350px;
+        aspect-ratio: 4/3;
         position: relative;
         > img {
           object-fit: cover;


### PR DESCRIPTION
## Summary

- Swap the post header `<figure>` from `height: 350px` to `aspect-ratio: 4/3` so the cover image crop matches the homepage card thumbnails (`Home.module.scss` already uses `4/3`).
- One-line CSS change in `src/styles/BlogPost.module.scss`. `<Image fill>` adapts to the new parent box automatically — no TSX change needed.

## Why

Today the post header is a fixed 350px band regardless of viewport, while index cards are `aspect-ratio: 4/3`. The crop you preview on the homepage doesn't match what you see on the detail page. Unifying the ratio gives a consistent visual identity across the funnel.

## Tradeoff

The header height is no longer a fixed px value. On a ~720px content column the cover renders ~540px tall (taller than the old 350px); on narrow mobile it shrinks. That trades "predictable header height" for "consistent crop framing across cards and detail."

## Test plan

- [x] `yarn lint` — clean
- [x] `yarn test --run` — 192/192 passing
- [ ] Eyeball the post detail page in the running dev server (homepage card and post detail should share the same crop framing)
- [ ] Check mobile viewport — confirm the shorter header doesn't crowd the title