### PR TITLE
Remove now-global rules and fix settings.json deny prefixes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,8 @@
 {
   "permissions": {
     "deny": [
-      "Read(./.env)",
-      "Read(./dist)"
+      "Read(.env)",
+      "Read(dist)"
     ]
   },
   "enabledPlugins": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,11 +66,8 @@ The build output goes to `dist/` (not `.next/`). Feeds (RSS/Atom/JSON) are gener
 
 ## Code style
 
-- Run `yarn format` after every file change to keep code conformant with the ESLint styleguide, then run `yarn test` to confirm nothing is broken.
-- Do not use single-character variable names — use descriptive names even for short-lived variables (e.g., `post` not `p`, `index` not `i`).
-- Never use `eslint-disable` or `eslint-disable-next-line` comments to suppress ESLint errors — fix the underlying code instead.
+- Use `yarn format` as the project formatter (ESLint with auto-fix); follow it with `yarn test` to confirm nothing is broken.
 - Enforce required environment variables at module scope using `import { strict as assert } from "assert"` followed by `assert( !!VAR )`. This ensures the build fails immediately if a variable is missing. See `src/utils/contentfulUtils.ts` for the canonical example. Never defer these checks to function-level.
-- Never use TypeScript `as` type assertions — they bypass the type checker and hide bugs. Use type guards, narrowing, or `satisfies` instead. See [why `as` is harmful](https://dev.to/alexanderop/the-problem-with-as-in-typescript-why-its-a-shortcut-we-should-avoid-2km4).
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Drop CLAUDE.md bullets that duplicate global Universal Preferences (single-char variable names, `eslint-disable` ban, TypeScript `as` ban) and reword the `yarn format` bullet to name it as the project formatter without restating the global "run formatter before committing" rule. Project-specific env-var `assert` pattern stays.
- Fix `.claude/settings.json` denies: `Read(./.env)` -> `Read(.env)` and `Read(./dist)` -> `Read(dist)`. The leading `./` made them no-ops because Claude matches bare paths.
- No `.env*` Bash deny entries existed locally; those reads are now covered globally by the `deny-env-bash.sh` hook shipped in dotfiles PR #29.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean
- [x] `yarn test` clean (192 tests)