### PR TITLE
Clarify describe-assets skill description as AI-generated alt text

### DIFF
--- a/.claude/skills/describe-assets/SKILL.md
+++ b/.claude/skills/describe-assets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: describe-assets
-description: Add SEO-friendly descriptions to Contentful media assets that are missing them. Picks random assets, shows the image, suggests a description, and lets the user refine before saving.
+description: Add SEO-friendly descriptions to Contentful media assets that are missing them. Picks random assets, shows the image, AI-generates a suggested alt text from the image, and lets the user refine before saving.
 disable-model-invocation: true
 argument-hint: [count]
 ---


### PR DESCRIPTION
## Summary

- One-line frontmatter tweak in `.claude/skills/describe-assets/SKILL.md`.
- Old description: "...shows the image, **suggests a description**, and lets the user refine before saving."
- New description: "...shows the image, **AI-generates a suggested alt text from the image**, and lets the user refine before saving."

## Why

The skill's body (lines 42–57) already does this — it downloads the asset, opens it in Preview, uses `Read` to let the model see the image, then drafts an 80–160-char alt text from what it sees. But the frontmatter description was understated, making the AI-drafting behavior easy to miss in skill discovery UIs. This tweak surfaces the actual behavior at the listing level.

## Test plan

- [ ] Open the skill in Claude Code, confirm the new description appears in the skill listing
- [ ] Run `/describe-assets` and verify the behavior matches the new description (it already did before this commit)