### PR TITLE
Move category "See all" link to bottom of each section

### DIFF
--- a/src/components/Home/CategoryPostSections.tsx
+++ b/src/components/Home/CategoryPostSections.tsx
@@ -39,20 +39,20 @@ export default function CategoryPostSections({ posts, categoryConfig }: Category
               <h2>
                 <Link href={ `/category/${section.categoryId}` }>{ config.title }</Link>
               </h2>
-              <Link
-                href={ `/category/${section.categoryId}` }
-                className={ styles.seeAll }
-                aria-hidden="true"
-                tabIndex={ -1 }
-              >
-                See all →
-              </Link>
             </header>
             <BlogPostList
               posts={ section.categoryPosts }
               page={ 1 }
               firstCardPriority={ sectionIndex === 0 }
             />
+            <div className={ styles.seeAllFooter }>
+              <Link
+                href={ `/category/${section.categoryId}` }
+                className={ styles.seeAll }
+              >
+                See all { config.title } →
+              </Link>
+            </div>
           </section>
         );
       }) }

--- a/src/styles/Home.module.scss
+++ b/src/styles/Home.module.scss
@@ -311,6 +311,33 @@ ul.imageGallery {
   }
 }
 
+.seeAllFooter {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  padding: 1.5rem 0.75rem 0;
+
+  @media (min-width: 800px) {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+
+  @media (min-width: 872px) {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
+  }
+
+  @media (min-width: 1100px) {
+    padding-left: 3.5rem;
+    padding-right: 3.5rem;
+  }
+
+  @media (min-width: 1600px) {
+    padding-left: 4.5rem;
+    padding-right: 4.5rem;
+  }
+}
+
 .allPostsLink {
   display: inline-block;
   margin: 3rem auto 4rem;


### PR DESCRIPTION
## Summary

- On the homepage, the per-category "See all →" link previously sat at the top of each section, aligned with the category heading. Moved it to the bottom of each category block so when a reader reaches the last preview card they can continue straight into the full category listing instead of scrolling back up.
- Dropped the `aria-hidden="true"` + `tabIndex={-1}` that hid the original link from keyboard/screen-reader users — those attributes existed because the link duplicated the heading link sitting right next to it. Spatially separated at the bottom of the section, it's a distinct CTA and should be a real focus stop.
- Link text changed from `See all →` to `See all <Category> →` so it's self-descriptive away from the heading (satisfies WCAG 2.4.4 *Link Purpose in Context*).
- New `.seeAllFooter` SCSS class mirrors `.tagSectionHeader`'s responsive horizontal padding (`800px`, `872px`, `1100px`, `1600px` breakpoints) so the link's right edge aligns with the heading and the post grid at every viewport width.

## Test plan

- [ ] On the homepage at desktop width, confirm each category section now shows the heading at top-left and `See all <Category> →` at bottom-right, with both flush to the same outer padding.
- [ ] At mobile (<800px), tablet (800–1099px), and wide-desktop (≥1600px) widths, confirm the bottom link's right edge still aligns with the category heading and the post grid.
- [ ] Tab through the homepage with the keyboard: the new bottom link should be focusable (no longer skipped) and visibly indicate focus.
- [ ] Click each bottom "See all" link — should land on `/category/music`, `/category/events`, `/category/lifestyle` respectively.
- [ ] Screen-reader spot-check (VoiceOver): the bottom link is announced with its category name (e.g. "See all music").