### PR TITLE
Fix yarn.lock drift from axios bump (unblocks CI on main)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2460,6 +2460,7 @@ __metadata:
     "@types/react-dom": "npm:^19.2.3"
     "@vitejs/plugin-react": "npm:^6.0.1"
     "@vitest/coverage-v8": "npm:^4.1.3"
+    axios: "npm:^1.16.0"
     cf-content-types-generator: "npm:^3.0.1"
     contentful: "npm:^11.12.0"
     contentful-cli: "npm:^4.0.0"
@@ -2496,7 +2497,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.13.5, axios@npm:^1.15.0":
+"axios@npm:^1.13.5, axios@npm:^1.15.0, axios@npm:^1.16.0":
   version: 1.16.1
   resolution: "axios@npm:1.16.1"
   dependencies:


### PR DESCRIPTION
## Summary
- `main` is red: the deploy workflow fails at **Install dependencies** because `yarn install --immutable` detects lockfile drift ([failing run](https://github.com/aud-eos/audeos.com/actions/runs/26648534293/job/78540545801)).
- Root cause: Dependabot PR #124 bumped the axios range in `package.json` to `^1.16.0`, but the committed `yarn.lock` descriptor key still read `axios@npm:^1.13.5, axios@npm:^1.15.0`. The resolved version (`1.16.1`) was already correct — only the requested-range key was stale.
- Regenerated `yarn.lock` so the root workspace requests `axios: "npm:^1.16.0"` and the descriptor key includes `^1.16.0`. No resolved versions change.

## Test plan
- [x] `yarn install --immutable` succeeds locally (the exact gate that failed in CI)
- [x] `yarn test` — 192 passed (24 files)