### PR TITLE
Add tag migration tooling + first taxonomy expansion plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,14 @@ make upload-images DIR="/path/to/video.mov"   # Upload a single video to Content
 
 Supports images (.jpg, .jpeg, .png, .gif, .webp) and videos (.mov, .mp4, .webm). Outputs a JSON array of `{ filename, assetId, url }` to stdout. Reads credentials from `.env` automatically. Always rename files to descriptive filenames before uploading.
 
+Tag migrations (Makefile):
+
+```bash
+make migrate-tags PLAN="scripts/migrations/2026-05-14-tag-cleanup.json"
+```
+
+Applies a tag migration plan: adds/removes tags on entries, republishes the modified entries, and optionally deletes tags afterward. Plan format defined by `scripts/migrate-tags.mjs` — each entry in `updates` lists `tagsToAdd` (concatenated to existing) and `tagsToRemove` (filtered out); top-level `tagDeletions` removes the listed tag IDs from the space. Bypasses the Contentful MCP's 5-entries-per-mutation cap by using the management SDK directly. Use for bulk taxonomy changes; check plan into `scripts/migrations/` for audit trail.
+
 Blog post creation (Claude Code skill):
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,19 @@ upload-images:
 		CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN=$(CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN); \
 		node scripts/upload-images.mjs "$(DIR)"
 
+# Apply a tag migration plan against Contentful. Adds/removes tags on entries,
+# republishes the modified entries, and optionally deletes tags afterward.
+# Plan format: see scripts/migrations/*.json — each entry in `updates` lists
+# tagsToAdd (concatenated to existing) and tagsToRemove (filtered out).
+# Bypasses the MCP's 5-entries-per-mutation cap by using the management SDK.
+# Usage:
+#   make migrate-tags PLAN="scripts/migrations/2026-05-14-tag-cleanup.json"
+migrate-tags:
+	@export CONTENTFUL_SPACE_ID=$(CONTENTFUL_SPACE_ID) \
+		CONTENTFUL_ENVIRONMENT=$(CONTENTFUL_ENVIRONMENT) \
+		CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN=$(CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN); \
+		node scripts/migrate-tags.mjs "$(PLAN)"
+
 # Run ESLint + TypeScript typecheck
 lint:
 	@yarn lint

--- a/scripts/migrate-tags.mjs
+++ b/scripts/migrate-tags.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { createClient } from "contentful-management";
+
+export async function applyEntryUpdate( client, update ) {
+  const entry = await client.entry.get({ entryId: update.entryId });
+  const currentTagIds = new Set(
+    ( entry.metadata?.tags || [] ).map( tag => tag.sys.id ),
+  );
+
+  for( const tagId of update.tagsToAdd || [] ) {
+    currentTagIds.add( tagId );
+  }
+  for( const tagId of update.tagsToRemove || [] ) {
+    currentTagIds.delete( tagId );
+  }
+
+  entry.metadata = {
+    ...entry.metadata,
+    tags: [ ...currentTagIds ].sort().map( tagId => ({
+      sys: { type: "Link", linkType: "Tag", id: tagId },
+    }) ),
+  };
+
+  return await client.entry.update({ entryId: update.entryId }, entry );
+}
+
+export async function publishEntry( client, entryId ) {
+  const entry = await client.entry.get({ entryId });
+  return await client.entry.publish({ entryId }, entry );
+}
+
+export async function deleteTag( client, tagId ) {
+  const tag = await client.tag.get({ tagId });
+  return await client.tag.delete({ tagId, version: tag.sys.version });
+}
+
+export async function main( args ) {
+  const planPath = args[0];
+  if( !planPath ) {
+    process.stderr.write( "Usage: node scripts/migrate-tags.mjs <plan.json>\n" );
+    process.exit( 1 );
+    return;
+  }
+
+  const spaceId = process.env.CONTENTFUL_SPACE_ID;
+  const accessToken = process.env.CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN;
+  const environmentId = process.env.CONTENTFUL_ENVIRONMENT;
+
+  if( !spaceId || !accessToken || !environmentId ) {
+    process.stderr.write(
+      "Missing required env vars: CONTENTFUL_SPACE_ID, CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN, CONTENTFUL_ENVIRONMENT\n",
+    );
+    process.exit( 1 );
+    return;
+  }
+
+  const plan = JSON.parse( readFileSync( planPath, "utf8" ) );
+  const updates = plan.updates || [];
+  const tagDeletions = plan.tagDeletions || [];
+
+  const client = createClient(
+    { accessToken },
+    {
+      type: "plain",
+      defaults: { spaceId, environmentId },
+    },
+  );
+
+  process.stderr.write( `Plan: ${plan.description || "(no description)"}\n` );
+  process.stderr.write( `Applying ${updates.length} entry update(s) + ${tagDeletions.length} tag deletion(s)\n\n` );
+
+  const updateFailures = [];
+  const publishFailures = [];
+  const updatedEntryIds = [];
+
+  for( const [ index, update ] of updates.entries() ) {
+    const label = update.title ? `${update.entryId} (${update.title})` : update.entryId;
+    process.stderr.write( `  [${index + 1}/${updates.length}] update ${label}...` );
+    try {
+      await applyEntryUpdate( client, update );
+      updatedEntryIds.push( update.entryId );
+      process.stderr.write( " done\n" );
+    } catch ( error ) {
+      process.stderr.write( ` FAILED: ${error.message}\n` );
+      updateFailures.push({ entryId: update.entryId, title: update.title, error: error.message });
+    }
+  }
+
+  process.stderr.write( `\nPublishing ${updatedEntryIds.length} updated entries...\n` );
+  for( const [ index, entryId ] of updatedEntryIds.entries() ) {
+    process.stderr.write( `  [${index + 1}/${updatedEntryIds.length}] publish ${entryId}...` );
+    try {
+      await publishEntry( client, entryId );
+      process.stderr.write( " done\n" );
+    } catch ( error ) {
+      process.stderr.write( ` FAILED: ${error.message}\n` );
+      publishFailures.push({ entryId, error: error.message });
+    }
+  }
+
+  const tagDeletionFailures = [];
+  if( tagDeletions.length > 0 ) {
+    process.stderr.write( `\nDeleting ${tagDeletions.length} tag(s)...\n` );
+    for( const tagId of tagDeletions ) {
+      process.stderr.write( `  - ${tagId}...` );
+      try {
+        await deleteTag( client, tagId );
+        process.stderr.write( " done\n" );
+      } catch ( error ) {
+        process.stderr.write( ` FAILED: ${error.message}\n` );
+        tagDeletionFailures.push({ tagId, error: error.message });
+      }
+    }
+  }
+
+  process.stderr.write( `\nSummary:\n` );
+  process.stderr.write( `  Updates: ${updates.length - updateFailures.length} succeeded, ${updateFailures.length} failed\n` );
+  process.stderr.write( `  Publishes: ${updatedEntryIds.length - publishFailures.length} succeeded, ${publishFailures.length} failed\n` );
+  process.stderr.write( `  Tag deletions: ${tagDeletions.length - tagDeletionFailures.length} succeeded, ${tagDeletionFailures.length} failed\n` );
+
+  const totalFailures = updateFailures.length + publishFailures.length + tagDeletionFailures.length;
+  process.exit( totalFailures > 0 ? 1 : 0 );
+}
+
+if( process.argv[1] === fileURLToPath( import.meta.url ) ) {
+  main( process.argv.slice( 2 ) );
+}

--- a/scripts/migrations/2026-05-14-tag-cleanup.json
+++ b/scripts/migrations/2026-05-14-tag-cleanup.json
@@ -1,0 +1,798 @@
+{
+  "description": "Tag taxonomy expansion (2026-05-14): adds 12 new tags, migrates 4 posts from `plantlife` to `cannabis`, prepares `plantlife` and `technology` for deletion.",
+  "updates": [
+    {
+      "entryId": "18SEYjx9AokNSu6qUMs1zv",
+      "title": "Winner's Circle & Dr. Helmet presents BASO New Exhibition",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "capitol-hill"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "35sVBAPdpm9oycizadqK2t",
+      "title": "Art Show at Winner's Circle on Broadway ft. Sicko and DJ Audeos",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "capitol-hill"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "67h1yaLOIdG8pmdNqoRgsU",
+      "title": "Halloween Party at Gan Bei Seattle",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "halloween"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "4SKuW9Ziz7wLwWxzidAmHL",
+      "title": "Lights On at Northwest Local Cannabis",
+      "currentTags": [
+        "plantlife"
+      ],
+      "tagsToAdd": [
+        "cannabis"
+      ],
+      "tagsToRemove": [
+        "plantlife"
+      ]
+    },
+    {
+      "entryId": "XPJFRya3xIAqvnkcr95OE",
+      "title": "u suck (dj mix)",
+      "currentTags": [
+        "dj",
+        "playlists",
+        "radio"
+      ],
+      "tagsToAdd": [
+        "mixes"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "1qa9BG8u8fbOhkBNluSCPT",
+      "title": "What is Love x Pepas Mashup",
+      "currentTags": [
+        "dj",
+        "edits"
+      ],
+      "tagsToAdd": [
+        "mixes"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "5XlF6zZEXNx3VNIwQy6sdD",
+      "title": "Mysterious Psych O — J Boog x Post Malone Mashup",
+      "currentTags": [
+        "dj",
+        "edits"
+      ],
+      "tagsToAdd": [
+        "mixes"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "6neJ4LeUwHLKRdCPk4qqLm",
+      "title": "Post Malone x J Boog — Psycho Reggae Mashup",
+      "currentTags": [
+        "dj",
+        "edits"
+      ],
+      "tagsToAdd": [
+        "mixes"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "2BThdM95iT14jUKFHpu7ms",
+      "title": "Messin' with Serato Stems: Drake x INOJ Mashup",
+      "currentTags": [
+        "dj",
+        "edits"
+      ],
+      "tagsToAdd": [
+        "mixes"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "3PSZoD1GlFHrAJ3eKywbnj",
+      "title": "Halloween Party at Rose Temple, Capitol Hill, Seattle",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "halloween",
+        "capitol-hill"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "4HiUc6f7zL0NnzQ6cyL5c",
+      "title": "Remembering MJ: The King Of Pop at Royal Room in Columbia City, Seattle",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "columbia-city"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "3kjRNrFrZryWG19QIHr8xb",
+      "title": "Prince Tribute at The Royal Room in Columbia City, Seattle",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "columbia-city"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "3fnWJ7LQ2HO9WX0FNAMHlq",
+      "title": "Memorial Day Weekend at Taco City in Columbia City, Seattle",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "columbia-city"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "DUTQsCFyhcmlBjcAe8Msq",
+      "title": "Country Wedding with DJ Audeos at Shangri-La On The Green Campground in Enumclaw",
+      "currentTags": [
+        "dj"
+      ],
+      "tagsToAdd": [
+        "wedding"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "3zXwrccX8Sg6GksW7Xp9If",
+      "title": "Daz Dillinger Live in Belltown | DPG Budz x SPR Launch",
+      "currentTags": [
+        "dj",
+        "nightlife",
+        "plantlife"
+      ],
+      "tagsToAdd": [
+        "belltown",
+        "cannabis"
+      ],
+      "tagsToRemove": [
+        "plantlife"
+      ]
+    },
+    {
+      "entryId": "7IAo0fWgQSDCdesSGj0UE6",
+      "title": "New Logo for The Northwest Clothing",
+      "currentTags": [
+        "graphics",
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing",
+        "logo"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "68OkG9gmzFdBtmkGmIuA6j",
+      "title": "DJ Audeos - Day Party Mix",
+      "currentTags": [
+        "dj",
+        "playlists",
+        "radio"
+      ],
+      "tagsToAdd": [
+        "mixes"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "4B12B1ZsomBxYKwWK7cvuk",
+      "title": "NWAC Snowbash at evo Fremont — September 2018",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "TK5KVdmpURHDRu9vIPkFt",
+      "title": "I was the DJ for my cousins wedding in Puyallup, WA",
+      "currentTags": [
+        "dj"
+      ],
+      "tagsToAdd": [
+        "wedding"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "1flH94FbNmdRkl4emWsBND",
+      "title": "No Requests with DJ Audeos at Speckled and Drake in Capitol Hill, Seattle",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "capitol-hill"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "3pftjZ48RQpsM72JkYAcvs",
+      "title": "Wedding DJ at Wisteria Hall, UW Botanic Gardens — Seattle",
+      "currentTags": [
+        "dj"
+      ],
+      "tagsToAdd": [
+        "wedding"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "4FFMgP6gtjzFw6y83334VM",
+      "title": "Open Format Fridays at Vittles in Belltown Seattle featuring DJ Audeos",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "belltown"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "7aFT3vNKxcA77oROGykOKV",
+      "title": "DJing NWAC SnowBash 2016 at evo Seattle",
+      "currentTags": [
+        "dj"
+      ],
+      "tagsToAdd": [
+        "halloween"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "7HOHDtRVS0tbchKeN4qgvZ",
+      "title": "DJing a Wedding in Shelburne, Vermont",
+      "currentTags": [
+        "dj"
+      ],
+      "tagsToAdd": [
+        "wedding"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "3JPstZk1fflYCFqKnnO6U1",
+      "title": "I got to DJ a Wedding Reception at the Roche Harbor Resort in Friday Harbor, WA",
+      "currentTags": [
+        "dj"
+      ],
+      "tagsToAdd": [
+        "wedding"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "4kNqG6TzOxCOqGJyfIekUq",
+      "title": "Holiday Party at Vittles in Belltown",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "belltown"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "23r3pFqAzkAg8qnRbPTpB7",
+      "title": "DJ Audeos Saturdays at Vittles Neighborhood Bistro & Bar in Belltown, Seattle, WA",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "belltown"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "2eaRJm8XAmgwZgWI4Hfn2i",
+      "title": "DJ Audeos - Droptop Hotbox Mix",
+      "currentTags": [
+        "dj",
+        "plantlife",
+        "playlists",
+        "radio"
+      ],
+      "tagsToAdd": [
+        "mixes",
+        "cannabis"
+      ],
+      "tagsToRemove": [
+        "plantlife"
+      ]
+    },
+    {
+      "entryId": "7IiIaW5BbMOw8Gs7JiqNb5",
+      "title": "Wedding Reception DJ at Tacoma's Landmark Event Center Rooftop",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "wedding"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "41QyYUg1gsxopLpP9jxLJ",
+      "title": "Beacon Hillfinger Design",
+      "currentTags": [
+        "graphics",
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing",
+        "logo"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "AMheazfl9IC5TQsRFTgFR",
+      "title": "DJ Audeos - Rear Wax (DJ mix show)",
+      "currentTags": [
+        "dj",
+        "radio"
+      ],
+      "tagsToAdd": [
+        "mixes"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "3fofhVpjWuHoXwaPpjL9Ia",
+      "title": "DJ Audeos - Slappers (DJ mix show)",
+      "currentTags": [
+        "dj",
+        "radio"
+      ],
+      "tagsToAdd": [
+        "mixes"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "5csdxvbPq4T4PpcoPq11Bx",
+      "title": "Cassandra McClure x The North West Clothing",
+      "currentTags": [
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing",
+        "photoshoot"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "10kqURxodims9F093Qphsi",
+      "title": "\"Howl-O-Ween\" Halloween Party at the Sexton Bar in Ballard",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "halloween"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "44zmCiejkGpNKtHsCAivDL",
+      "title": "The Northwest Clothing x Hempfest in Seattle",
+      "currentTags": [
+        "merch",
+        "plantlife"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing",
+        "cannabis"
+      ],
+      "tagsToRemove": [
+        "plantlife"
+      ]
+    },
+    {
+      "entryId": "7CpUwEn62XrXxGIaASjhbm",
+      "title": "My Tam's Going Away Party with DJ Audeos at 2312 in Belltown, Seattle",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "belltown"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "5DkqonuAM2WVKVSDh66AwI",
+      "title": "Ballard Is For Lovers",
+      "currentTags": [
+        "graphics",
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "2Hde1agTz3sRBDCjUsjTak",
+      "title": "Pioneer Square Art Walk at CrisisNW in Seattle",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing",
+        "art-walk",
+        "pioneer-square"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "3OoK1MSKAiAxqQiDkrHZaJ",
+      "title": "Tac Town Never Back Down Design",
+      "currentTags": [
+        "graphics",
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "x7hbBGcS7SBcw3T74hz4i",
+      "title": "Sasquatch 2013 at The Gorge Amphitheatre",
+      "currentTags": [
+        "merch",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "6DOSGG0ElDK6RQyMK9EoaZ",
+      "title": "Pioneer Square Art Walk Party — May 2013",
+      "currentTags": [
+        "dj",
+        "merch",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing",
+        "art-walk",
+        "pioneer-square"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "3Tt8kDcVLifVvJcwhCy2y9",
+      "title": "Charmaine Glock models The North West Clothing — Seattle Photoshoot",
+      "currentTags": [
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing",
+        "photoshoot"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "9CJgdLmYNxs8C3yXY54Et",
+      "title": "Neko Jamilla x The North West Clothing",
+      "currentTags": [
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing",
+        "photoshoot"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "6OjSt3nbrcIjNGj8OcyOa7",
+      "title": "Pioneer Square Art Walk Tattoo Party ft. Mario James at The OK Hotel",
+      "currentTags": [
+        "dj",
+        "merch",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "art-walk",
+        "pioneer-square"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "4SnC2k0FvkaeOBEAJqLzbi",
+      "title": "Yaye Kassamali x The North West Clothing",
+      "currentTags": [
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing",
+        "photoshoot",
+        "pioneer-square"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "2PB4H73JpUjlEt13FYPyTW",
+      "title": "Sunday Night Social at Mestizo Ultra Lounge in Belltown, Seattle",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "belltown"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "5mtKec7hG3gsyZazgmgwJP",
+      "title": "Ladies Night Tuesdays at Splash Lounge in Belltown Seattle",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "belltown"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "4AYmHZIHLd8P0RsCJe2HQE",
+      "title": "DJ Audeos - Breakup Beats (DJ mix show)",
+      "currentTags": [
+        "dj",
+        "radio"
+      ],
+      "tagsToAdd": [
+        "mixes"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "1e2mhlEWsdvWzCrPWSECiL",
+      "title": "DJing a private party at Dry Soda headquarters in Pioneer Square, Seattle",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "pioneer-square"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "1MPgzwM0gzY3adZ96WoPm4",
+      "title": "Be My #2 x American Boy (Audeos Edit)",
+      "currentTags": [
+        "dj",
+        "edits"
+      ],
+      "tagsToAdd": [
+        "mixes"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "70mvg4B2UuEh6FWMDa3bGE",
+      "title": "Uniquely Seattle: Kimberly Nichole at Chop Suey in Seattle",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "capitol-hill"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "4QKclBXIljtVnljAhkt7KG",
+      "title": "Officials Vintage is now carrying The North West tees",
+      "currentTags": [
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "eyLfI4Pvy4hQWqcQTtU1W",
+      "title": "Anne rocking The North West Hoodie",
+      "currentTags": [
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing",
+        "photoshoot"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "7wJBIDZKfYZ196uQnTLF19",
+      "title": "Photoshoot with Syreeta McKelvey at the Olympic Sculpture Park in Downtown Seattle",
+      "currentTags": [
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing",
+        "photoshoot"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "2o7ZcC2cjZ4Bkidr6B3TYl",
+      "title": "DJ Audeos - Erotic City Mix",
+      "currentTags": [
+        "dj",
+        "playlists",
+        "radio"
+      ],
+      "tagsToAdd": [
+        "mixes",
+        "pioneer-square"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "5ppxTjExpcS8crwDtQU58E",
+      "title": "The North West Crew Wins A Trophy",
+      "currentTags": [
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "24Y55lbqbp2CVhR7tc87P8",
+      "title": "The North West Native Logo Design",
+      "currentTags": [
+        "graphics",
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing",
+        "logo"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "28gQtDWvkShZbxDe7JXEPA",
+      "title": "Boiler Room After Hours in Capitol Hill with DJ Audeos",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "capitol-hill"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "gDrhOs1Etjt0RUUcP1lgS",
+      "title": "Water: Jan 23, 2008 at Columbia City Theatre",
+      "currentTags": [
+        "dj",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "columbia-city"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "5rlAxBOae5TmuTTeN4yFT9",
+      "title": "Jamaican 45 Donuts on B-Girl Radio",
+      "currentTags": [
+        "dj",
+        "radio"
+      ],
+      "tagsToAdd": [
+        "mixes",
+        "capitol-hill"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "70FiwG9pWCvQnXyHbR69wp",
+      "title": "Sasquatch at the Gorge",
+      "currentTags": [
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "7uKv4g8XZr4RI4IV2qtD0l",
+      "title": "Happy Halloween",
+      "currentTags": [
+        "merch"
+      ],
+      "tagsToAdd": [
+        "the-north-west-clothing",
+        "halloween"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "5puicdSE8EWITAklefiP4s",
+      "title": "Major W8 - A Night of Fashion, Drinking, and Dancing",
+      "currentTags": [
+        "merch",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "columbia-city"
+      ],
+      "tagsToRemove": []
+    },
+    {
+      "entryId": "2m6BSnPohSNC0SdhwyrVnd",
+      "title": "Nights at the Maharaja Cuisine Of India in Capitol Hill, Seattle",
+      "currentTags": [
+        "merch",
+        "nightlife"
+      ],
+      "tagsToAdd": [
+        "capitol-hill"
+      ],
+      "tagsToRemove": []
+    }
+  ],
+  "tagDeletions": [
+    "plantlife",
+    "technology"
+  ]
+}


### PR DESCRIPTION
## Summary

The new-post skill's prior policy of "never suggest creating new tags" was tied to tags doubling as main navigation. Categories now handle main nav, so tags have been freed up for granular subject taxonomy. This PR adds the tooling to make taxonomy migrations safe + reproducible, and ships the first such migration.

### Files

- `scripts/migrate-tags.mjs` — generic tag migration runner. Reads a plan JSON, applies entry-level tag adds/removes, republishes the modified entries, optionally deletes tags from the space. Uses `contentful-management` SDK directly to bypass MCP constraints (no `delete_tag` tool, `update_entry` only concatenates, 5-entries-per-mutation cap).
- `scripts/migrations/2026-05-14-tag-cleanup.json` — the specific plan for the first taxonomy expansion. Checked in for audit.
- `Makefile` — new `make migrate-tags PLAN=...` target following the same env-var pattern as `make upload-images`.
- `CLAUDE.md` — documents the new command + plan-file convention.

### What the first migration does

**Adds 12 new tags** (created via Contentful MCP earlier, before this PR):
- Subject: `the-north-west-clothing`, `mixes`, `wedding`, `photoshoot`, `art-walk`, `halloween`, `logo`
- Neighborhood: `belltown`, `pioneer-square`, `capitol-hill`, `columbia-city`
- Rename target: `cannabis`

**Updates 64 existing posts** with new tag additions:
| Tag | # posts |
|---|---|
| `the-north-west-clothing` | 20 |
| `mixes` | 13 |
| `capitol-hill` | 8 |
| `belltown` | 7 |
| `wedding` | 6 |
| `photoshoot` | 6 |
| `pioneer-square` | 6 |
| `halloween` | 5 |
| `columbia-city` | 5 |
| `cannabis` | 4 |
| `logo` | 3 |
| `art-walk` | 3 |

**Renames `plantlife` → `cannabis`** by migrating 4 affected posts (Hempfest 2013, Daz Dillinger DPG Budz, NW Local Cannabis, Droptop Hotbox Mix) — add `cannabis`, remove `plantlife`.

**Deletes 2 tags from the space:**
- `plantlife` (after the 4 posts are migrated off it)
- `technology` (zero entries currently use it)

## Test plan

- [ ] Review `scripts/migrations/2026-05-14-tag-cleanup.json` for any per-post tag additions that look off — the auto-match was keyword-driven with manual adjustments applied.
- [ ] Once merged, run `make migrate-tags PLAN="scripts/migrations/2026-05-14-tag-cleanup.json"`. Expect ~64 entry updates + ~64 republishes + 2 tag deletions.
- [ ] After run completes, verify on the live site (after deploy) that:
  - The 4 cannabis posts no longer show `plantlife` chip
  - New `the-north-west-clothing` chip appears on NW Clothing posts
  - Neighborhood chips appear on local-venue posts
- [ ] Run `make migrate-tags` a second time with the same plan and confirm it's idempotent — `tagsToAdd` skips already-present tags, `tagsToRemove` skips absent tags, `tagDeletions` will error harmlessly on the second pass since the tags will already be gone.